### PR TITLE
CMS patterns polish: opencode-aligned Effect patterns

### DIFF
--- a/app/lib/auth.server.test.ts
+++ b/app/lib/auth.server.test.ts
@@ -26,12 +26,12 @@ const ENABLED_ENV = {
 // `Effect.scoped` supplies the `Scope` that `TestClock.adjust` requires; the
 // `Auth` layer + test clock are provided beneath it.
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Auth>,
+  effect: Effect.Effect<A, E, Auth.Service>,
   env: Record<string, string>,
 ) => Effect.runPromise(Effect.scoped(Effect.provide(effect, authLayer(env))));
 
 const runExit = <A, E>(
-  effect: Effect.Effect<A, E, Auth>,
+  effect: Effect.Effect<A, E, Auth.Service>,
   env: Record<string, string>,
 ) =>
   Effect.runPromise(
@@ -55,7 +55,7 @@ describe('Auth (enabled)', () => {
   it('reports the admin as enabled when ADMIN_PASSWORD is set', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         expect(auth.enabled).toBe(true);
       }),
       ENABLED_ENV,
@@ -64,7 +64,7 @@ describe('Auth (enabled)', () => {
   it('round-trips: a token minted by the correct password verifies', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         const token = yield* auth.verifyPassword(ENABLED_ENV.ADMIN_PASSWORD);
         expect(token.split('.')).toHaveLength(3);
         // The signed cookie verifies through the same secret.
@@ -76,7 +76,7 @@ describe('Auth (enabled)', () => {
   it('rejects a wrong password with BadPassword', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         return yield* auth.verifyPassword('wrong password');
       }),
       ENABLED_ENV,
@@ -87,7 +87,7 @@ describe('Auth (enabled)', () => {
   it('rejects a missing cookie with Unauthorized', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         yield* auth.checkCookie(null);
       }),
       ENABLED_ENV,
@@ -98,7 +98,7 @@ describe('Auth (enabled)', () => {
   it('rejects an expired token with Unauthorized', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         const token = yield* auth.verifyPassword(ENABLED_ENV.ADMIN_PASSWORD);
         // Advance past the 30-day TTL — the same token must now be rejected.
         yield* TestClock.adjust('31 days');
@@ -112,7 +112,7 @@ describe('Auth (enabled)', () => {
   it('rejects a token whose signature was tampered with', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         const token = yield* auth.verifyPassword(ENABLED_ENV.ADMIN_PASSWORD);
         const [issued, expires] = token.split('.');
         // Keep the issued/expires claims but forge the signature.
@@ -127,7 +127,7 @@ describe('Auth (enabled)', () => {
   it('rejects a token whose expires claim was extended', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         const token = yield* auth.verifyPassword(ENABLED_ENV.ADMIN_PASSWORD);
         const [issued, , sig] = token.split('.');
         // Push the expiry far into the future without re-signing — the
@@ -143,7 +143,7 @@ describe('Auth (enabled)', () => {
   it('rejects a malformed (non-three-part) token with Unauthorized', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         yield* auth.checkCookie('gycc_admin=not-a-valid-token');
       }),
       ENABLED_ENV,
@@ -156,7 +156,7 @@ describe('Auth (disabled when ADMIN_PASSWORD unset)', () => {
   it('reports the admin as disabled', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         expect(auth.enabled).toBe(false);
       }),
       {},
@@ -165,7 +165,7 @@ describe('Auth (disabled when ADMIN_PASSWORD unset)', () => {
   it('rejects every password with AdminDisabled (never BadPassword)', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         // Even the empty string must NOT authenticate — a missing password is
         // "no admin", not "an admin whose password is empty".
         return yield* auth.verifyPassword('');
@@ -179,7 +179,7 @@ describe('Auth (disabled when ADMIN_PASSWORD unset)', () => {
   it('rejects cookie checks with AdminDisabled (never Unauthorized)', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         yield* auth.checkCookie('gycc_admin=anything');
       }),
       {},
@@ -191,7 +191,7 @@ describe('Auth (disabled when ADMIN_PASSWORD unset)', () => {
   it('treats a present-but-blank ADMIN_PASSWORD as disabled', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         expect(auth.enabled).toBe(false);
       }),
       { ADMIN_PASSWORD: '', COOKIE_SECRET: 'secret' },
@@ -202,7 +202,7 @@ describe('Auth (disabled when COOKIE_SECRET unset)', () => {
   it('reports the admin as disabled when only ADMIN_PASSWORD is set', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         expect(auth.enabled).toBe(false);
       }),
       { ADMIN_PASSWORD: 'correct horse battery staple' },
@@ -211,7 +211,7 @@ describe('Auth (disabled when COOKIE_SECRET unset)', () => {
   it('treats a present-but-blank COOKIE_SECRET as disabled', () =>
     run(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         expect(auth.enabled).toBe(false);
       }),
       { ADMIN_PASSWORD: 'correct horse battery staple', COOKIE_SECRET: '' },
@@ -225,7 +225,7 @@ describe('Auth (disabled when COOKIE_SECRET unset)', () => {
   it('rejects verifyPassword with AdminDisabled instead of crashing on an empty HMAC key', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         return yield* auth.verifyPassword('correct horse battery staple');
       }),
       { ADMIN_PASSWORD: 'correct horse battery staple', COOKIE_SECRET: '' },
@@ -239,7 +239,7 @@ describe('Auth (disabled when COOKIE_SECRET unset)', () => {
   it('rejects checkCookie with AdminDisabled when COOKIE_SECRET is unset', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const auth = yield* Auth;
+        const auth = yield* Auth.Service;
         yield* auth.checkCookie('gycc_admin=anything');
       }),
       { ADMIN_PASSWORD: 'correct horse battery staple' },

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -1,3 +1,5 @@
+export * as Auth from './auth.server';
+
 import {
   Clock,
   Config,
@@ -41,12 +43,12 @@ import {
  */
 
 export class BadPassword extends Schema.TaggedErrorClass<BadPassword>()(
-  'gycc/lib/auth.server/BadPassword',
+  'Auth.BadPassword',
   {},
 ) {}
 
 export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
-  'gycc/lib/auth.server/Unauthorized',
+  'Auth.Unauthorized',
   {},
 ) {}
 
@@ -57,7 +59,7 @@ export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
  * unauthenticated visitor to the login page when it is enabled.
  */
 export class AdminDisabled extends Schema.TaggedErrorClass<AdminDisabled>()(
-  'gycc/lib/auth.server/AdminDisabled',
+  'Auth.Disabled',
   {},
 ) {}
 
@@ -117,8 +119,8 @@ const parseCookie = (header: string | null, name: string): string | null => {
   return null;
 };
 
-export class Auth extends Context.Service<
-  Auth,
+export class Service extends Context.Service<
+  Service,
   {
     /**
      * Whether the admin area is configured (both `ADMIN_PASSWORD` and
@@ -144,94 +146,102 @@ export class Auth extends Context.Service<
     readonly cookieHeader: (token: string) => string;
     readonly clearCookieHeader: () => string;
   }
->()('gycc/lib/auth.server/Auth') {
-  static layer = Layer.effect(
-    Auth,
-    Effect.gen(function* () {
-      // Both optional — a missing password disables the admin (degrade, not
-      // fail-fast), matching the bucket's optional-everywhere contract.
-      const adminPassword = yield* Config.redacted('ADMIN_PASSWORD').pipe(
-        Config.withDefault(Redacted.make('')),
+>()('gycc/lib/auth.server/Service') {}
+
+/**
+ * The `Auth` layer (opencode's module-level `export const layer`,
+ * `packages/core/src/git.ts:79`). It reads `ADMIN_PASSWORD` / `COOKIE_SECRET`
+ * straight off the platform `Config` and has no service dependencies, so
+ * `defaultLayer` is just `layer`.
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    // Both optional — a missing password disables the admin (degrade, not
+    // fail-fast), matching the bucket's optional-everywhere contract.
+    const adminPassword = yield* Config.redacted('ADMIN_PASSWORD').pipe(
+      Config.withDefault(Redacted.make('')),
+    );
+    const cookieSecret = yield* Config.redacted('COOKIE_SECRET').pipe(
+      Config.withDefault(Redacted.make('')),
+    );
+
+    const adminPw = Redacted.value(adminPassword);
+    const secret = Redacted.value(cookieSecret);
+    // The admin is enabled only when BOTH a real password AND a real signing
+    // secret are set — matching the `.env.example` contract ("set both to
+    // enable it"). An "enabled admin with a blank secret" is an impossible,
+    // unsafe state (make-impossible-states-unrepresentable): the HMAC key
+    // would be the empty string, which `crypto.subtle.importKey` rejects with
+    // a `DataError` — so the first sign/verify would crash login with a 500 —
+    // and a blank signing key is trivially forgeable anyway. Requiring both
+    // collapses "auth on, no secret" into the single "disabled" state.
+    const enabled = adminPw !== '' && secret !== '';
+
+    // Internal helpers (not part of the service surface) — untraced, mirroring
+    // opencode's traced-boundary / untraced-internal split (`git.ts`).
+    const issueToken = Effect.fnUntraced(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const issued = Math.floor(now / 1000);
+      const expires = issued + TOKEN_TTL_SECONDS;
+      const payload = `${issued}.${expires}`;
+      const sig = yield* sign(secret, payload);
+      return `${payload}.${sig}`;
+    });
+
+    const validateToken = Effect.fnUntraced(function* (token: string) {
+      const parts = token.split('.');
+      if (parts.length !== 3) return yield* new Unauthorized();
+      const [issuedStr, expiresStr, sig] = parts as [string, string, string];
+      const expires = Number(expiresStr);
+      if (!Number.isFinite(expires)) return yield* new Unauthorized();
+      const now = yield* Clock.currentTimeMillis;
+      if (expires < Math.floor(now / 1000)) return yield* new Unauthorized();
+      const ok = yield* verifySig(secret, `${issuedStr}.${expiresStr}`, sig);
+      if (!ok) return yield* new Unauthorized();
+    });
+
+    const verifyPassword = Effect.fn('Auth.verifyPassword')(function* (
+      password: string,
+    ) {
+      if (!enabled) return yield* new AdminDisabled();
+      // HMAC both sides to a fixed-length digest under the signing secret
+      // before comparing, so the compare never branches on the secret
+      // `ADMIN_PASSWORD`'s length — defeating a timing probe of the
+      // password length. The digests are equal-length (43-char base64url
+      // of a 32-byte SHA-256 HMAC), so the constant-time compare runs the
+      // full loop regardless of the submitted password.
+      const submitted = yield* sign(secret, password);
+      const expected = yield* sign(secret, adminPw);
+      const ok = constantTimeEqual(
+        new TextEncoder().encode(submitted),
+        new TextEncoder().encode(expected),
       );
-      const cookieSecret = yield* Config.redacted('COOKIE_SECRET').pipe(
-        Config.withDefault(Redacted.make('')),
-      );
+      if (!ok) return yield* new BadPassword();
+      return yield* issueToken();
+    });
 
-      const adminPw = Redacted.value(adminPassword);
-      const secret = Redacted.value(cookieSecret);
-      // The admin is enabled only when BOTH a real password AND a real signing
-      // secret are set — matching the `.env.example` contract ("set both to
-      // enable it"). An "enabled admin with a blank secret" is an impossible,
-      // unsafe state (make-impossible-states-unrepresentable): the HMAC key
-      // would be the empty string, which `crypto.subtle.importKey` rejects with
-      // a `DataError` — so the first sign/verify would crash login with a 500 —
-      // and a blank signing key is trivially forgeable anyway. Requiring both
-      // collapses "auth on, no secret" into the single "disabled" state.
-      const enabled = adminPw !== '' && secret !== '';
+    const checkCookie = Effect.fn('Auth.checkCookie')(function* (
+      header: string | null,
+    ) {
+      if (!enabled) return yield* new AdminDisabled();
+      const token = parseCookie(header, COOKIE_NAME);
+      if (token === null) return yield* new Unauthorized();
+      yield* validateToken(token);
+    });
 
-      // Internal helpers (not part of the service surface) — untraced, mirroring
-      // opencode's traced-boundary / untraced-internal split (`git.ts`).
-      const issueToken = Effect.fnUntraced(function* () {
-        const now = yield* Clock.currentTimeMillis;
-        const issued = Math.floor(now / 1000);
-        const expires = issued + TOKEN_TTL_SECONDS;
-        const payload = `${issued}.${expires}`;
-        const sig = yield* sign(secret, payload);
-        return `${payload}.${sig}`;
-      });
+    return Service.of({
+      enabled,
+      verifyPassword,
+      checkCookie,
 
-      const validateToken = Effect.fnUntraced(function* (token: string) {
-        const parts = token.split('.');
-        if (parts.length !== 3) return yield* new Unauthorized();
-        const [issuedStr, expiresStr, sig] = parts as [string, string, string];
-        const expires = Number(expiresStr);
-        if (!Number.isFinite(expires)) return yield* new Unauthorized();
-        const now = yield* Clock.currentTimeMillis;
-        if (expires < Math.floor(now / 1000)) return yield* new Unauthorized();
-        const ok = yield* verifySig(secret, `${issuedStr}.${expiresStr}`, sig);
-        if (!ok) return yield* new Unauthorized();
-      });
+      cookieHeader: (token) =>
+        `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${TOKEN_TTL_SECONDS}`,
 
-      const verifyPassword = Effect.fn('Auth.verifyPassword')(function* (
-        password: string,
-      ) {
-        if (!enabled) return yield* new AdminDisabled();
-        // HMAC both sides to a fixed-length digest under the signing secret
-        // before comparing, so the compare never branches on the secret
-        // `ADMIN_PASSWORD`'s length — defeating a timing probe of the
-        // password length. The digests are equal-length (43-char base64url
-        // of a 32-byte SHA-256 HMAC), so the constant-time compare runs the
-        // full loop regardless of the submitted password.
-        const submitted = yield* sign(secret, password);
-        const expected = yield* sign(secret, adminPw);
-        const ok = constantTimeEqual(
-          new TextEncoder().encode(submitted),
-          new TextEncoder().encode(expected),
-        );
-        if (!ok) return yield* new BadPassword();
-        return yield* issueToken();
-      });
+      clearCookieHeader: () =>
+        `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    });
+  }),
+);
 
-      const checkCookie = Effect.fn('Auth.checkCookie')(function* (
-        header: string | null,
-      ) {
-        if (!enabled) return yield* new AdminDisabled();
-        const token = parseCookie(header, COOKIE_NAME);
-        if (token === null) return yield* new Unauthorized();
-        yield* validateToken(token);
-      });
-
-      return Auth.of({
-        enabled,
-        verifyPassword,
-        checkCookie,
-
-        cookieHeader: (token) =>
-          `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${TOKEN_TTL_SECONDS}`,
-
-        clearCookieHeader: () =>
-          `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
-      });
-    }),
-  );
-}
+export const defaultLayer = layer;

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -69,8 +69,8 @@ const toBase64Url = (bytes: Uint8Array): string => {
   return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 };
 
-const importKey = (secret: string): Effect.Effect<CryptoKey> =>
-  Effect.promise(() =>
+const importKey = Effect.fnUntraced(function* (secret: string) {
+  return yield* Effect.promise(() =>
     crypto.subtle.importKey(
       'raw',
       new TextEncoder().encode(secret),
@@ -79,15 +79,15 @@ const importKey = (secret: string): Effect.Effect<CryptoKey> =>
       ['sign', 'verify'],
     ),
   );
+});
 
-const sign = (secret: string, payload: string): Effect.Effect<string> =>
-  Effect.gen(function* () {
-    const key = yield* importKey(secret);
-    const sig = yield* Effect.promise(() =>
-      crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload)),
-    );
-    return toBase64Url(new Uint8Array(sig));
-  });
+const sign = Effect.fnUntraced(function* (secret: string, payload: string) {
+  const key = yield* importKey(secret);
+  const sig = yield* Effect.promise(() =>
+    crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload)),
+  );
+  return toBase64Url(new Uint8Array(sig));
+});
 
 const constantTimeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
   if (a.length !== b.length) return false;
@@ -96,18 +96,17 @@ const constantTimeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
   return diff === 0;
 };
 
-const verifySig = (
+const verifySig = Effect.fnUntraced(function* (
   secret: string,
   payload: string,
   sig: string,
-): Effect.Effect<boolean> =>
-  Effect.gen(function* () {
-    const expected = yield* sign(secret, payload);
-    return constantTimeEqual(
-      new TextEncoder().encode(expected),
-      new TextEncoder().encode(sig),
-    );
-  });
+) {
+  const expected = yield* sign(secret, payload);
+  return constantTimeEqual(
+    new TextEncoder().encode(expected),
+    new TextEncoder().encode(sig),
+  );
+});
 
 const parseCookie = (header: string | null, name: string): string | null => {
   if (header === null) return null;
@@ -170,64 +169,62 @@ export class Auth extends Context.Service<
       // collapses "auth on, no secret" into the single "disabled" state.
       const enabled = adminPw !== '' && secret !== '';
 
-      const issueToken = (): Effect.Effect<string> =>
-        Effect.gen(function* () {
-          const now = yield* Clock.currentTimeMillis;
-          const issued = Math.floor(now / 1000);
-          const expires = issued + TOKEN_TTL_SECONDS;
-          const payload = `${issued}.${expires}`;
-          const sig = yield* sign(secret, payload);
-          return `${payload}.${sig}`;
-        });
+      // Internal helpers (not part of the service surface) — untraced, mirroring
+      // opencode's traced-boundary / untraced-internal split (`git.ts`).
+      const issueToken = Effect.fnUntraced(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const issued = Math.floor(now / 1000);
+        const expires = issued + TOKEN_TTL_SECONDS;
+        const payload = `${issued}.${expires}`;
+        const sig = yield* sign(secret, payload);
+        return `${payload}.${sig}`;
+      });
 
-      const validateToken = (
-        token: string,
-      ): Effect.Effect<void, Unauthorized> =>
-        Effect.gen(function* () {
-          const parts = token.split('.');
-          if (parts.length !== 3) return yield* new Unauthorized();
-          const [issuedStr, expiresStr, sig] = parts as [
-            string,
-            string,
-            string,
-          ];
-          const expires = Number(expiresStr);
-          if (!Number.isFinite(expires)) return yield* new Unauthorized();
-          const now = yield* Clock.currentTimeMillis;
-          if (expires < Math.floor(now / 1000)) return yield* new Unauthorized();
-          const ok = yield* verifySig(secret, `${issuedStr}.${expiresStr}`, sig);
-          if (!ok) return yield* new Unauthorized();
-        });
+      const validateToken = Effect.fnUntraced(function* (token: string) {
+        const parts = token.split('.');
+        if (parts.length !== 3) return yield* new Unauthorized();
+        const [issuedStr, expiresStr, sig] = parts as [string, string, string];
+        const expires = Number(expiresStr);
+        if (!Number.isFinite(expires)) return yield* new Unauthorized();
+        const now = yield* Clock.currentTimeMillis;
+        if (expires < Math.floor(now / 1000)) return yield* new Unauthorized();
+        const ok = yield* verifySig(secret, `${issuedStr}.${expiresStr}`, sig);
+        if (!ok) return yield* new Unauthorized();
+      });
+
+      const verifyPassword = Effect.fn('Auth.verifyPassword')(function* (
+        password: string,
+      ) {
+        if (!enabled) return yield* new AdminDisabled();
+        // HMAC both sides to a fixed-length digest under the signing secret
+        // before comparing, so the compare never branches on the secret
+        // `ADMIN_PASSWORD`'s length — defeating a timing probe of the
+        // password length. The digests are equal-length (43-char base64url
+        // of a 32-byte SHA-256 HMAC), so the constant-time compare runs the
+        // full loop regardless of the submitted password.
+        const submitted = yield* sign(secret, password);
+        const expected = yield* sign(secret, adminPw);
+        const ok = constantTimeEqual(
+          new TextEncoder().encode(submitted),
+          new TextEncoder().encode(expected),
+        );
+        if (!ok) return yield* new BadPassword();
+        return yield* issueToken();
+      });
+
+      const checkCookie = Effect.fn('Auth.checkCookie')(function* (
+        header: string | null,
+      ) {
+        if (!enabled) return yield* new AdminDisabled();
+        const token = parseCookie(header, COOKIE_NAME);
+        if (token === null) return yield* new Unauthorized();
+        yield* validateToken(token);
+      });
 
       return Auth.of({
         enabled,
-
-        verifyPassword: (password) =>
-          Effect.gen(function* () {
-            if (!enabled) return yield* new AdminDisabled();
-            // HMAC both sides to a fixed-length digest under the signing secret
-            // before comparing, so the compare never branches on the secret
-            // `ADMIN_PASSWORD`'s length — defeating a timing probe of the
-            // password length. The digests are equal-length (43-char base64url
-            // of a 32-byte SHA-256 HMAC), so the constant-time compare runs the
-            // full loop regardless of the submitted password.
-            const submitted = yield* sign(secret, password);
-            const expected = yield* sign(secret, adminPw);
-            const ok = constantTimeEqual(
-              new TextEncoder().encode(submitted),
-              new TextEncoder().encode(expected),
-            );
-            if (!ok) return yield* new BadPassword();
-            return yield* issueToken();
-          }),
-
-        checkCookie: (header) =>
-          Effect.gen(function* () {
-            if (!enabled) return yield* new AdminDisabled();
-            const token = parseCookie(header, COOKIE_NAME);
-            if (token === null) return yield* new Unauthorized();
-            yield* validateToken(token);
-          }),
+        verifyPassword,
+        checkCookie,
 
         cookieHeader: (token) =>
           `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${TOKEN_TTL_SECONDS}`,

--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -12,6 +12,7 @@ import { HexColour, SiteContent } from './content/schema';
 import type { SiteContent as SiteContentType } from './content/schema';
 import { dayjs } from './dayjs';
 import { NotFound, Storage, StorageError } from './storage.server';
+import { layerTest } from './storage.test-helper';
 
 /**
  * The `Content` service is the single read path for the public site (C3). These
@@ -36,8 +37,8 @@ const encodeDoc = (doc: SiteContentType): Promise<string> =>
 
 /** A `Storage` with no document — every read reports `NotFound` (bucket-less). */
 const emptyStorage = Layer.succeed(
-  Storage,
-  Storage.of({
+  Storage.Service,
+  Storage.Service.of({
     get: (key) => Effect.fail(new NotFound({ key })),
     put: (key) =>
       Effect.fail(
@@ -50,8 +51,8 @@ const emptyStorage = Layer.succeed(
 );
 
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Content | Storage>,
-  storageLayer: Layer.Layer<Storage>,
+  effect: Effect.Effect<A, E, Content.Service | Storage.Service>,
+  storageLayer: Layer.Layer<Storage.Service>,
 ) =>
   Effect.runPromise(
     Effect.scoped(
@@ -70,8 +71,8 @@ const run = <A, E>(
  * test hits the same backing store `Content` reads (publish → bust → read).
  */
 const runWithStorage = <A, E>(
-  effect: Effect.Effect<A, E, Content | Storage>,
-  storageLayer: Layer.Layer<Storage>,
+  effect: Effect.Effect<A, E, Content.Service | Storage.Service>,
+  storageLayer: Layer.Layer<Storage.Service>,
 ) =>
   Effect.runPromise(
     Effect.scoped(
@@ -86,7 +87,7 @@ describe('Content fallback (no document in bucket)', () => {
   it('serves the bundled defaults when the document is absent', async () => {
     const content = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getSiteContent();
       }),
       emptyStorage,
@@ -100,7 +101,7 @@ describe('Content fallback (no document in bucket)', () => {
         // Pin "now" to a date before the earliest conference so the
         // first-future-conference branch selects 2024 deterministically.
         yield* TestClock.setTime(dayjs('2024-01-01').valueOf());
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getCurrentConference('en');
       }),
       emptyStorage,
@@ -115,7 +116,7 @@ describe('Content fallback (no document in bucket)', () => {
     const conference = await run(
       Effect.gen(function* () {
         yield* TestClock.setTime(dayjs('2030-01-01').valueOf());
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getCurrentConference('en');
       }),
       emptyStorage,
@@ -131,10 +132,10 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
     const json = await encodeDoc(defaultContent);
     const conference = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getConference('en', 2024);
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
 
     // Dates widen to the exact end-of-day-UTC ms the route code formats.
@@ -158,10 +159,10 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
     const json = await encodeDoc(defaultContent);
     const fr = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getConference('fr', 2024);
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
     expect(fr.title).toBe("Tant qu'il fait jour");
     expect(fr.hero.image.desktop).toBe('/images/2024/fr/hero-desktop.jpg');
@@ -172,10 +173,10 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
     const json = await encodeDoc(defaultContent);
     const conference = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getConference('en', 2026);
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
     expect(conference.registration).toBeUndefined();
     expect(conference.title).toBe('Speak');
@@ -193,10 +194,10 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
     const json = await encodeDoc(edited);
     const conference = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getConference('en', 2026);
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
     expect(conference.theme).toBe('#123456');
   });
@@ -220,13 +221,13 @@ describe('Content fallback (semantically-invalid document)', () => {
     const json = invalidJson((doc) => ({ ...doc, conferences: [] }));
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         const site = yield* content.getSiteContent();
         // The selectors must not throw (they would 500 the public site).
         const current = yield* content.getCurrentConference('en');
         return { site, current };
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
     expect(result.site).toEqual(defaultContent);
     // At the default TestClock time (epoch) every conference is still future, so
@@ -245,10 +246,10 @@ describe('Content fallback (semantically-invalid document)', () => {
     }));
     const conference = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getConference('en', 2026);
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
     // The defaults' 2026 conference is served, not a 500.
     expect(conference.slug).toBe('/2026');
@@ -261,12 +262,12 @@ describe('Content translations + team selectors', () => {
     const json = await encodeDoc(defaultContent);
     const { translations, team } = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         const translations = yield* content.getTranslations('fr');
         const team = yield* content.getTeam();
         return { translations, team };
       }),
-      Storage.layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
+      layerTest({ [SITE_CONTENT_KEY]: { body: json } }),
     );
 
     expect(translations['team.position.president']).toBe('Président');
@@ -281,10 +282,10 @@ describe('Content cache (TTL + single-flight)', () => {
   /** A `Storage` whose `get` count is observable, to assert caching. */
   const countingStorage = (json: string) =>
     Layer.effect(
-      Storage,
+      Storage.Service,
       Effect.gen(function* () {
         const calls = yield* Ref.make(0);
-        return Storage.of({
+        return Storage.Service.of({
           get: (key) =>
             key === SITE_CONTENT_KEY
               ? Ref.update(calls, (n) => n + 1).pipe(
@@ -317,7 +318,7 @@ describe('Content cache (TTL + single-flight)', () => {
     // built-in `Effect.cachedInvalidateWithTTL` provides both contracts.
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         const a = yield* content.getSiteContent();
         const b = yield* content.getSiteContent(); // cached — same reference
         yield* TestClock.adjust('31 seconds'); // past the 30s TTL
@@ -339,10 +340,10 @@ describe('Content cache (TTL + single-flight)', () => {
    */
   const mutableStorage = (initial: string) =>
     Layer.effect(
-      Storage,
+      Storage.Service,
       Effect.gen(function* () {
         const body = yield* Ref.make(initial);
-        return Storage.of({
+        return Storage.Service.of({
           get: (key) =>
             key === SITE_CONTENT_KEY
               ? Ref.get(body).pipe(
@@ -390,8 +391,8 @@ describe('Content cache (TTL + single-flight)', () => {
 
     const result = await runWithStorage(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
 
         const before = yield* content.getSiteContent(); // caches the original
         yield* storage.put(SITE_CONTENT_KEY, edited, 'application/json'); // publish
@@ -423,7 +424,7 @@ describe('Content cache (TTL + single-flight)', () => {
 
     const result = await runWithStorage(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         // Race many cold-cache reads at once; the built-in cache must collapse
         // them onto a single `fetchDocument`.
         const docs = yield* Effect.all(
@@ -447,7 +448,7 @@ describe('Content cache (TTL + single-flight)', () => {
 
 describe('Content admin read (draft → published → defaults)', () => {
   const adminStorage = (objects: Record<string, string>) =>
-    Storage.layerTest(
+    layerTest(
       Object.fromEntries(
         Object.entries(objects).map(([key, body]) => [key, { body }]),
       ),
@@ -456,7 +457,7 @@ describe('Content admin read (draft → published → defaults)', () => {
   it('falls back to the bundled defaults when nothing is stored', async () => {
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getAdminContent();
       }),
       adminStorage({}),
@@ -469,7 +470,7 @@ describe('Content admin read (draft → published → defaults)', () => {
     const published = await encodeDoc(defaultContent);
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getAdminContent();
       }),
       adminStorage({ [SITE_CONTENT_KEY]: published }),
@@ -488,8 +489,8 @@ describe('Content admin read (draft → published → defaults)', () => {
     // "I edited and saved a draft after the last publish" timeline.
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
         yield* TestClock.adjust('1 second');
         yield* storage.put(SITE_CONTENT_DRAFT_KEY, draft, 'application/json');
         return yield* content.getAdminContent();
@@ -516,8 +517,8 @@ describe('Content admin read (draft → published → defaults)', () => {
     const published = await encodeDoc(publishedDoc);
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
         // Draft written first…
         yield* storage.put(
           SITE_CONTENT_DRAFT_KEY,

--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { Deferred, Effect, Fiber, Layer, Option, Ref, Schema } from 'effect';
+import { Effect, Layer, Option, Ref, Schema } from 'effect';
 import { TestClock } from 'effect/testing';
 
 import {
@@ -23,8 +23,10 @@ import { NotFound, Storage, StorageError } from './storage.server';
  *     leading-`/` image URLs) so component code is unchanged;
  *   - the current-conference-by-date and by-year selection match today's
  *     `conference.server.ts` semantics (`derive-dont-sync`);
- *   - reads are cached within the TTL and refreshed after it
- *     (`serialize-shared-state-mutations`, `make-operations-idempotent`).
+ *   - reads are cached within the TTL (same reference) and refreshed after it,
+ *     concurrent first-reads are single-flighted, and the editor's `bust` makes
+ *     a publish visible on the next read (`use-the-platform` — the built-in
+ *     `Effect.cachedInvalidateWithTTL`).
  */
 
 const encode = Schema.encodeUnknownEffect(Schema.fromJsonString(SiteContent));
@@ -308,9 +310,9 @@ describe('Content cache (TTL + single-flight)', () => {
     const json = await encodeDoc(defaultContent);
 
     // We can't read the private call count from outside, so assert behaviour:
-    // two reads inside the TTL return the same value, and a read after the TTL
-    // still works (a fresh load). The single-flight + TTL logic is exercised by
-    // the storage `get` being called under the lock either way.
+    // two reads inside the TTL return the SAME decoded reference (the cache hit,
+    // not a re-decode), and a read after the TTL still works (a fresh load). The
+    // built-in `Effect.cachedInvalidateWithTTL` provides both contracts.
     const result = await run(
       Effect.gen(function* () {
         const content = yield* Content;
@@ -403,120 +405,37 @@ describe('Content cache (TTL + single-flight)', () => {
   });
 
   /**
-   * Regression for the publish/refresh race: a public read that is mid-refresh
-   * (it has already read the OLD document from the bucket) must NOT be able to
-   * repopulate the cache with that stale document AFTER a concurrent publish has
-   * busted it — which would serve stale content for a full TTL and break D3.
-   *
-   * The `Storage.get` here parks on a latch so we can pin the interleaving the
-   * finding describes: fiber A starts a refresh and reads the OLD document, the
-   * main fiber publishes the NEW document and busts the cache, then A's read
-   * completes. `bust()` advances the publish epoch under the same `refreshLock`
-   * the refresh holds, so the refresh's stale write can never win — the very
-   * next read re-fetches and serves the published document.
+   * Single-flight: concurrent first-reads must not stampede the bucket. The
+   * built-in `Effect.cachedInvalidateWithTTL` parks every reader on one
+   * in-flight `fetchDocument` and shares its result, so the bucket is read
+   * exactly once even when many fibers race the cold cache
+   * (`use-the-platform`). The `Storage.get` counts its calls so we can assert
+   * the single read directly.
    */
-  const latchedStorage = (
-    body: string,
-    started: Deferred.Deferred<void>,
-    release: Deferred.Deferred<void>,
-  ) =>
-    Layer.effect(
-      Storage,
-      Effect.gen(function* () {
-        const current = yield* Ref.make(body);
-        return Storage.of({
-          get: (key) =>
-            key === SITE_CONTENT_KEY
-              ? Effect.gen(function* () {
-                  // Snapshot the document, then announce the read has begun and
-                  // park until the test releases us — so the publish + bust land
-                  // while this read is in flight.
-                  const json = yield* Ref.get(current);
-                  yield* Deferred.succeed(started, undefined);
-                  yield* Deferred.await(release);
-                  return {
-                    stream:
-                      new Response(json).body ??
-                      new ReadableStream<Uint8Array>(),
-                    contentType: 'application/json',
-                    size: json.length,
-                  };
-                })
-              : Effect.fail(new NotFound({ key })),
-          put: (key, value) =>
-            key === SITE_CONTENT_KEY && typeof value === 'string'
-              ? Ref.set(current, value)
-              : Effect.fail(
-                  new StorageError({ key, op: 'put', message: 'unsupported' }),
-                ),
-          head: () => Effect.succeed(Option.none()),
-          list: () => Effect.succeed([]),
-          delete: () => Effect.void,
-        });
-      }),
-    );
-
-  it('an in-flight refresh cannot repopulate the cache with a document a concurrent bust invalidated (D3)', async () => {
-    const original = await encodeDoc(defaultContent);
-    const editedDoc = SiteContent.make({
-      ...defaultContent,
-      conferences: defaultContent.conferences.map((conference) =>
-        conference.slug === '/2026'
-          ? { ...conference, accentColor: '#0a0a0a' }
-          : conference,
-      ),
-    });
-    const edited = await encodeDoc(editedDoc);
-
-    const accent2026 = (content: SiteContentType): string | undefined =>
-      content.conferences.find((c) => c.slug === '/2026')?.accentColor;
-
-    // The latches are created outside the run so the same `Deferred`s are shared
-    // by the storage layer (which signals/parks on the read) and the test body
-    // (which drives the publish + bust between them).
-    const started = await Effect.runPromise(Deferred.make<void>());
-    const release = await Effect.runPromise(Deferred.make<void>());
+  it('single-flights concurrent first-reads onto one bucket read', async () => {
+    const json = await encodeDoc(defaultContent);
 
     const result = await runWithStorage(
       Effect.gen(function* () {
         const content = yield* Content;
-        const storage = yield* Storage;
-
-        // Fiber A: a public read whose refresh reads the OLD document and then
-        // parks on the latch, holding `refreshLock`.
-        const reader = yield* Effect.forkChild(content.getSiteContent());
-        yield* Deferred.await(started); // A has read the OLD document
-
-        // Publish the NEW document, then bust on a forked fiber. With the FIXED
-        // `bust()` this fiber blocks on the `refreshLock` A holds (so it cannot
-        // possibly clear the cache before A finishes its conditional write); the
-        // bust then runs after A and raises the epoch A snapshotted, dropping A's
-        // stale write. With the BROKEN `bust()` (a bare `Ref.set(none)` that
-        // skips the lock) the fork would clear the cache immediately — BEFORE A
-        // resumes — and A would then re-cache the stale OLD document as the final
-        // state, which the `after` assertion catches.
-        yield* storage.put(SITE_CONTENT_KEY, edited, 'application/json');
-        const buster = yield* Effect.forkChild(content.bust());
-
-        // Give the buster a scheduling window to run if it is *able* to (the
-        // broken, lock-free bust runs here; the fixed bust stays parked on the
-        // lock A holds). Then release A so its read + conditional cache write
-        // complete, and join both fibers.
-        yield* Effect.yieldNow;
-        yield* Deferred.succeed(release, undefined);
-        const stale = yield* Fiber.join(reader);
-        yield* Fiber.join(buster);
-
-        // The next read must re-fetch and serve the PUBLISHED document — never
-        // the stale one A had cached.
-        const after = yield* content.getSiteContent();
-        return { stale, after };
+        // Race many cold-cache reads at once; the built-in cache must collapse
+        // them onto a single `fetchDocument`.
+        const docs = yield* Effect.all(
+          Array.from({ length: 8 }, () => content.getSiteContent()),
+          { concurrency: 'unbounded' },
+        );
+        return docs;
       }),
-      latchedStorage(original, started, release),
+      countingStorage(json),
     );
 
-    expect(accent2026(result.stale)).toBe('#D4A24E'); // A read the OLD document
-    expect(accent2026(result.after)).toBe('#0a0a0a'); // bust wins → published
+    // Every racer got the bundled defaults…
+    for (const doc of result) {
+      expect(doc).toEqual(defaultContent);
+    }
+    // …and they share ONE decoded reference (proves the single in-flight load,
+    // not eight independent decodes).
+    expect(result.every((doc) => doc === result[0])).toBe(true);
   });
 });
 

--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -40,7 +40,9 @@ const emptyStorage = Layer.succeed(
   Storage.of({
     get: (key) => Effect.fail(new NotFound({ key })),
     put: (key) =>
-      Effect.fail(new StorageError({ key, op: 'put', message: 'disabled' })),
+      Effect.fail(
+        new StorageError({ key, op: 'put', cause: new Error('disabled') }),
+      ),
     head: () => Effect.succeed(Option.none()),
     list: () => Effect.succeed([]),
     delete: () => Effect.void,
@@ -297,7 +299,7 @@ describe('Content cache (TTL + single-flight)', () => {
               : Effect.fail(new NotFound({ key })),
           put: (key) =>
             Effect.fail(
-              new StorageError({ key, op: 'put', message: 'disabled' }),
+              new StorageError({ key, op: 'put', cause: new Error('disabled') }),
             ),
           head: () => Effect.succeed(Option.none()),
           list: () => Effect.succeed([]),
@@ -358,7 +360,11 @@ describe('Content cache (TTL + single-flight)', () => {
             key === SITE_CONTENT_KEY && typeof value === 'string'
               ? Ref.set(body, value)
               : Effect.fail(
-                  new StorageError({ key, op: 'put', message: 'unsupported' }),
+                  new StorageError({
+                    key,
+                    op: 'put',
+                    cause: new Error('unsupported'),
+                  }),
                 ),
           head: () => Effect.succeed(Option.none()),
           list: () => Effect.succeed([]),

--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -8,7 +8,7 @@ import {
   SITE_CONTENT_KEY,
 } from './content.server';
 import { defaultContent } from './content/defaults';
-import { SiteContent } from './content/schema';
+import { HexColour, SiteContent } from './content/schema';
 import type { SiteContent as SiteContentType } from './content/schema';
 import { dayjs } from './dayjs';
 import { NotFound, Storage, StorageError } from './storage.server';
@@ -184,7 +184,7 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
       ...defaultContent,
       conferences: defaultContent.conferences.map((conference) =>
         conference.slug === '/2026'
-          ? { ...conference, accentColor: '#123456' }
+          ? { ...conference, accentColor: HexColour.make('#123456') }
           : conference,
       ),
     };
@@ -373,7 +373,7 @@ describe('Content cache (TTL + single-flight)', () => {
       ...defaultContent,
       conferences: defaultContent.conferences.map((conference) =>
         conference.slug === '/2026'
-          ? { ...conference, accentColor: '#0a0a0a' }
+          ? { ...conference, accentColor: HexColour.make('#0a0a0a') }
           : conference,
       ),
     });

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -1,3 +1,5 @@
+export * as Content from './content.server';
+
 import {
   Clock,
   Context,
@@ -312,8 +314,8 @@ const CACHE_TTL_MS = 30_000;
 
 const decodeDocument = Schema.decodeUnknownEffect(Schema.fromJsonString(SiteContent));
 
-export class Content extends Context.Service<
-  Content,
+export class Service extends Context.Service<
+  Service,
   {
     readonly getSiteContent: () => Effect.Effect<SiteContentType>;
     readonly getConference: (
@@ -347,186 +349,204 @@ export class Content extends Context.Service<
      */
     readonly bust: () => Effect.Effect<void>;
   }
->()('gycc/lib/content.server/Content') {
-  static layer = Layer.effect(
-    Content,
-    Effect.gen(function* () {
-      const storage = yield* Storage;
+>()('gycc/lib/content.server/Service') {}
 
-      /**
-       * Read + decode the `SiteContent` document at `key`, or `Option.none()`
-       * when it is absent / unreadable / malformed. Shared by the public read
-       * path (which maps `none` to the bundled defaults) and the admin read
-       * path (which tries the draft, then the published key, then defaults).
-       */
-      const readDocument = Effect.fnUntraced(
-        function* (key: string) {
-          const object = yield* storage.get(key);
-          const json = yield* Effect.promise(() =>
-            new Response(object.stream).text(),
-          );
-          return Option.some(yield* decodeDocument(json));
-        },
-        (effect, key) =>
-          effect.pipe(
-            Effect.catchCause((cause) =>
-              Effect.logWarning(`Content: could not read ${key}`, cause).pipe(
-                Effect.as(Option.none<SiteContentType>()),
-              ),
+/**
+ * The `Content` layer (opencode's module-level `export const layer`,
+ * `packages/core/src/git.ts:79`), leaving its `Storage` requirement open so the
+ * app runtime and tests can supply different `Storage` layers. `defaultLayer`
+ * pre-provides `Storage.layerOptional` (the never-fails-to-build storage,
+ * mirroring `git.ts:347`), leaving only `Env` open — the public read path is
+ * thus wired with a single `Content.defaultLayer` in the runtime, with `Env`
+ * discharged by the surrounding merge.
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const storage = yield* Storage.Service;
+
+    /**
+     * Read + decode the `SiteContent` document at `key`, or `Option.none()`
+     * when it is absent / unreadable / malformed. Shared by the public read
+     * path (which maps `none` to the bundled defaults) and the admin read
+     * path (which tries the draft, then the published key, then defaults).
+     */
+    const readDocument = Effect.fnUntraced(
+      function* (key: string) {
+        const object = yield* storage.get(key);
+        const json = yield* Effect.promise(() =>
+          new Response(object.stream).text(),
+        );
+        return Option.some(yield* decodeDocument(json));
+      },
+      (effect, key) =>
+        effect.pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning(`Content: could not read ${key}`, cause).pipe(
+              Effect.as(Option.none<SiteContentType>()),
             ),
           ),
-      );
-
-      /**
-       * Read + decode the document from the bucket, falling back to the bundled
-       * defaults on every failure mode (`boundary-discipline`, D3):
-       *   - no bucket configured → `Storage.layerOptional` yields a disabled
-       *     storage whose `get` reports `NotFound`;
-       *   - object absent / empty → `NotFound`;
-       *   - bucket unreachable or document malformed → any other failure /
-       *     decode error / unexpected defect.
-       * In all cases `readDocument` logs and yields `none`, so the site is never
-       * broken by a missing or bad document — the public read always gets a
-       * `SiteContent`.
-       */
-      const fetchDocument: Effect.Effect<SiteContentType> = readDocument(
-        SITE_CONTENT_KEY,
-      ).pipe(
-        Effect.map((document) =>
-          Option.getOrElse(document, () => defaultContent),
         ),
-      );
+    );
 
-      /**
-       * The public read cache: Effect's built-in TTL cache with manual
-       * invalidation (`use-the-platform`). `cachedContent` single-flights
-       * concurrent first-reads onto one `fetchDocument` (the others park on its
-       * latch and share the result, so the bucket is not stampeded) and returns
-       * the same decoded `SiteContent` reference for the TTL's duration;
-       * `invalidate` arms the next read to re-fetch (the editor's publish path).
-       */
-      const [cachedContent, invalidate] = yield* Effect.cachedInvalidateWithTTL(
-        fetchDocument,
-        Duration.millis(CACHE_TTL_MS),
-      );
+    /**
+     * Read + decode the document from the bucket, falling back to the bundled
+     * defaults on every failure mode (`boundary-discipline`, D3):
+     *   - no bucket configured → `Storage.layerOptional` yields a disabled
+     *     storage whose `get` reports `NotFound`;
+     *   - object absent / empty → `NotFound`;
+     *   - bucket unreachable or document malformed → any other failure /
+     *     decode error / unexpected defect.
+     * In all cases `readDocument` logs and yields `none`, so the site is never
+     * broken by a missing or bad document — the public read always gets a
+     * `SiteContent`.
+     */
+    const fetchDocument: Effect.Effect<SiteContentType> = readDocument(
+      SITE_CONTENT_KEY,
+    ).pipe(
+      Effect.map((document) =>
+        Option.getOrElse(document, () => defaultContent),
+      ),
+    );
 
-      const getSiteContent = Effect.fn('Content.getSiteContent')(function* () {
-        return yield* cachedContent;
-      });
+    /**
+     * The public read cache: Effect's built-in TTL cache with manual
+     * invalidation (`use-the-platform`). `cachedContent` single-flights
+     * concurrent first-reads onto one `fetchDocument` (the others park on its
+     * latch and share the result, so the bucket is not stampeded) and returns
+     * the same decoded `SiteContent` reference for the TTL's duration;
+     * `invalidate` arms the next read to re-fetch (the editor's publish path).
+     */
+    const [cachedContent, invalidate] = yield* Effect.cachedInvalidateWithTTL(
+      fetchDocument,
+      Duration.millis(CACHE_TTL_MS),
+    );
 
-      const getConference = Effect.fn('Content.getConference')(function* (
-        locale: Locale,
-        year?: number,
-      ) {
-        assertValidLocale(locale);
-        const content = yield* getSiteContent();
-        const now = yield* Clock.currentTimeMillis;
-        return year === undefined
-          ? selectCurrent(content, locale, now)
-          : selectByYear(content, locale, year);
-      });
+    const getSiteContent = Effect.fn('Content.getSiteContent')(function* () {
+      return yield* cachedContent;
+    });
 
-      const getCurrentConference = Effect.fn('Content.getCurrentConference')(
-        function* (locale: Locale) {
-          return yield* getConference(locale);
-        },
-      );
+    const getConference = Effect.fn('Content.getConference')(function* (
+      locale: Locale,
+      year?: number,
+    ) {
+      assertValidLocale(locale);
+      const content = yield* getSiteContent();
+      const now = yield* Clock.currentTimeMillis;
+      return year === undefined
+        ? selectCurrent(content, locale, now)
+        : selectByYear(content, locale, year);
+    });
 
-      const getTranslations = Effect.fn('Content.getTranslations')(function* (
-        locale: Locale,
-      ) {
-        assertValidLocale(locale);
-        const content = yield* getSiteContent();
-        return content.translations[locale];
-      });
+    const getCurrentConference = Effect.fn('Content.getCurrentConference')(
+      function* (locale: Locale) {
+        return yield* getConference(locale);
+      },
+    );
 
-      const getTeam = Effect.fn('Content.getTeam')(function* () {
-        const content = yield* getSiteContent();
-        return {
-          team: content.team.map(toTeamMember),
-          board: [...content.board],
-        };
-      });
+    const getTranslations = Effect.fn('Content.getTranslations')(function* (
+      locale: Locale,
+    ) {
+      assertValidLocale(locale);
+      const content = yield* getSiteContent();
+      return content.translations[locale];
+    });
 
-      /**
-       * Load the document the `/admin` editor edits, reconciling draft vs
-       * published by their bucket `lastModified` rather than by the mere
-       * *presence* of a draft object (`derive-dont-sync`,
-       * `make-impossible-states-unrepresentable`).
-       *
-       * A draft represents pending unpublished edits **only when it is strictly
-       * newer than the published document** — i.e. it was saved after the last
-       * publish. The publish path deletes the draft best-effort, but correctness
-       * must not depend on that delete succeeding: a draft left behind by a
-       * failed delete, or a stale draft that predates the current published doc,
-       * is older-or-equal and is therefore ignored, so the editor opens from the
-       * published document and a subsequent save/publish can never overwrite the
-       * live content with stale draft values. A draft with no published document
-       * to compare against is always a valid edit source.
-       *
-       * (Bucket `lastModified` is second-granular on some backends, so a draft
-       * saved and published within the same second compares equal — the strict
-       * `>` then drops the ambiguous draft in favour of the just-published live
-       * content, the safe direction.)
-       */
-      const getAdminContent = Effect.fn('Content.getAdminContent')(
-        function* () {
-          const draft = yield* readDocument(SITE_CONTENT_DRAFT_KEY);
-          const published = yield* readDocument(SITE_CONTENT_KEY);
+    const getTeam = Effect.fn('Content.getTeam')(function* () {
+      const content = yield* getSiteContent();
+      return {
+        team: content.team.map(toTeamMember),
+        board: [...content.board],
+      };
+    });
 
-          if (Option.isSome(draft)) {
-            if (Option.isNone(published)) {
-              return { content: draft.value, source: 'draft' as const };
-            }
-            const draftHead = yield* storage
-              .head(SITE_CONTENT_DRAFT_KEY)
-              .pipe(Effect.orElseSucceed(() => Option.none<ObjectHead>()));
-            const publishedHead = yield* storage
-              .head(SITE_CONTENT_KEY)
-              .pipe(Effect.orElseSucceed(() => Option.none<ObjectHead>()));
-            const draftIsNewer =
-              Option.isSome(draftHead) &&
-              Option.isSome(publishedHead) &&
-              draftHead.value.lastModified.getTime() >
-                publishedHead.value.lastModified.getTime();
-            if (draftIsNewer) {
-              return { content: draft.value, source: 'draft' as const };
-            }
-            return { content: published.value, source: 'published' as const };
+    /**
+     * Load the document the `/admin` editor edits, reconciling draft vs
+     * published by their bucket `lastModified` rather than by the mere
+     * *presence* of a draft object (`derive-dont-sync`,
+     * `make-impossible-states-unrepresentable`).
+     *
+     * A draft represents pending unpublished edits **only when it is strictly
+     * newer than the published document** — i.e. it was saved after the last
+     * publish. The publish path deletes the draft best-effort, but correctness
+     * must not depend on that delete succeeding: a draft left behind by a
+     * failed delete, or a stale draft that predates the current published doc,
+     * is older-or-equal and is therefore ignored, so the editor opens from the
+     * published document and a subsequent save/publish can never overwrite the
+     * live content with stale draft values. A draft with no published document
+     * to compare against is always a valid edit source.
+     *
+     * (Bucket `lastModified` is second-granular on some backends, so a draft
+     * saved and published within the same second compares equal — the strict
+     * `>` then drops the ambiguous draft in favour of the just-published live
+     * content, the safe direction.)
+     */
+    const getAdminContent = Effect.fn('Content.getAdminContent')(
+      function* () {
+        const draft = yield* readDocument(SITE_CONTENT_DRAFT_KEY);
+        const published = yield* readDocument(SITE_CONTENT_KEY);
+
+        if (Option.isSome(draft)) {
+          if (Option.isNone(published)) {
+            return { content: draft.value, source: 'draft' as const };
           }
-
-          if (Option.isSome(published)) {
-            return { content: published.value, source: 'published' as const };
+          const draftHead = yield* storage
+            .head(SITE_CONTENT_DRAFT_KEY)
+            .pipe(Effect.orElseSucceed(() => Option.none<ObjectHead>()));
+          const publishedHead = yield* storage
+            .head(SITE_CONTENT_KEY)
+            .pipe(Effect.orElseSucceed(() => Option.none<ObjectHead>()));
+          const draftIsNewer =
+            Option.isSome(draftHead) &&
+            Option.isSome(publishedHead) &&
+            draftHead.value.lastModified.getTime() >
+              publishedHead.value.lastModified.getTime();
+          if (draftIsNewer) {
+            return { content: draft.value, source: 'draft' as const };
           }
-          return { content: defaultContent, source: 'defaults' as const };
-        },
-      );
+          return { content: published.value, source: 'published' as const };
+        }
 
-      // Arm the next public read to re-fetch the bucket so a publish is visible
-      // immediately, with no redeploy and without waiting out the TTL (D3). This
-      // is the built-in cache's `invalidate`: it expires the cached document and
-      // clears the stored result, so the next `getSiteContent` recomputes
-      // `fetchDocument`. (`make-operations-idempotent`: busting an already-empty
-      // or already-expired cache is a harmless no-op.) The built-in does NOT
-      // pre-empt an in-flight refresh: a publish landing during one is masked
-      // because that refresh re-arms the TTL with its pre-publish document, so
-      // the stale window measured from the publish is `(the refresh's remaining
-      // bucket-read duration) + one TTL`, not ≤ one TTL. That documented window
-      // is within D3's "visible on the next read after the window" contract
-      // (see the `Content` doc above for the full mechanism).
-      const bust = Effect.fn('Content.bust')(function* () {
-        yield* invalidate;
-      });
+        if (Option.isSome(published)) {
+          return { content: published.value, source: 'published' as const };
+        }
+        return { content: defaultContent, source: 'defaults' as const };
+      },
+    );
 
-      return Content.of({
-        getSiteContent,
-        getConference,
-        getCurrentConference,
-        getTranslations,
-        getTeam,
-        getAdminContent,
-        bust,
-      });
-    }),
-  );
-}
+    // Arm the next public read to re-fetch the bucket so a publish is visible
+    // immediately, with no redeploy and without waiting out the TTL (D3). This
+    // is the built-in cache's `invalidate`: it expires the cached document and
+    // clears the stored result, so the next `getSiteContent` recomputes
+    // `fetchDocument`. (`make-operations-idempotent`: busting an already-empty
+    // or already-expired cache is a harmless no-op.) The built-in does NOT
+    // pre-empt an in-flight refresh: a publish landing during one is masked
+    // because that refresh re-arms the TTL with its pre-publish document, so
+    // the stale window measured from the publish is `(the refresh's remaining
+    // bucket-read duration) + one TTL`, not ≤ one TTL. That documented window
+    // is within D3's "visible on the next read after the window" contract
+    // (see the `Content` doc above for the full mechanism).
+    const bust = Effect.fn('Content.bust')(function* () {
+      yield* invalidate;
+    });
+
+    return Service.of({
+      getSiteContent,
+      getConference,
+      getCurrentConference,
+      getTranslations,
+      getTeam,
+      getAdminContent,
+      bust,
+    });
+  }),
+);
+
+/**
+ * The public read path's `Content`, with its `Storage` dependency pre-provided
+ * as `Storage.layerOptional` (the never-fails-to-build storage, mirroring
+ * opencode `packages/core/src/git.ts:347`). Only `Env` stays open, discharged
+ * by the surrounding app-runtime merge. The admin write path provides `Storage`
+ * standalone (a legit second consumer), so it is NOT wired here.
+ */
+export const defaultLayer = layer.pipe(Layer.provide(Storage.layerOptional));

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -359,24 +359,23 @@ export class Content extends Context.Service<
        * path (which maps `none` to the bundled defaults) and the admin read
        * path (which tries the draft, then the published key, then defaults).
        */
-      const readDocument = (
-        key: string,
-      ): Effect.Effect<Option.Option<SiteContentType>> =>
-        Effect.gen(function* () {
+      const readDocument = Effect.fnUntraced(
+        function* (key: string) {
           const object = yield* storage.get(key);
           const json = yield* Effect.promise(() =>
             new Response(object.stream).text(),
           );
-          return yield* decodeDocument(json);
-        }).pipe(
-          Effect.map(Option.some),
-          Effect.catchCause((cause) =>
-            Effect.logWarning(
-              `Content: could not read ${key}`,
-              cause,
-            ).pipe(Effect.as(Option.none<SiteContentType>())),
+          return Option.some(yield* decodeDocument(json));
+        },
+        (effect, key) =>
+          effect.pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning(`Content: could not read ${key}`, cause).pipe(
+                Effect.as(Option.none<SiteContentType>()),
+              ),
+            ),
           ),
-        );
+      );
 
       /**
        * Read + decode the document from the bucket, falling back to the bundled
@@ -411,40 +410,43 @@ export class Content extends Context.Service<
         Duration.millis(CACHE_TTL_MS),
       );
 
-      const getSiteContent = (): Effect.Effect<SiteContentType> => cachedContent;
+      const getSiteContent = Effect.fn('Content.getSiteContent')(function* () {
+        return yield* cachedContent;
+      });
 
-      const getConference = (
+      const getConference = Effect.fn('Content.getConference')(function* (
         locale: Locale,
         year?: number,
-      ): Effect.Effect<Conference> =>
-        Effect.gen(function* () {
-          assertValidLocale(locale);
-          const content = yield* getSiteContent();
-          const now = yield* Clock.currentTimeMillis;
-          return year === undefined
-            ? selectCurrent(content, locale, now)
-            : selectByYear(content, locale, year);
-        });
+      ) {
+        assertValidLocale(locale);
+        const content = yield* getSiteContent();
+        const now = yield* Clock.currentTimeMillis;
+        return year === undefined
+          ? selectCurrent(content, locale, now)
+          : selectByYear(content, locale, year);
+      });
 
-      const getCurrentConference = (
+      const getCurrentConference = Effect.fn('Content.getCurrentConference')(
+        function* (locale: Locale) {
+          return yield* getConference(locale);
+        },
+      );
+
+      const getTranslations = Effect.fn('Content.getTranslations')(function* (
         locale: Locale,
-      ): Effect.Effect<Conference> => getConference(locale);
+      ) {
+        assertValidLocale(locale);
+        const content = yield* getSiteContent();
+        return content.translations[locale];
+      });
 
-      const getTranslations = (locale: Locale): Effect.Effect<Translation> =>
-        Effect.gen(function* () {
-          assertValidLocale(locale);
-          const content = yield* getSiteContent();
-          return content.translations[locale];
-        });
-
-      const getTeam = () =>
-        Effect.gen(function* () {
-          const content = yield* getSiteContent();
-          return {
-            team: content.team.map(toTeamMember),
-            board: [...content.board],
-          };
-        });
+      const getTeam = Effect.fn('Content.getTeam')(function* () {
+        const content = yield* getSiteContent();
+        return {
+          team: content.team.map(toTeamMember),
+          board: [...content.board],
+        };
+      });
 
       /**
        * Load the document the `/admin` editor edits, reconciling draft vs
@@ -467,8 +469,8 @@ export class Content extends Context.Service<
        * `>` then drops the ambiguous draft in favour of the just-published live
        * content, the safe direction.)
        */
-      const getAdminContent = (): Effect.Effect<AdminContent> =>
-        Effect.gen(function* () {
+      const getAdminContent = Effect.fn('Content.getAdminContent')(
+        function* () {
           const draft = yield* readDocument(SITE_CONTENT_DRAFT_KEY);
           const published = yield* readDocument(SITE_CONTENT_KEY);
 
@@ -497,7 +499,8 @@ export class Content extends Context.Service<
             return { content: published.value, source: 'published' as const };
           }
           return { content: defaultContent, source: 'defaults' as const };
-        });
+        },
+      );
 
       // Arm the next public read to re-fetch the bucket so a publish is visible
       // immediately, with no redeploy and without waiting out the TTL (D3). This
@@ -511,7 +514,9 @@ export class Content extends Context.Service<
       // bucket-read duration) + one TTL`, not ≤ one TTL. That documented window
       // is within D3's "visible on the next read after the window" contract
       // (see the `Content` doc above for the full mechanism).
-      const bust = (): Effect.Effect<void> => invalidate;
+      const bust = Effect.fn('Content.bust')(function* () {
+        yield* invalidate;
+      });
 
       return Content.of({
         getSiteContent,

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -1,12 +1,11 @@
 import {
   Clock,
   Context,
+  Duration,
   Effect,
   Layer,
   Option,
-  Ref,
   Schema,
-  Semaphore,
 } from 'effect';
 
 import { defaultContent } from './content/defaults';
@@ -44,11 +43,23 @@ import type { ObjectHead } from './storage.server';
  *     `Schema`-decoded on read — and is converted HERE to the legacy
  *     route/component shape (per-locale strings, `[start, end]` millisecond
  *     tuples, leading-`/` image URLs) so component code is UNCHANGED.
- *   - `serialize-shared-state-mutations` + `make-operations-idempotent`: a
- *     single-permit `Semaphore` guards the cache refresh so concurrent
- *     first-reads do not stampede the bucket; the holder double-checks the TTL
- *     after acquiring the permit, so a refresh that already happened is not
- *     repeated.
+ *   - `use-the-platform`: the read cache is Effect's built-in
+ *     `Effect.cachedInvalidateWithTTL` — it single-flights concurrent
+ *     first-reads (a fetch in flight parks the other fibers on a latch and they
+ *     all get the one result, so the bucket is not stampeded) and hands back an
+ *     `invalidate` effect the editor's publish calls (`bust`). Within the TTL it
+ *     returns the *same* decoded `SiteContent` reference. **Documented staleness
+ *     window:** the built-in `invalidate` is a bare sync that only expires the
+ *     entry (`expiresAt = 0`); it does not pre-empt an in-flight refresh nor
+ *     clear its `running` flag. So a publish that lands while a refresh is
+ *     already fetching the bucket is masked: that refresh's `onExit` completes
+ *     with the *pre-publish* document and re-arms the TTL from its own
+ *     completion instant. Measured from the publish instant the stale window is
+ *     therefore `(the refresh's remaining bucket-read duration) + one TTL` — not
+ *     ≤ one TTL. For a 30s-TTL, low-write CMS this worst case (a multi-second
+ *     bucket read in flight + 30s) still stays inside D3's "visible on the next
+ *     read after the window" contract, so we take the platform primitive over a
+ *     hand-rolled epoch guard (`subtract-before-you-add`).
  *   - `make-impossible-states-unrepresentable`: a Conference whose pricing is
  *     undecided carries `registration: undefined` (the `Option.none()` in the
  *     document), never empty tuples.
@@ -292,16 +303,11 @@ export interface AdminContent {
 
 /**
  * Cache TTL. Short by design (D3 — runtime read with cache, no redeploy): a
- * publish becomes visible on the next read after the TTL elapses (or an
- * explicit bust, added with the editor in C5). 30s keeps the bucket-read rate
- * negligible while making edits feel near-instant.
+ * publish becomes visible on the next read after the TTL elapses (or the
+ * editor's explicit `bust`). 30s keeps the bucket-read rate negligible while
+ * making edits feel near-instant.
  */
 const CACHE_TTL_MS = 30_000;
-
-interface CacheEntry {
-  readonly value: SiteContentType;
-  readonly loadedAt: number;
-}
 
 const decodeDocument = Schema.decodeUnknownEffect(Schema.fromJsonString(SiteContent));
 
@@ -329,10 +335,14 @@ export class Content extends Context.Service<
      */
     readonly getAdminContent: () => Effect.Effect<AdminContent>;
     /**
-     * Invalidate the public read cache so the next `getSiteContent` re-reads the
-     * bucket. Called by the editor's publish action so a publish is visible
-     * immediately, with no redeploy and without waiting out the TTL (D3,
+     * Invalidate the public read cache so a subsequent `getSiteContent`
+     * re-reads the bucket. Called by the editor's publish action so a publish
+     * is visible with no redeploy and without waiting out the TTL (D3,
      * `make-operations-idempotent` — busting an already-empty cache is a no-op).
+     * When no refresh is already in flight a publish is visible on the very
+     * next read; otherwise it is visible within the documented staleness window
+     * — `invalidate` only expires the entry, it does not pre-empt an in-flight
+     * refresh (see the `Content` doc above for the full mechanism).
      */
     readonly bust: () => Effect.Effect<void>;
   }
@@ -341,36 +351,7 @@ export class Content extends Context.Service<
     Content,
     Effect.gen(function* () {
       const storage = yield* Storage;
-      const cache = yield* Ref.make<Option.Option<CacheEntry>>(Option.none());
-      const refreshLock = yield* Semaphore.make(1);
-      /**
-       * Monotonic publish-epoch counter (`derive-dont-sync`,
-       * `serialize-shared-state-mutations`). `bust()` increments it; a refresh
-       * snapshots it *before* its bucket read and only commits the freshly-read
-       * document to the cache if the epoch is unchanged when it goes to write.
-       * This closes the publish/refresh race: a refresh that read the document
-       * the bucket held *before* a concurrent publish cannot repopulate the
-       * cache with that now-stale document, because the publish's `bust()` will
-       * have advanced the epoch in between — the refresh observes the change and
-       * leaves the cache empty so the very next read re-fetches the published
-       * document (D3 — a publish is visible on the next read, never stale for a
-       * full TTL).
-       */
-      const epoch = yield* Ref.make(0);
 
-      /**
-       * Read + decode the document from the bucket, falling back to the bundled
-       * defaults on every failure mode (`boundary-discipline`, D3):
-       *   - no bucket configured → `Storage.layerOptional` yields a disabled
-       *     storage whose `get` reports `NotFound`;
-       *   - object absent / empty → `NotFound`;
-       *   - bucket unreachable or document malformed → any other failure /
-       *     decode error / unexpected defect.
-       * In all cases we log and serve the defaults, so the site is never broken
-       * by a missing or bad document. `catchCause` recovers from BOTH the typed
-       * failures and any defect so the read is total — the public site always
-       * gets a `SiteContent`.
-       */
       /**
        * Read + decode the `SiteContent` document at `key`, or `Option.none()`
        * when it is absent / unreadable / malformed. Shared by the public read
@@ -396,6 +377,18 @@ export class Content extends Context.Service<
           ),
         );
 
+      /**
+       * Read + decode the document from the bucket, falling back to the bundled
+       * defaults on every failure mode (`boundary-discipline`, D3):
+       *   - no bucket configured → `Storage.layerOptional` yields a disabled
+       *     storage whose `get` reports `NotFound`;
+       *   - object absent / empty → `NotFound`;
+       *   - bucket unreachable or document malformed → any other failure /
+       *     decode error / unexpected defect.
+       * In all cases `readDocument` logs and yields `none`, so the site is never
+       * broken by a missing or bad document — the public read always gets a
+       * `SiteContent`.
+       */
       const fetchDocument: Effect.Effect<SiteContentType> = readDocument(
         SITE_CONTENT_KEY,
       ).pipe(
@@ -405,59 +398,19 @@ export class Content extends Context.Service<
       );
 
       /**
-       * Return the cached document if it is within the TTL, otherwise refresh
-       * it under the single-permit lock. The lock holder re-checks the TTL
-       * after acquiring the permit so a refresh that another fiber already
-       * completed is not repeated (`make-operations-idempotent`); waiters
-       * therefore return the freshly-loaded value without a second bucket read
-       * (`serialize-shared-state-mutations`).
+       * The public read cache: Effect's built-in TTL cache with manual
+       * invalidation (`use-the-platform`). `cachedContent` single-flights
+       * concurrent first-reads onto one `fetchDocument` (the others park on its
+       * latch and share the result, so the bucket is not stampeded) and returns
+       * the same decoded `SiteContent` reference for the TTL's duration;
+       * `invalidate` arms the next read to re-fetch (the editor's publish path).
        */
-      const getSiteContent = (): Effect.Effect<SiteContentType> =>
-        Effect.gen(function* () {
-          const now = yield* Clock.currentTimeMillis;
-          const current = yield* Ref.get(cache);
-          if (
-            Option.isSome(current) &&
-            now - current.value.loadedAt < CACHE_TTL_MS
-          ) {
-            return current.value.value;
-          }
+      const [cachedContent, invalidate] = yield* Effect.cachedInvalidateWithTTL(
+        fetchDocument,
+        Duration.millis(CACHE_TTL_MS),
+      );
 
-          return yield* refreshLock.withPermits(1)(
-            Effect.gen(function* () {
-              const afterLock = yield* Ref.get(cache);
-              const lockNow = yield* Clock.currentTimeMillis;
-              if (
-                Option.isSome(afterLock) &&
-                lockNow - afterLock.value.loadedAt < CACHE_TTL_MS
-              ) {
-                return afterLock.value.value;
-              }
-
-              // Snapshot the publish epoch *before* reading the bucket. If a
-              // concurrent publish busts the cache while this read is in flight,
-              // the epoch advances and we must NOT cache the value we just read
-              // (it predates the publish). We still return it to *this* caller —
-              // it is a coherent decoded document — but we leave the cache empty
-              // so the next read re-fetches the published document.
-              const readEpoch = yield* Ref.get(epoch);
-              const value = yield* fetchDocument;
-              const loadedAt = yield* Clock.currentTimeMillis;
-              // Commit the cache write only if no bust intervened during the
-              // read. `bust()` advances the epoch under the *same* `refreshLock`
-              // this fiber holds, so it cannot interleave between this check and
-              // the store; a bust that lands while `fetchDocument` is in flight
-              // raises the epoch above `readEpoch`, and we skip the write —
-              // leaving the cache empty so the next read re-fetches the freshly
-              // published document.
-              const currentEpoch = yield* Ref.get(epoch);
-              if (currentEpoch === readEpoch) {
-                yield* Ref.set(cache, Option.some({ value, loadedAt }));
-              }
-              return value;
-            }),
-          );
-        });
+      const getSiteContent = (): Effect.Effect<SiteContentType> => cachedContent;
 
       const getConference = (
         locale: Locale,
@@ -545,26 +498,19 @@ export class Content extends Context.Service<
           return { content: defaultContent, source: 'defaults' as const };
         });
 
-      // Drop the cached document AND advance the publish epoch so the next
-      // public read re-fetches the bucket (D3 — a publish is visible on the very
-      // next read). Both steps run *under* `refreshLock`, the same permit a
-      // refresh holds while it reads the bucket and writes the cache. This
-      // closes the publish/refresh race (`serialize-shared-state-mutations`): a
-      // bust cannot interleave between a refresh's epoch-check and its cache
-      // store, so it either runs *before* the refresh snapshots the epoch (the
-      // refresh then sees the new bucket document) or *after* the refresh
-      // commits — in which case it raises the epoch the refresh had snapshotted
-      // and clears the just-cached stale document. Either way the stale,
-      // pre-publish document can never survive in the cache.
-      // (`make-operations-idempotent`: busting an already-empty cache, or
-      // double-busting, is harmless — it just clears `none` and bumps a counter.)
-      const bust = (): Effect.Effect<void> =>
-        refreshLock.withPermits(1)(
-          Effect.gen(function* () {
-            yield* Ref.update(epoch, (current) => current + 1);
-            yield* Ref.set(cache, Option.none());
-          }),
-        );
+      // Arm the next public read to re-fetch the bucket so a publish is visible
+      // immediately, with no redeploy and without waiting out the TTL (D3). This
+      // is the built-in cache's `invalidate`: it expires the cached document and
+      // clears the stored result, so the next `getSiteContent` recomputes
+      // `fetchDocument`. (`make-operations-idempotent`: busting an already-empty
+      // or already-expired cache is a harmless no-op.) The built-in does NOT
+      // pre-empt an in-flight refresh: a publish landing during one is masked
+      // because that refresh re-arms the TTL with its pre-publish document, so
+      // the stale window measured from the publish is `(the refresh's remaining
+      // bucket-read duration) + one TTL`, not ≤ one TTL. That documented window
+      // is within D3's "visible on the next read after the window" contract
+      // (see the `Content` doc above for the full mechanism).
+      const bust = (): Effect.Effect<void> => invalidate;
 
       return Content.of({
         getSiteContent,

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -11,6 +11,7 @@ import {
 import { defaultContent } from './content/defaults';
 import { SiteContent } from './content/schema';
 import type {
+  AssetKey,
   Conference as DocConference,
   IsoDate,
   Seminar as DocSeminar,
@@ -155,7 +156,7 @@ export type Translation = Record<string, string>;
  * overrides it — with no change to any component (`derive-dont-sync`,
  * `boundary-discipline`).
  */
-const assetUrl = (key: string): string => `/images/${key}`;
+const assetUrl = (key: AssetKey): string => `/images/${key}`;
 
 /**
  * Widen an ISO calendar date to the existing end-of-day-UTC millisecond the

--- a/app/lib/content/admin-form.test.ts
+++ b/app/lib/content/admin-form.test.ts
@@ -96,9 +96,10 @@ describe('merge-onto-current-document round-trip', () => {
     const merged = deepMerge(base, overrides);
     const decoded = await Effect.runPromise(decode(merged));
 
-    // The edited fields changed…
+    // The edited fields changed… (`accentColor` is the branded `HexColour`;
+    // widen to its base string for the value assertion).
     expect(decoded.conferences[2]?.themeName.en).toBe('Speak Up');
-    expect(decoded.conferences[2]?.accentColor).toBe('#123456');
+    expect(String(decoded.conferences[2]?.accentColor)).toBe('#123456');
     // …and everything else (deep bios, the 2024 speakers, the team) survived.
     expect(decoded.conferences[0]?.speakers.length).toBe(
       defaultContent.conferences[0]?.speakers.length,

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -8,6 +8,7 @@ import {
   SITE_CONTENT_KEY,
 } from '../content.server';
 import { Storage } from '../storage.server';
+import { layerTest } from '../storage.test-helper';
 import {
   assembleOverrides,
   deepMerge,
@@ -21,7 +22,7 @@ import { SiteContent } from './schema';
 
 /**
  * End-to-end-ish proof of the C5 publish + image paths against the in-memory
- * `Storage.layerTest` (a real S3 / MinIO is not reachable headless in CI —
+ * `layerTest` storage helper (a real S3 / MinIO is not reachable headless in CI —
  * flagged in the C5 runtime-verify notes). It reproduces, step for step, what
  * the `/admin/content` route's action does — assemble form → deepMerge onto the
  * current document → decode → `Storage.put(site.json)` → `Content.bust()` — and
@@ -42,13 +43,13 @@ const seedBody = (): Promise<string> =>
 
 /** Wire `Content` over a shared in-memory bucket also exposed to the test. */
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Content | Storage>,
+  effect: Effect.Effect<A, E, Content.Service | Storage.Service>,
   objects: Record<string, { body: string }> = {},
 ) =>
   Effect.runPromise(
     Effect.scoped(
       Effect.provide(effect, [
-        Layer.provideMerge(Content.layer, Storage.layerTest(objects)),
+        Layer.provideMerge(Content.layer, layerTest(objects)),
         TestClock.layer(),
       ]),
     ),
@@ -60,8 +61,8 @@ describe('CMS publish → cache-bust → public read (in-memory bucket, D3)', ()
 
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
 
         // 1. The public site reads the seeded defaults.
         const before = yield* content.getConference('en', 2026);
@@ -101,8 +102,8 @@ describe('CMS publish → cache-bust → public read (in-memory bucket, D3)', ()
 
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
 
         // Save a draft that renames 2026 — public read must NOT see it. The
         // draft is saved AFTER the seeded publish (clock advanced) so it is the
@@ -138,8 +139,8 @@ describe('CMS image upload → /images/<key> retrieval (in-memory bucket)', () =
 
     const result = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
-        const storage = yield* Storage;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
 
         // Validate + store the upload exactly as the route action does.
         const contentType = 'image/png';
@@ -193,7 +194,7 @@ describe('CMS image upload → /images/<key> retrieval (in-memory bucket)', () =
     const seed = await seedBody();
     const team = await run(
       Effect.gen(function* () {
-        const content = yield* Content;
+        const content = yield* Content.Service;
         return yield* content.getTeam();
       }),
       { [SITE_CONTENT_KEY]: { body: seed } },

--- a/app/lib/content/defaults.ts
+++ b/app/lib/content/defaults.ts
@@ -1,4 +1,4 @@
-import { Option } from 'effect';
+import { Schema } from 'effect';
 
 import { root } from '../localization/translations';
 import { SiteContent } from './schema';
@@ -29,11 +29,21 @@ import { SiteContent } from './schema';
  *     defect the `Text` schema rightly forbids. Descriptive bilingual alt text
  *     is authored here; it is the only place real new content is introduced.
  *   - `2024` registration windows carry the same dates as today; `2025` / `2026`
- *     have no pricing yet, modelled as `Option.none()` (not empty tuples).
+ *     have no pricing yet, so they simply omit the `registration` key (it is an
+ *     `Option.none()` on the decoded side, never empty tuples).
  *   - The UI translations are spread directly from `root` rather than re-typed,
  *     so the default table can never drift from the live one (`derive-dont-sync`).
+ *
+ * Authored in the schema's **encoded** form (the literal IS the JSON that would
+ * live at `content/site.json`: plain `string`s, `registration` an optional key)
+ * and decoded through `SiteContent` once. Decoding — not `SiteContent.make` — is
+ * the honest construction: the validated primitives (`AssetKey`, `IsoDate`,
+ * `HexColour`, the conference `ConferenceSlug`) are branded, so a value only
+ * earns the brand by crossing the schema boundary (`boundary-discipline`,
+ * `make-impossible-states-unrepresentable`). `decodeUnknownSync` throws on a
+ * malformed default, so a transcription typo fails fast at module load.
  */
-export const defaultContent: SiteContent = SiteContent.make({
+export const defaultContent: SiteContent = Schema.decodeUnknownSync(SiteContent)({
   meta: { schemaVersion: 1 },
 
   conferences: [
@@ -69,11 +79,11 @@ export const defaultContent: SiteContent = SiteContent.make({
         },
       },
       dates: { start: '2024-08-21', end: '2024-08-25' },
-      registration: Option.some({
+      registration: {
         early: { start: '2024-05-19', end: '2024-06-22' },
         regular: { start: '2024-06-23', end: '2024-07-20' },
         late: { start: '2024-07-21', end: '2024-08-25' },
-      }),
+      },
       location: {
         en: '130 Gerstmar Rd, Kelowna, BC V1X 4A7',
         fr: '130 Gerstmar Rd, Kelowna, BC V1X 4A7',
@@ -237,7 +247,7 @@ lives in Michigan with his wife and daughter where he works as a pastor.
         },
       },
       dates: { start: '2025-08-20', end: '2025-08-24' },
-      registration: Option.none(),
+      // No pricing for 2025 — omit `registration` (decodes to `Option.none()`).
       location: { en: 'Montreal, QC', fr: 'Montréal, QC' },
       tagline: {
         en: '"And after the earthquake a fire, but the Lord was not in the fire; and after the fire a still small voice."',
@@ -287,8 +297,7 @@ lives in Michigan with his wife and daughter where he works as a pastor.
         },
       },
       dates: { start: '2026-08-05', end: '2026-08-09' },
-      // Pricing not set yet — no registration windows.
-      registration: Option.none(),
+      // Pricing not set yet — omit `registration` (decodes to `Option.none()`).
       location: {
         en: 'Ramada Plaza by Wyndham Calgary Downtown, Calgary, AB',
         fr: 'Ramada Plaza by Wyndham Calgary Downtown, Calgary, AB',

--- a/app/lib/content/schema.test.ts
+++ b/app/lib/content/schema.test.ts
@@ -2,7 +2,20 @@ import { describe, expect, it } from 'bun:test';
 import { Effect, Schema } from 'effect';
 
 import { defaultContent } from './defaults';
-import { AssetKey, DateRange, IsoDate, SiteContent } from './schema';
+import {
+  AssetKey,
+  ConferenceSlug,
+  DateRange,
+  HexColour,
+  IsoDate,
+  SiteContent,
+} from './schema';
+import type {
+  AssetKey as AssetKeyType,
+  ConferenceSlug as ConferenceSlugType,
+  HexColour as HexColourType,
+  IsoDate as IsoDateType,
+} from './schema';
 
 /**
  * The encoded form of `SiteContent` IS the JSON stored at `content/site.json`,
@@ -137,5 +150,79 @@ describe('DateRange ordering', () => {
     expect(isValidDateRange({ start: '2027-01-01', end: '2026-12-31' })).toBe(
       false,
     );
+  });
+});
+
+const isValidSlug = (value: string): boolean =>
+  Schema.decodeUnknownResult(ConferenceSlug)(value)._tag === 'Success';
+
+describe('ConferenceSlug validation', () => {
+  it('accepts a `/YYYY` slug', () => {
+    for (const value of ['/2024', '/2025', '/2026', '/0001']) {
+      expect(isValidSlug(value)).toBe(true);
+    }
+  });
+
+  it('rejects anything that is not a `/YYYY` slug', () => {
+    for (const value of [
+      '', // empty
+      '2026', // missing leading slash
+      '/26', // too few digits
+      '/20260', // too many digits
+      '/2026/', // trailing slash
+      'speak', // not a slug at all
+    ]) {
+      expect(isValidSlug(value)).toBe(false);
+    }
+  });
+});
+
+/**
+ * Branding is encode/decode-transparent — the round-trip above proves the values
+ * still pass through losslessly — but it makes the validation guarantee
+ * load-bearing past the decoder: a value only earns the brand by crossing the
+ * schema (`make-impossible-states-unrepresentable`, `boundary-discipline`). The
+ * decode-rejection cases above (`AssetKey`, `IsoDate`, `HexColour`,
+ * `ConferenceSlug`) already prove a bad value never produces a branded value;
+ * these checks pin the *type-level* half of the guarantee so a future change that
+ * silently drops a brand fails the typecheck (this whole block is a compile-time
+ * assertion — the `@ts-expect-error` lines fail `tsc` the moment a raw `string`
+ * becomes assignable to a brand again).
+ */
+describe('branded primitives carry their nominal brand', () => {
+  it('decode/make produce a branded value, and a raw string is not assignable', () => {
+    // Decoding yields the branded type, assignable to its own brand…
+    const key: AssetKeyType = AssetKey.make('2026/en/hero.png');
+    const date: IsoDateType = IsoDate.make('2026-06-10');
+    const colour: HexColourType = HexColour.make('#D4A24E');
+    const slug: ConferenceSlugType = ConferenceSlug.make('/2026');
+
+    // …and erase to their base string at runtime (brands are type-only).
+    expect(String(key)).toBe('2026/en/hero.png');
+    expect(String(date)).toBe('2026-06-10');
+    expect(String(colour)).toBe('#D4A24E');
+    expect(String(slug)).toBe('/2026');
+
+    // A raw `string` must NOT be assignable where a brand is required: each line
+    // is a deliberate type error guarded by `@ts-expect-error`, so the typecheck
+    // fails if branding is ever lost (`prove-it-works` at the type level).
+    // @ts-expect-error a raw string is not an AssetKey until it crosses the decoder
+    const notKey: AssetKeyType = '2026/en/hero.png';
+    // @ts-expect-error a raw string is not an IsoDate until it crosses the decoder
+    const notDate: IsoDateType = '2026-06-10';
+    // @ts-expect-error a raw string is not a HexColour until it crosses the decoder
+    const notColour: HexColourType = '#D4A24E';
+    // @ts-expect-error a raw string is not a ConferenceSlug until it crosses the decoder
+    const notSlug: ConferenceSlugType = '/2026';
+
+    // Reference the locals so they are not flagged as unused; their string
+    // values are intentionally identical to the branded ones above (widen to
+    // base string so the matcher compares plain strings).
+    expect([notKey, notDate, notColour, notSlug].map(String)).toEqual([
+      '2026/en/hero.png',
+      '2026-06-10',
+      '#D4A24E',
+      '/2026',
+    ]);
   });
 });

--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -76,7 +76,9 @@ const assetKeyFilter = Schema.makeFilter<string>(
   { title: 'AssetKey' },
 );
 
-export const AssetKey = Schema.NonEmptyString.check(assetKeyFilter);
+export const AssetKey = Schema.NonEmptyString.check(assetKeyFilter).pipe(
+  Schema.brand('AssetKey'),
+);
 export type AssetKey = typeof AssetKey.Type;
 
 /**
@@ -110,7 +112,7 @@ export type ImageRef = typeof ImageRef.Type;
  */
 export const HexColour = Schema.NonEmptyString.check(
   Schema.isPattern(/^#[0-9a-fA-F]{6}$/, { title: 'HexColour' }),
-);
+).pipe(Schema.brand('HexColour'));
 export type HexColour = typeof HexColour.Type;
 
 /**
@@ -149,7 +151,7 @@ const isoCalendarDateFilter = Schema.makeFilter<string>(
 export const IsoDate = Schema.NonEmptyString.check(
   Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/, { title: 'IsoDate' }),
   isoCalendarDateFilter,
-);
+).pipe(Schema.brand('IsoDate'));
 export type IsoDate = typeof IsoDate.Type;
 
 /**
@@ -249,10 +251,21 @@ export type Hero = typeof Hero.Type;
  * pricing is undecided (2026), never empty tuples
  * (`make-impossible-states-unrepresentable`).
  */
+/**
+ * A conference's canonical year identifier — a `/YYYY` slug (`/2024`). It is the
+ * routes' year key (the `/YYYY` public pages, the `SiteContent` required-slug
+ * invariant) so it is branded to keep the validation guarantee load-bearing past
+ * the decoder: a raw `/${year}` string is not a `ConferenceSlug` until it has
+ * crossed the schema (`boundary-discipline`,
+ * `make-impossible-states-unrepresentable`).
+ */
+export const ConferenceSlug = Schema.NonEmptyString.check(
+  Schema.isPattern(/^\/\d{4}$/, { title: 'ConferenceSlug' }),
+).pipe(Schema.brand('ConferenceSlug'));
+export type ConferenceSlug = typeof ConferenceSlug.Type;
+
 export const Conference = Schema.Struct({
-  slug: Schema.NonEmptyString.check(
-    Schema.isPattern(/^\/\d{4}$/, { title: 'ConferenceSlug' }),
-  ),
+  slug: ConferenceSlug,
   themeName: Text,
   accentColor: HexColour,
   hero: Hero,

--- a/app/lib/effect/runtime.ts
+++ b/app/lib/effect/runtime.ts
@@ -9,7 +9,13 @@ import { NotFound, Storage, StorageError } from '~/lib/storage.server';
 
 import { ReactRouterContext, type RouteArgs } from './router-context';
 
-export type AppServices = Env | Mailer | Mailchimp | Content | Auth | Storage;
+export type AppServices =
+  | Env.Service
+  | Mailer.Service
+  | Mailchimp.Service
+  | Content.Service
+  | Auth.Service
+  | Storage.Service;
 export type AppError =
   | Response
   | MailError
@@ -21,25 +27,29 @@ export type AppError =
   | StorageError
   | NotFound;
 
-// `Storage.layerOptional` never fails to *build*: bucket-less it provides a
-// disabled storage whose reads report `NotFound` and whose writes fail
-// `StorageError`, so the runtime boots identically with or without a bucket
-// (D3). It is provided once and shared by BOTH `Content` (the public read path,
-// which recovers `NotFound` → bundled defaults) and the `/admin` editor (C5 —
-// the write path: save-draft / publish / image upload). The admin write surface
-// is only *reachable* when `Auth` is enabled (`ADMIN_PASSWORD` + `COOKIE_SECRET`
-// set), independent of the bucket; the editor still surfaces a `StorageError`
-// when an admin is configured without a bucket, rather than silently dropping a
-// save.
+// `Content.defaultLayer` wires the public read path: it is `Content.layer` with
+// its `Storage` dependency pre-provided as `Storage.layerOptional` (the
+// never-fails-to-build storage — bucket-less it reports `NotFound`, which the
+// read path recovers to the bundled defaults, D3), leaving only `Env` open for
+// the merge below to discharge.
+//
+// `Storage.layerOptional` is ALSO provided standalone here — a legit second
+// consumer (the `/admin` editor's write path: save-draft / publish / image
+// upload, plus any route that reads `Storage` directly). It is a separate
+// instance from the one inside `Content.defaultLayer`; both point at the same
+// bucket via `Env`, so there is no shared in-memory state to coordinate. The
+// admin write surface is only *reachable* when `Auth` is enabled
+// (`ADMIN_PASSWORD` + `COOKIE_SECRET` set), independent of the bucket; the
+// editor still surfaces a `StorageError` when an admin is configured without a
+// bucket, rather than silently dropping a save.
 //
 // `Auth` is likewise optional everywhere: with `ADMIN_PASSWORD` unset its layer
 // builds a disabled instance (admin 404s), so it never fails to build either.
-const StorageLive = Storage.layerOptional;
 const AppLayer = Layer.mergeAll(
   Mailer.layer,
   Mailchimp.layer,
-  Content.layer.pipe(Layer.provide(StorageLive)),
-  StorageLive,
+  Content.defaultLayer,
+  Storage.layerOptional,
   Auth.layer,
 ).pipe(Layer.provideMerge(Env.layer));
 const AppRuntime = ManagedRuntime.make(AppLayer);

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -1,3 +1,5 @@
+export * as Env from './env.server';
+
 import { Config, Context, Effect, Layer, Option, Redacted } from 'effect';
 
 /**
@@ -110,43 +112,52 @@ const bucketConfig: Config.Config<Option.Option<BucketConfig>> = Config.all({
   ),
 );
 
-export class Env extends Context.Service<
-  Env,
+export class Service extends Context.Service<
+  Service,
   {
     readonly isProduction: boolean;
     readonly mail: Option.Option<MailConfig>;
     readonly mailchimp: Option.Option<MailchimpConfig>;
     readonly bucket: Option.Option<BucketConfig>;
   }
->()('gycc/lib/env.server/Env') {
-  static layer = Layer.effect(
-    Env,
-    Effect.gen(function* () {
-      const nodeEnv = yield* Config.string('NODE_ENV').pipe(
-        Config.withDefault('development'),
-      );
-      const isProduction = nodeEnv === 'production';
+>()('gycc/lib/env.server/Service') {}
 
-      // Bucket is optional in dev AND prod: a bucket-less prod still serves the
-      // bundled defaults, so it must never fail the layer at boot. `bucketConfig`
-      // already yields `Option.none()` whenever any required key is missing OR
-      // present-but-blank.
-      const bucket = yield* bucketConfig;
+/**
+ * The `Env` layer, read straight off the platform `Config` (opencode's
+ * module-level `export const layer`, `packages/core/src/git.ts:79`). It has no
+ * service dependencies, so `defaultLayer` is just `layer` — provided for shape
+ * parity with the other services so every consumer can pre-provide `Env`
+ * uniformly via `Env.defaultLayer`.
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const nodeEnv = yield* Config.string('NODE_ENV').pipe(
+      Config.withDefault('development'),
+    );
+    const isProduction = nodeEnv === 'production';
 
-      if (isProduction) {
-        const mail = yield* mailConfigRequired;
-        const mailchimp = yield* mailchimpConfigRequired;
-        return Env.of({
-          isProduction,
-          mail: Option.some(mail),
-          mailchimp: Option.some(mailchimp),
-          bucket,
-        });
-      }
+    // Bucket is optional in dev AND prod: a bucket-less prod still serves the
+    // bundled defaults, so it must never fail the layer at boot. `bucketConfig`
+    // already yields `Option.none()` whenever any required key is missing OR
+    // present-but-blank.
+    const bucket = yield* bucketConfig;
 
-      const mail = yield* Config.option(mailConfigRequired);
-      const mailchimp = yield* Config.option(mailchimpConfigRequired);
-      return Env.of({ isProduction, mail, mailchimp, bucket });
-    }),
-  );
-}
+    if (isProduction) {
+      const mail = yield* mailConfigRequired;
+      const mailchimp = yield* mailchimpConfigRequired;
+      return Service.of({
+        isProduction,
+        mail: Option.some(mail),
+        mailchimp: Option.some(mailchimp),
+        bucket,
+      });
+    }
+
+    const mail = yield* Config.option(mailConfigRequired);
+    const mailchimp = yield* Config.option(mailchimpConfigRequired);
+    return Service.of({ isProduction, mail, mailchimp, bucket });
+  }),
+);
+
+export const defaultLayer = layer;

--- a/app/lib/mailchimp.server.ts
+++ b/app/lib/mailchimp.server.ts
@@ -49,24 +49,26 @@ export class Mailchimp extends Context.Service<
         server: 'us10',
       });
 
-      return Mailchimp.of({
-        subscribe: (email, name) =>
-          Effect.gen(function* () {
-            const nameParts = name.split(' ');
-            yield* Effect.tryPromise({
-              try: () =>
-                mailchimp.lists.addListMember(config.listId, {
-                  email_address: email,
-                  status: 'subscribed',
-                  merge_fields: {
-                    FNAME: nameParts[0] ?? '',
-                    LNAME: nameParts.slice(1).join(' '),
-                  },
-                }),
-              catch: (cause) => new MailchimpError({ cause }),
-            });
-          }),
+      const subscribe = Effect.fn('Mailchimp.subscribe')(function* (
+        email: string,
+        name: string,
+      ) {
+        const nameParts = name.split(' ');
+        yield* Effect.tryPromise({
+          try: () =>
+            mailchimp.lists.addListMember(config.listId, {
+              email_address: email,
+              status: 'subscribed',
+              merge_fields: {
+                FNAME: nameParts[0] ?? '',
+                LNAME: nameParts.slice(1).join(' '),
+              },
+            }),
+          catch: (cause) => new MailchimpError({ cause }),
+        });
       });
+
+      return Mailchimp.of({ subscribe });
     }),
   );
 }

--- a/app/lib/mailchimp.server.ts
+++ b/app/lib/mailchimp.server.ts
@@ -5,7 +5,7 @@ import { Env } from './env.server';
 
 export class MailchimpError extends Schema.TaggedErrorClass<MailchimpError>()(
   'gycc/lib/mailchimp.server/MailchimpError',
-  { message: Schema.String },
+  { cause: Schema.optional(Schema.Defect) },
 ) {}
 
 export class MailchimpDisabled extends Schema.TaggedErrorClass<MailchimpDisabled>()(
@@ -63,8 +63,7 @@ export class Mailchimp extends Context.Service<
                     LNAME: nameParts.slice(1).join(' '),
                   },
                 }),
-              catch: (cause) =>
-                new MailchimpError({ message: String(cause) }),
+              catch: (cause) => new MailchimpError({ cause }),
             });
           }),
       });

--- a/app/lib/mailchimp.server.ts
+++ b/app/lib/mailchimp.server.ts
@@ -1,15 +1,17 @@
+export * as Mailchimp from './mailchimp.server';
+
 import mailchimp from '@mailchimp/mailchimp_marketing';
 import { Context, Effect, Layer, Option, Redacted, Schema } from 'effect';
 
 import { Env } from './env.server';
 
 export class MailchimpError extends Schema.TaggedErrorClass<MailchimpError>()(
-  'gycc/lib/mailchimp.server/MailchimpError',
+  'Mailchimp.Error',
   { cause: Schema.optional(Schema.Defect) },
 ) {}
 
 export class MailchimpDisabled extends Schema.TaggedErrorClass<MailchimpDisabled>()(
-  'gycc/lib/mailchimp.server/MailchimpDisabled',
+  'Mailchimp.Disabled',
   {},
 ) {}
 
@@ -23,52 +25,59 @@ export class MailchimpDisabled extends Schema.TaggedErrorClass<MailchimpDisabled
  * fails with `MailchimpDisabled` so the newsletter route surfaces the same
  * form error the old try/catch produced.
  */
-export class Mailchimp extends Context.Service<
-  Mailchimp,
+export class Service extends Context.Service<
+  Service,
   {
     readonly subscribe: (
       email: string,
       name: string,
     ) => Effect.Effect<void, MailchimpError | MailchimpDisabled>;
   }
->()('gycc/lib/mailchimp.server/Mailchimp') {
-  static layer = Layer.effect(
-    Mailchimp,
-    Effect.gen(function* () {
-      const env = yield* Env;
+>()('gycc/lib/mailchimp.server/Service') {}
 
-      if (Option.isNone(env.mailchimp)) {
-        return Mailchimp.of({
-          subscribe: () => Effect.fail(new MailchimpDisabled()),
-        });
-      }
+/**
+ * The `Mailchimp` layer (opencode's module-level `export const layer`,
+ * `packages/core/src/git.ts:79`); `defaultLayer` pre-provides its `Env`
+ * dependency so a standalone consumer wires it in one step.
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
 
-      const config = env.mailchimp.value;
-      mailchimp.setConfig({
-        apiKey: Redacted.value(config.apiKey),
-        server: 'us10',
+    if (Option.isNone(env.mailchimp)) {
+      return Service.of({
+        subscribe: () => Effect.fail(new MailchimpDisabled()),
       });
+    }
 
-      const subscribe = Effect.fn('Mailchimp.subscribe')(function* (
-        email: string,
-        name: string,
-      ) {
-        const nameParts = name.split(' ');
-        yield* Effect.tryPromise({
-          try: () =>
-            mailchimp.lists.addListMember(config.listId, {
-              email_address: email,
-              status: 'subscribed',
-              merge_fields: {
-                FNAME: nameParts[0] ?? '',
-                LNAME: nameParts.slice(1).join(' '),
-              },
-            }),
-          catch: (cause) => new MailchimpError({ cause }),
-        });
+    const config = env.mailchimp.value;
+    mailchimp.setConfig({
+      apiKey: Redacted.value(config.apiKey),
+      server: 'us10',
+    });
+
+    const subscribe = Effect.fn('Mailchimp.subscribe')(function* (
+      email: string,
+      name: string,
+    ) {
+      const nameParts = name.split(' ');
+      yield* Effect.tryPromise({
+        try: () =>
+          mailchimp.lists.addListMember(config.listId, {
+            email_address: email,
+            status: 'subscribed',
+            merge_fields: {
+              FNAME: nameParts[0] ?? '',
+              LNAME: nameParts.slice(1).join(' '),
+            },
+          }),
+        catch: (cause) => new MailchimpError({ cause }),
       });
+    });
 
-      return Mailchimp.of({ subscribe });
-    }),
-  );
-}
+    return Service.of({ subscribe });
+  }),
+);
+
+export const defaultLayer = layer.pipe(Layer.provide(Env.defaultLayer));

--- a/app/lib/mailer.server.ts
+++ b/app/lib/mailer.server.ts
@@ -1,10 +1,12 @@
+export * as Mailer from './mailer.server';
+
 import { Context, Effect, Layer, Option, Redacted, Schema } from 'effect';
 import nodemailer from 'nodemailer';
 
 import { Env } from './env.server';
 
 export class MailError extends Schema.TaggedErrorClass<MailError>()(
-  'gycc/lib/mailer.server/MailError',
+  'Mailer.Error',
   { cause: Schema.optional(Schema.Defect) },
 ) {}
 
@@ -17,50 +19,57 @@ export class MailError extends Schema.TaggedErrorClass<MailError>()(
  * sends through the configured SMTP transport with the same
  * `GYCC Contact <from>` envelope.
  */
-export class Mailer extends Context.Service<
-  Mailer,
+export class Service extends Context.Service<
+  Service,
   {
     readonly send: (input: {
       readonly subject: string;
       readonly content: string;
     }) => Effect.Effect<void, MailError>;
   }
->()('gycc/lib/mailer.server/Mailer') {
-  static layer = Layer.effect(
-    Mailer,
-    Effect.gen(function* () {
-      const env = yield* Env;
+>()('gycc/lib/mailer.server/Service') {}
 
-      if (!env.isProduction || Option.isNone(env.mail)) {
-        return Mailer.of({ send: () => Effect.void });
-      }
+/**
+ * The `Mailer` layer (opencode's module-level `export const layer`,
+ * `packages/core/src/git.ts:79`); `defaultLayer` pre-provides its `Env`
+ * dependency so a standalone consumer wires it in one step.
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
 
-      const mail = env.mail.value;
-      const transporter = nodemailer.createTransport({
-        host: mail.host,
-        port: mail.port,
-        secure: mail.port === 465,
-        auth: {
-          user: mail.user,
-          pass: Redacted.value(mail.pass),
-        },
-      });
+    if (!env.isProduction || Option.isNone(env.mail)) {
+      return Service.of({ send: () => Effect.void });
+    }
 
-      const send = Effect.fn('Mailer.send')(
-        (input: { readonly subject: string; readonly content: string }) =>
-          Effect.tryPromise({
-            try: () =>
-              transporter.sendMail({
-                from: `GYCC Contact <${mail.from}>`,
-                to: mail.to,
-                subject: input.subject,
-                text: input.content,
-              }),
-            catch: (cause) => new MailError({ cause }),
-          }).pipe(Effect.asVoid),
-      );
+    const mail = env.mail.value;
+    const transporter = nodemailer.createTransport({
+      host: mail.host,
+      port: mail.port,
+      secure: mail.port === 465,
+      auth: {
+        user: mail.user,
+        pass: Redacted.value(mail.pass),
+      },
+    });
 
-      return Mailer.of({ send });
-    }),
-  );
-}
+    const send = Effect.fn('Mailer.send')(
+      (input: { readonly subject: string; readonly content: string }) =>
+        Effect.tryPromise({
+          try: () =>
+            transporter.sendMail({
+              from: `GYCC Contact <${mail.from}>`,
+              to: mail.to,
+              subject: input.subject,
+              text: input.content,
+            }),
+          catch: (cause) => new MailError({ cause }),
+        }).pipe(Effect.asVoid),
+    );
+
+    return Service.of({ send });
+  }),
+);
+
+export const defaultLayer = layer.pipe(Layer.provide(Env.defaultLayer));

--- a/app/lib/mailer.server.ts
+++ b/app/lib/mailer.server.ts
@@ -46,19 +46,21 @@ export class Mailer extends Context.Service<
         },
       });
 
-      return Mailer.of({
-        send: ({ subject, content }) =>
+      const send = Effect.fn('Mailer.send')(
+        (input: { readonly subject: string; readonly content: string }) =>
           Effect.tryPromise({
             try: () =>
               transporter.sendMail({
                 from: `GYCC Contact <${mail.from}>`,
                 to: mail.to,
-                subject,
-                text: content,
+                subject: input.subject,
+                text: input.content,
               }),
             catch: (cause) => new MailError({ cause }),
           }).pipe(Effect.asVoid),
-      });
+      );
+
+      return Mailer.of({ send });
     }),
   );
 }

--- a/app/lib/mailer.server.ts
+++ b/app/lib/mailer.server.ts
@@ -5,7 +5,7 @@ import { Env } from './env.server';
 
 export class MailError extends Schema.TaggedErrorClass<MailError>()(
   'gycc/lib/mailer.server/MailError',
-  { message: Schema.String },
+  { cause: Schema.optional(Schema.Defect) },
 ) {}
 
 /**
@@ -56,7 +56,7 @@ export class Mailer extends Context.Service<
                 subject,
                 text: content,
               }),
-            catch: (cause) => new MailError({ message: String(cause) }),
+            catch: (cause) => new MailError({ cause }),
           }).pipe(Effect.asVoid),
       });
     }),

--- a/app/lib/services.test.ts
+++ b/app/lib/services.test.ts
@@ -43,7 +43,7 @@ describe('Env config', () => {
   it('treats every mail/mailchimp var as optional in development', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(env.isProduction).toBe(false);
         expect(Option.isNone(env.mail)).toBe(true);
         expect(Option.isNone(env.mailchimp)).toBe(true);
@@ -55,7 +55,7 @@ describe('Env config', () => {
   it('requires every mail/mailchimp var in production and redacts secrets', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(env.isProduction).toBe(true);
         expect(Option.isSome(env.mail)).toBe(true);
         expect(Option.isSome(env.mailchimp)).toBe(true);
@@ -74,7 +74,7 @@ describe('Env config', () => {
 
   it('fails fast in production when a required mail var is missing', async () => {
     const exit = await runExit(
-      Env.asEffect(),
+      Env.Service.asEffect(),
       envLayer({ NODE_ENV: 'production', MAIL_HOST: 'only-host' }),
     );
     expect(Exit.isFailure(exit)).toBe(true);
@@ -83,7 +83,7 @@ describe('Env config', () => {
   it('leaves the bucket absent in production when its vars are unset', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(env.isProduction).toBe(true);
         expect(Option.isNone(env.bucket)).toBe(true);
       }),
@@ -93,7 +93,7 @@ describe('Env config', () => {
   it('resolves the bucket, redacts the secret, and defaults region to auto', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(Option.isSome(env.bucket)).toBe(true);
         if (Option.isSome(env.bucket)) {
           expect(env.bucket.value.endpoint).toBe('https://s3.example.com');
@@ -115,7 +115,7 @@ describe('Env config', () => {
   it('treats present-but-blank bucket vars as absent (env.example placeholders)', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(Option.isNone(env.bucket)).toBe(true);
       }),
       // Mirrors a freshly-copied `.env.example`: the BUCKET_* keys are present
@@ -134,7 +134,7 @@ describe('Env config', () => {
   it('treats whitespace-only bucket vars as absent', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(Option.isNone(env.bucket)).toBe(true);
       }),
       envLayer({
@@ -149,7 +149,7 @@ describe('Env config', () => {
   it('treats a partially-blank bucket group as absent', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         expect(Option.isNone(env.bucket)).toBe(true);
       }),
       // Endpoint set, but the rest left blank — not a usable bucket, so None.
@@ -165,7 +165,7 @@ describe('Env config', () => {
   it('honours an explicit BUCKET_REGION', () =>
     run(
       Effect.gen(function* () {
-        const env = yield* Env;
+        const env = yield* Env.Service;
         if (Option.isSome(env.bucket)) {
           expect(env.bucket.value.region).toBe('us-east-1');
         } else {
@@ -187,7 +187,7 @@ describe('Mailer', () => {
   it('is a no-op outside production', () =>
     run(
       Effect.gen(function* () {
-        const mailer = yield* Mailer;
+        const mailer = yield* Mailer.Service;
         yield* mailer.send({ subject: 's', content: 'c' });
       }),
       Layer.provide(Mailer.layer, envLayer({ NODE_ENV: 'development' })),
@@ -198,7 +198,7 @@ describe('Mailchimp', () => {
   it('fails with MailchimpDisabled when unconfigured', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const mailchimp = yield* Mailchimp;
+        const mailchimp = yield* Mailchimp.Service;
         yield* mailchimp.subscribe('a@b.com', 'Ada Lovelace');
       }),
       Layer.provide(Mailchimp.layer, envLayer({ NODE_ENV: 'development' })),

--- a/app/lib/storage.server.test.ts
+++ b/app/lib/storage.server.test.ts
@@ -10,25 +10,26 @@ import {
 
 import { Env } from './env.server';
 import { NotFound, Storage, StorageUnconfigured } from './storage.server';
+import { layerTest } from './storage.test-helper';
 
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Storage>,
-  layer: Layer.Layer<Storage>,
+  effect: Effect.Effect<A, E, Storage.Service>,
+  layer: Layer.Layer<Storage.Service>,
 ) => Effect.runPromise(Effect.provide(effect, layer));
 
 const runExit = <A, E>(
-  effect: Effect.Effect<A, E, Storage>,
-  layer: Layer.Layer<Storage>,
+  effect: Effect.Effect<A, E, Storage.Service>,
+  layer: Layer.Layer<Storage.Service>,
 ) => Effect.runPromise(Effect.exit(Effect.provide(effect, layer)));
 
 const text = (object: { readonly stream: ReadableStream<Uint8Array> }) =>
   new Response(object.stream).text();
 
-describe('Storage.layerTest', () => {
+describe('Storage in-memory test layer', () => {
   it('round-trips a put → get → head → list → delete', async () => {
     const result = await run(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
 
         yield* storage.put('content/site.json', '{"hello":"world"}', 'application/json');
 
@@ -43,7 +44,7 @@ describe('Storage.layerTest', () => {
 
         return { body, got, head, listed, afterDelete };
       }),
-      Storage.layerTest(),
+      layerTest(),
     );
 
     expect(result.body).toBe('{"hello":"world"}');
@@ -70,13 +71,13 @@ describe('Storage.layerTest', () => {
   it('overwrites an existing object on a second put', async () => {
     const body = await run(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
         yield* storage.put('content/site.json', 'first', 'text/plain');
         yield* storage.put('content/site.json', 'second', 'text/plain');
         const got = yield* storage.get('content/site.json');
         return yield* Effect.promise(() => text(got));
       }),
-      Storage.layerTest(),
+      layerTest(),
     );
 
     expect(body).toBe('second');
@@ -85,12 +86,12 @@ describe('Storage.layerTest', () => {
   it('serves seeded objects and filters list by prefix', async () => {
     const result = await run(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
         const images = yield* storage.list('images/');
         const all = yield* storage.list();
         return { images, all };
       }),
-      Storage.layerTest({
+      layerTest({
         'content/site.json': { body: '{}' },
         'images/a.avif': { body: 'a' },
         'images/bb.avif': { body: 'bb' },
@@ -108,10 +109,10 @@ describe('Storage.layerTest', () => {
   it('fails get with NotFound for a missing key', async () => {
     const exit = await runExit(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
         return yield* storage.get('missing.json');
       }),
-      Storage.layerTest(),
+      layerTest(),
     );
 
     expect(exit._tag).toBe('Failure');
@@ -126,10 +127,10 @@ describe('Storage.layerTest', () => {
   it('reports head as None for a missing key without failing', async () => {
     const head = await run(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
         return yield* storage.head('missing.json');
       }),
-      Storage.layerTest(),
+      layerTest(),
     );
 
     expect(Option.isNone(head)).toBe(true);
@@ -138,10 +139,10 @@ describe('Storage.layerTest', () => {
   it('treats delete of a missing key as a no-op', async () => {
     await run(
       Effect.gen(function* () {
-        const storage = yield* Storage;
+        const storage = yield* Storage.Service;
         yield* storage.delete('never-existed.json');
       }),
-      Storage.layerTest(),
+      layerTest(),
     );
   });
 });
@@ -153,7 +154,7 @@ describe('Storage.layer', () => {
   it('fails with StorageUnconfigured when no bucket is configured', async () => {
     const exit = await Effect.runPromise(
       Effect.exit(
-        Storage.asEffect().pipe(
+        Storage.Service.asEffect().pipe(
           Effect.provide(
             Storage.layer.pipe(
               Layer.provide(envFromBucketless({ NODE_ENV: 'development' })),
@@ -176,7 +177,7 @@ describe('Storage.layer', () => {
   it('constructs a storage instance when the bucket is configured', async () => {
     const exit = await Effect.runPromise(
       Effect.exit(
-        Storage.asEffect().pipe(
+        Storage.Service.asEffect().pipe(
           Effect.provide(
             Storage.layer.pipe(
               Layer.provide(

--- a/app/lib/storage.server.ts
+++ b/app/lib/storage.server.ts
@@ -111,7 +111,7 @@ type ListClient = {
 
 const epoch = (): Date => DateTime.toDateUtc(DateTime.makeUnsafe(0));
 
-const listStoredObjects = Effect.fn('listStoredObjects')(function* (
+const listStoredObjects = Effect.fnUntraced(function* (
   client: ListClient,
   prefix: string | undefined,
 ) {
@@ -172,58 +172,64 @@ export class Storage extends Context.Service<
           ? body
           : new Blob([body as Uint8Array<ArrayBuffer>]);
 
-      return Storage.of({
-        get: (key) => {
-          const object = entries.get(key);
-          if (object === undefined) return Effect.fail(new NotFound({ key }));
-          return Effect.sync(() => ({
-            stream:
-              new Response(responseBody(object.body)).body ??
-              new ReadableStream<Uint8Array>(),
-            contentType: object.contentType,
-            size: bytes(object.body).byteLength,
-          }));
-        },
-
-        put: (key, body, contentType) =>
-          Effect.gen(function* () {
-            const now = yield* Clock.currentTimeMillis;
-            entries.set(key, {
-              body,
-              contentType,
-              lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(now)),
-              etag: `"test-${now}"`,
-            });
-          }),
-
-        head: (key) =>
-          Effect.sync(() => {
-            const object = entries.get(key);
-            if (object === undefined) return Option.none();
-            return Option.some({
-              size: bytes(object.body).byteLength,
-              contentType: object.contentType,
-              lastModified: object.lastModified,
-              etag: object.etag,
-            });
-          }),
-
-        list: (prefix) =>
-          Effect.sync(() =>
-            [...entries.entries()]
-              .filter(([key]) => prefix === undefined || key.startsWith(prefix))
-              .map(([key, object]) => ({
-                key,
-                size: bytes(object.body).byteLength,
-                lastModified: object.lastModified,
-              })),
-          ),
-
-        delete: (key) =>
-          Effect.sync(() => {
-            entries.delete(key);
-          }),
+      const get = Effect.fn('Storage.get')(function* (key: string) {
+        const object = entries.get(key);
+        if (object === undefined) return yield* new NotFound({ key });
+        return {
+          stream:
+            new Response(responseBody(object.body)).body ??
+            new ReadableStream<Uint8Array>(),
+          contentType: object.contentType,
+          size: bytes(object.body).byteLength,
+        };
       });
+
+      const put = Effect.fn('Storage.put')(function* (
+        key: string,
+        body: Uint8Array | string,
+        contentType: string,
+      ) {
+        const now = yield* Clock.currentTimeMillis;
+        entries.set(key, {
+          body,
+          contentType,
+          lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(now)),
+          etag: `"test-${now}"`,
+        });
+      });
+
+      const head = Effect.fn('Storage.head')((key: string) =>
+        Effect.sync(() => {
+          const object = entries.get(key);
+          if (object === undefined) return Option.none<ObjectHead>();
+          return Option.some<ObjectHead>({
+            size: bytes(object.body).byteLength,
+            contentType: object.contentType,
+            lastModified: object.lastModified,
+            etag: object.etag,
+          });
+        }),
+      );
+
+      const list = Effect.fn('Storage.list')((prefix?: string) =>
+        Effect.sync(() =>
+          [...entries.entries()]
+            .filter(([key]) => prefix === undefined || key.startsWith(prefix))
+            .map(([key, object]) => ({
+              key,
+              size: bytes(object.body).byteLength,
+              lastModified: object.lastModified,
+            })),
+        ),
+      );
+
+      const del = Effect.fn('Storage.delete')((key: string) =>
+        Effect.sync(() => {
+          entries.delete(key);
+        }),
+      );
+
+      return Storage.of({ get, put, head, list, delete: del });
     });
 
   static layer = Layer.effect(
@@ -244,59 +250,64 @@ export class Storage extends Context.Service<
         region: config.region,
       });
 
-      return Storage.of({
-        get: (key) =>
-          Effect.gen(function* () {
-            const file = client.file(key);
-            const stat = yield* Effect.tryPromise({
-              try: () => file.stat(),
-              catch: (e) =>
-                isNoSuchKey(e)
-                  ? new NotFound({ key })
-                  : new StorageError({ key, op: 'get', cause: e }),
-            });
-            return {
-              stream: file.stream(),
-              contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
-              size: stat.size,
-            };
-          }),
-
-        put: (key, body, contentType) =>
-          Effect.tryPromise({
-            try: () => client.write(key, body, { type: contentType }),
-            catch: (e) => new StorageError({ key, op: 'put', cause: e }),
-          }).pipe(Effect.asVoid),
-
-        head: (key) =>
-          Effect.gen(function* () {
-            const file = client.file(key);
-            const exists = yield* Effect.tryPromise({
-              try: () => file.exists(),
-              catch: (e) => new StorageError({ key, op: 'head', cause: e }),
-            });
-            if (!exists) return Option.none();
-            const stat = yield* Effect.tryPromise({
-              try: () => file.stat(),
-              catch: (e) => new StorageError({ key, op: 'head', cause: e }),
-            });
-            return Option.some({
-              size: stat.size,
-              contentType:
-                stat.type === '' ? 'application/octet-stream' : stat.type,
-              lastModified: stat.lastModified,
-              etag: stat.etag,
-            });
-          }),
-
-        list: (prefix) => listStoredObjects(client, prefix),
-
-        delete: (key) =>
-          Effect.tryPromise({
-            try: () => client.delete(key),
-            catch: (e) => new StorageError({ key, op: 'delete', cause: e }),
-          }),
+      const get = Effect.fn('Storage.get')(function* (key: string) {
+        const file = client.file(key);
+        const stat = yield* Effect.tryPromise({
+          try: () => file.stat(),
+          catch: (e) =>
+            isNoSuchKey(e)
+              ? new NotFound({ key })
+              : new StorageError({ key, op: 'get', cause: e }),
+        });
+        return {
+          stream: file.stream(),
+          contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
+          size: stat.size,
+        };
       });
+
+      const put = Effect.fn('Storage.put')(function* (
+        key: string,
+        body: Uint8Array | string,
+        contentType: string,
+      ) {
+        yield* Effect.tryPromise({
+          try: () => client.write(key, body, { type: contentType }),
+          catch: (e) => new StorageError({ key, op: 'put', cause: e }),
+        });
+      });
+
+      const head = Effect.fn('Storage.head')(function* (key: string) {
+        const file = client.file(key);
+        const exists = yield* Effect.tryPromise({
+          try: () => file.exists(),
+          catch: (e) => new StorageError({ key, op: 'head', cause: e }),
+        });
+        if (!exists) return Option.none<ObjectHead>();
+        const stat = yield* Effect.tryPromise({
+          try: () => file.stat(),
+          catch: (e) => new StorageError({ key, op: 'head', cause: e }),
+        });
+        return Option.some<ObjectHead>({
+          size: stat.size,
+          contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
+          lastModified: stat.lastModified,
+          etag: stat.etag,
+        });
+      });
+
+      const list = Effect.fn('Storage.list')(function* (prefix?: string) {
+        return yield* listStoredObjects(client, prefix);
+      });
+
+      const del = Effect.fn('Storage.delete')(function* (key: string) {
+        yield* Effect.tryPromise({
+          try: () => client.delete(key),
+          catch: (e) => new StorageError({ key, op: 'delete', cause: e }),
+        });
+      });
+
+      return Storage.of({ get, put, head, list, delete: del });
     }),
   );
 

--- a/app/lib/storage.server.ts
+++ b/app/lib/storage.server.ts
@@ -37,9 +37,27 @@ export class StorageError extends Schema.TaggedErrorClass<StorageError>()(
   {
     key: Schema.String,
     op: StorageOp,
-    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
   },
 ) {}
+
+/**
+ * Structured not-found predicate over Bun's S3 error, mirroring opencode's
+ * `missing()` (`packages/opencode/src/storage/storage.ts:67-74`,
+ * `packages/core/src/fs-util.ts:114`) which matches on `err.code === 'ENOENT'`
+ * rather than substring-matching a stringified error.
+ *
+ * Bun raises a structured `S3Error` (an `Error` with `name === 'S3Error'`) for
+ * S3-protocol failures, carrying the upstream S3 XML `<Code>` as a `code`
+ * field — `'NoSuchKey'` for a missing object (confirmed against the runtime;
+ * `Bun.S3Error` is not an exported constructor in Bun 1.3.x, so we match the
+ * structured field instead of `instanceof`).
+ */
+const isNoSuchKey = (e: unknown): boolean =>
+  typeof e === 'object' &&
+  e !== null &&
+  'code' in e &&
+  (e as { readonly code?: unknown }).code === 'NoSuchKey';
 
 export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
   'gycc/lib/storage.server/NotFound',
@@ -100,9 +118,10 @@ const listStoredObjects = Effect.fn('listStoredObjects')(function* (
   const objects: ListedObject[] = [];
   let continuationToken: string | undefined;
   do {
-    const page = yield* Effect.tryPromise(() =>
-      client.list({ prefix, continuationToken }),
-    );
+    const page = yield* Effect.tryPromise({
+      try: () => client.list({ prefix, continuationToken }),
+      catch: (e) => new StorageError({ key: prefix ?? '', op: 'list', cause: e }),
+    });
     for (const item of page.contents ?? []) {
       objects.push({
         key: item.key,
@@ -231,17 +250,10 @@ export class Storage extends Context.Service<
             const file = client.file(key);
             const stat = yield* Effect.tryPromise({
               try: () => file.stat(),
-              catch: (e) => {
-                const message = String(e);
-                if (
-                  message.includes('NoSuchKey') ||
-                  message.includes('does not exist') ||
-                  message.includes('404')
-                ) {
-                  return new NotFound({ key });
-                }
-                return new StorageError({ key, op: 'get', message });
-              },
+              catch: (e) =>
+                isNoSuchKey(e)
+                  ? new NotFound({ key })
+                  : new StorageError({ key, op: 'get', cause: e }),
             });
             return {
               stream: file.stream(),
@@ -253,8 +265,7 @@ export class Storage extends Context.Service<
         put: (key, body, contentType) =>
           Effect.tryPromise({
             try: () => client.write(key, body, { type: contentType }),
-            catch: (e) =>
-              new StorageError({ key, op: 'put', message: String(e) }),
+            catch: (e) => new StorageError({ key, op: 'put', cause: e }),
           }).pipe(Effect.asVoid),
 
         head: (key) =>
@@ -262,14 +273,12 @@ export class Storage extends Context.Service<
             const file = client.file(key);
             const exists = yield* Effect.tryPromise({
               try: () => file.exists(),
-              catch: (e) =>
-                new StorageError({ key, op: 'head', message: String(e) }),
+              catch: (e) => new StorageError({ key, op: 'head', cause: e }),
             });
             if (!exists) return Option.none();
             const stat = yield* Effect.tryPromise({
               try: () => file.stat(),
-              catch: (e) =>
-                new StorageError({ key, op: 'head', message: String(e) }),
+              catch: (e) => new StorageError({ key, op: 'head', cause: e }),
             });
             return Option.some({
               size: stat.size,
@@ -280,24 +289,12 @@ export class Storage extends Context.Service<
             });
           }),
 
-        list: (prefix) =>
-          listStoredObjects(client, prefix).pipe(
-            Effect.catchCause((cause) =>
-              Effect.fail(
-                new StorageError({
-                  key: prefix ?? '',
-                  op: 'list',
-                  message: String(cause),
-                }),
-              ),
-            ),
-          ),
+        list: (prefix) => listStoredObjects(client, prefix),
 
         delete: (key) =>
           Effect.tryPromise({
             try: () => client.delete(key),
-            catch: (e) =>
-              new StorageError({ key, op: 'delete', message: String(e) }),
+            catch: (e) => new StorageError({ key, op: 'delete', cause: e }),
           }),
       });
     }),
@@ -326,7 +323,7 @@ export class Storage extends Context.Service<
               new StorageError({
                 key,
                 op: 'put',
-                message: 'storage unconfigured',
+                cause: new Error('storage unconfigured'),
               }),
             ),
           head: () => Effect.succeed(Option.none()),

--- a/app/lib/storage.server.ts
+++ b/app/lib/storage.server.ts
@@ -1,5 +1,6 @@
+export * as Storage from './storage.server';
+
 import {
-  Clock,
   Context,
   DateTime,
   Effect,
@@ -17,23 +18,26 @@ import { Env } from './env.server';
  * `put`, `head`, `list`, `delete` — that the `Content`/admin layers build on
  * (small-interface-deep-implementation).
  *
- * `static layer` reads the bucket config off the `Env` service. The bucket is
- * optional everywhere (the CMS degrades to bundled defaults without one), so a
- * `Storage` *instance* is only constructible when a bucket is configured: with
- * `Env.bucket` absent the layer fails with `StorageUnconfigured`, and callers
- * that want the degraded path (the `Content` service) decide not to require
- * `Storage` rather than holding a half-built one
+ * The module-level `layer` reads the bucket config off the `Env` service
+ * (opencode's strongest service convention — `export const layer` /
+ * `export const defaultLayer`, `packages/core/src/git.ts:347`, vs a `static`
+ * member). The bucket is optional everywhere (the CMS degrades to bundled
+ * defaults without one), so a `Storage` *instance* is only constructible when a
+ * bucket is configured: with `Env.bucket` absent the layer fails with
+ * `StorageUnconfigured`, and callers that want the degraded path (the `Content`
+ * service) decide not to require `Storage` rather than holding a half-built one
  * (make-impossible-states-unrepresentable).
  *
- * `static layerTest` is an in-memory `Map`, used by the unit tests and by any
- * service-level test that needs a real round-trip without a bucket.
+ * The in-memory test layer lives in `storage.test-helper.ts` (opencode keeps
+ * test layers under `test/`, per its AGENTS.md "test real impl"), so the
+ * production module never ships a `Map`-backed fake.
  */
 
 const StorageOp = Schema.Literals(['get', 'put', 'head', 'list', 'delete']);
 type StorageOp = typeof StorageOp.Type;
 
 export class StorageError extends Schema.TaggedErrorClass<StorageError>()(
-  'gycc/lib/storage.server/StorageError',
+  'Storage.Error',
   {
     key: Schema.String,
     op: StorageOp,
@@ -60,12 +64,12 @@ const isNoSuchKey = (e: unknown): boolean =>
   (e as { readonly code?: unknown }).code === 'NoSuchKey';
 
 export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
-  'gycc/lib/storage.server/NotFound',
+  'Storage.NotFound',
   { key: Schema.String },
 ) {}
 
 export class StorageUnconfigured extends Schema.TaggedErrorClass<StorageUnconfigured>()(
-  'gycc/lib/storage.server/StorageUnconfigured',
+  'Storage.Unconfigured',
   {},
 ) {}
 
@@ -86,13 +90,6 @@ export interface ListedObject {
   readonly key: string;
   readonly size: number;
   readonly lastModified: Date;
-}
-
-export interface TestStoredObject {
-  readonly body: Uint8Array | string;
-  readonly contentType?: string;
-  readonly lastModified?: Date;
-  readonly etag?: string;
 }
 
 type ListClient = {
@@ -137,8 +134,8 @@ const listStoredObjects = Effect.fnUntraced(function* (
   return objects;
 });
 
-export class Storage extends Context.Service<
-  Storage,
+export class Service extends Context.Service<
+  Service,
   {
     readonly get: (key: string) => Effect.Effect<StoredObject, StorageError | NotFound>;
     readonly put: (
@@ -152,196 +149,135 @@ export class Storage extends Context.Service<
     readonly list: (prefix?: string) => Effect.Effect<readonly ListedObject[], StorageError>;
     readonly delete: (key: string) => Effect.Effect<void, StorageError>;
   }
->()('gycc/lib/storage.server/Storage') {
-  static layerTest = (objects: Record<string, TestStoredObject> = {}) =>
-    Layer.sync(Storage, () => {
-      const entries = new Map<string, Required<TestStoredObject>>();
-      for (const [key, object] of Object.entries(objects)) {
-        entries.set(key, {
-          body: object.body,
-          contentType: object.contentType ?? 'application/json',
-          lastModified: object.lastModified ?? epoch(),
-          etag: object.etag ?? `"${key}"`,
-        });
-      }
+>()('gycc/lib/storage.server/Service') {}
 
-      const bytes = (body: Uint8Array | string): Uint8Array =>
-        typeof body === 'string' ? new TextEncoder().encode(body) : body;
-      const responseBody = (body: Uint8Array | string): BodyInit =>
-        typeof body === 'string'
-          ? body
-          : new Blob([body as Uint8Array<ArrayBuffer>]);
+/**
+ * The bucket-backed `Storage`, reading its config off `Env` (opencode's
+ * module-level `export const layer`, `packages/core/src/git.ts:79`). When
+ * `Env.bucket` is absent it fails with `StorageUnconfigured`; callers that want
+ * the degraded path compose `layerOptional` instead of holding a half-built
+ * instance (`make-impossible-states-unrepresentable`).
+ */
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
 
-      const get = Effect.fn('Storage.get')(function* (key: string) {
-        const object = entries.get(key);
-        if (object === undefined) return yield* new NotFound({ key });
-        return {
-          stream:
-            new Response(responseBody(object.body)).body ??
-            new ReadableStream<Uint8Array>(),
-          contentType: object.contentType,
-          size: bytes(object.body).byteLength,
-        };
-      });
+    if (Option.isNone(env.bucket)) {
+      return yield* new StorageUnconfigured();
+    }
 
-      const put = Effect.fn('Storage.put')(function* (
-        key: string,
-        body: Uint8Array | string,
-        contentType: string,
-      ) {
-        const now = yield* Clock.currentTimeMillis;
-        entries.set(key, {
-          body,
-          contentType,
-          lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(now)),
-          etag: `"test-${now}"`,
-        });
-      });
-
-      const head = Effect.fn('Storage.head')((key: string) =>
-        Effect.sync(() => {
-          const object = entries.get(key);
-          if (object === undefined) return Option.none<ObjectHead>();
-          return Option.some<ObjectHead>({
-            size: bytes(object.body).byteLength,
-            contentType: object.contentType,
-            lastModified: object.lastModified,
-            etag: object.etag,
-          });
-        }),
-      );
-
-      const list = Effect.fn('Storage.list')((prefix?: string) =>
-        Effect.sync(() =>
-          [...entries.entries()]
-            .filter(([key]) => prefix === undefined || key.startsWith(prefix))
-            .map(([key, object]) => ({
-              key,
-              size: bytes(object.body).byteLength,
-              lastModified: object.lastModified,
-            })),
-        ),
-      );
-
-      const del = Effect.fn('Storage.delete')((key: string) =>
-        Effect.sync(() => {
-          entries.delete(key);
-        }),
-      );
-
-      return Storage.of({ get, put, head, list, delete: del });
+    const config = env.bucket.value;
+    const client = new Bun.S3Client({
+      endpoint: config.endpoint,
+      accessKeyId: Redacted.value(config.accessKeyId),
+      secretAccessKey: Redacted.value(config.secretAccessKey),
+      bucket: config.bucket,
+      region: config.region,
     });
 
-  static layer = Layer.effect(
-    Storage,
-    Effect.gen(function* () {
-      const env = yield* Env;
-
-      if (Option.isNone(env.bucket)) {
-        return yield* new StorageUnconfigured();
-      }
-
-      const config = env.bucket.value;
-      const client = new Bun.S3Client({
-        endpoint: config.endpoint,
-        accessKeyId: Redacted.value(config.accessKeyId),
-        secretAccessKey: Redacted.value(config.secretAccessKey),
-        bucket: config.bucket,
-        region: config.region,
+    const get = Effect.fn('Storage.get')(function* (key: string) {
+      const file = client.file(key);
+      const stat = yield* Effect.tryPromise({
+        try: () => file.stat(),
+        catch: (e) =>
+          isNoSuchKey(e)
+            ? new NotFound({ key })
+            : new StorageError({ key, op: 'get', cause: e }),
       });
+      return {
+        stream: file.stream(),
+        contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
+        size: stat.size,
+      };
+    });
 
-      const get = Effect.fn('Storage.get')(function* (key: string) {
-        const file = client.file(key);
-        const stat = yield* Effect.tryPromise({
-          try: () => file.stat(),
-          catch: (e) =>
-            isNoSuchKey(e)
-              ? new NotFound({ key })
-              : new StorageError({ key, op: 'get', cause: e }),
-        });
-        return {
-          stream: file.stream(),
-          contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
-          size: stat.size,
-        };
+    const put = Effect.fn('Storage.put')(function* (
+      key: string,
+      body: Uint8Array | string,
+      contentType: string,
+    ) {
+      yield* Effect.tryPromise({
+        try: () => client.write(key, body, { type: contentType }),
+        catch: (e) => new StorageError({ key, op: 'put', cause: e }),
       });
+    });
 
-      const put = Effect.fn('Storage.put')(function* (
-        key: string,
-        body: Uint8Array | string,
-        contentType: string,
-      ) {
-        yield* Effect.tryPromise({
-          try: () => client.write(key, body, { type: contentType }),
-          catch: (e) => new StorageError({ key, op: 'put', cause: e }),
-        });
+    const head = Effect.fn('Storage.head')(function* (key: string) {
+      const file = client.file(key);
+      const exists = yield* Effect.tryPromise({
+        try: () => file.exists(),
+        catch: (e) => new StorageError({ key, op: 'head', cause: e }),
       });
-
-      const head = Effect.fn('Storage.head')(function* (key: string) {
-        const file = client.file(key);
-        const exists = yield* Effect.tryPromise({
-          try: () => file.exists(),
-          catch: (e) => new StorageError({ key, op: 'head', cause: e }),
-        });
-        if (!exists) return Option.none<ObjectHead>();
-        const stat = yield* Effect.tryPromise({
-          try: () => file.stat(),
-          catch: (e) => new StorageError({ key, op: 'head', cause: e }),
-        });
-        return Option.some<ObjectHead>({
-          size: stat.size,
-          contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
-          lastModified: stat.lastModified,
-          etag: stat.etag,
-        });
+      if (!exists) return Option.none<ObjectHead>();
+      const stat = yield* Effect.tryPromise({
+        try: () => file.stat(),
+        catch: (e) => new StorageError({ key, op: 'head', cause: e }),
       });
-
-      const list = Effect.fn('Storage.list')(function* (prefix?: string) {
-        return yield* listStoredObjects(client, prefix);
+      return Option.some<ObjectHead>({
+        size: stat.size,
+        contentType: stat.type === '' ? 'application/octet-stream' : stat.type,
+        lastModified: stat.lastModified,
+        etag: stat.etag,
       });
+    });
 
-      const del = Effect.fn('Storage.delete')(function* (key: string) {
-        yield* Effect.tryPromise({
-          try: () => client.delete(key),
-          catch: (e) => new StorageError({ key, op: 'delete', cause: e }),
-        });
+    const list = Effect.fn('Storage.list')(function* (prefix?: string) {
+      return yield* listStoredObjects(client, prefix);
+    });
+
+    const del = Effect.fn('Storage.delete')(function* (key: string) {
+      yield* Effect.tryPromise({
+        try: () => client.delete(key),
+        catch: (e) => new StorageError({ key, op: 'delete', cause: e }),
       });
+    });
 
-      return Storage.of({ get, put, head, list, delete: del });
-    }),
-  );
+    return Service.of({ get, put, head, list, delete: del });
+  }),
+);
 
-  /**
-   * A `Storage` that never fails to *build*: it uses the real bucket-backed
-   * `layer` when a bucket is configured, and a **disabled** in-bucket-less
-   * instance otherwise (where every read reports `NotFound` and every write
-   * fails `StorageError`). This is the layer the always-on `Content` service
-   * (C3) composes: the CMS is optional everywhere, so `Storage` must be present
-   * in the application context even without a bucket — callers then degrade to
-   * bundled defaults on the `NotFound`, rather than the whole runtime failing to
-   * build on `StorageUnconfigured` (`make-impossible-states-unrepresentable`,
-   * D3). The admin write path (C4/C5) is only reachable when a bucket *is*
-   * configured, so the disabled writes are unreachable there.
-   */
-  static layerOptional = Storage.layer.pipe(
-    Layer.catchCause(() =>
-      Layer.succeed(
-        Storage,
-        Storage.of({
-          get: (key) => Effect.fail(new NotFound({ key })),
-          put: (key) =>
-            Effect.fail(
-              new StorageError({
-                key,
-                op: 'put',
-                cause: new Error('storage unconfigured'),
-              }),
-            ),
-          head: () => Effect.succeed(Option.none()),
-          list: () => Effect.succeed([]),
-          delete: () => Effect.void,
-        }),
-      ),
+/**
+ * A `Storage` that never fails to *build*: it uses the real bucket-backed
+ * `layer` when a bucket is configured, and a **disabled** in-bucket-less
+ * instance otherwise (where every read reports `NotFound` and every write
+ * fails `StorageError`). This is the layer the always-on `Content` service
+ * (C3) composes: the CMS is optional everywhere, so `Storage` must be present
+ * in the application context even without a bucket — callers then degrade to
+ * bundled defaults on the `NotFound`, rather than the whole runtime failing to
+ * build on `StorageUnconfigured` (`make-impossible-states-unrepresentable`,
+ * D3). The admin write path (C4/C5) is only reachable when a bucket *is*
+ * configured, so the disabled writes are unreachable there.
+ */
+export const layerOptional = layer.pipe(
+  Layer.catchCause(() =>
+    Layer.succeed(
+      Service,
+      Service.of({
+        get: (key) => Effect.fail(new NotFound({ key })),
+        put: (key) =>
+          Effect.fail(
+            new StorageError({
+              key,
+              op: 'put',
+              cause: new Error('storage unconfigured'),
+            }),
+          ),
+        head: () => Effect.succeed(Option.none()),
+        list: () => Effect.succeed([]),
+        delete: () => Effect.void,
+      }),
     ),
-  );
-}
+  ),
+);
+
+/**
+ * The self-contained, never-fails-to-build `Storage` (opencode's
+ * `export const defaultLayer`, `packages/core/src/git.ts:347`): `layerOptional`
+ * with its `Env` dependency pre-provided. The standalone consumers that need a
+ * `Storage` without separately wiring `Env` — the `/images/*` route in
+ * `server.ts` and the `/admin` write path — provide this directly. (`Content`
+ * composes `layerOptional` on its own `defaultLayer` instead, sharing `Env`
+ * with the rest of the app runtime.)
+ */
+export const defaultLayer = layerOptional.pipe(Layer.provide(Env.defaultLayer));

--- a/app/lib/storage.test-helper.ts
+++ b/app/lib/storage.test-helper.ts
@@ -1,0 +1,103 @@
+import { Clock, DateTime, Effect, Layer, Option } from 'effect';
+
+import {
+  type ObjectHead,
+  NotFound,
+  Storage,
+} from './storage.server';
+
+/**
+ * In-memory `Storage` test layer (opencode keeps test layers out of the
+ * production module, under `test/` — per its AGENTS.md "test real impl"). This
+ * is the `Map`-backed fake the unit tests and the service-level round-trip
+ * tests provide instead of a real bucket; it lives here so `storage.server.ts`
+ * never ships a fake.
+ */
+
+export interface TestStoredObject {
+  readonly body: Uint8Array | string;
+  readonly contentType?: string;
+  readonly lastModified?: Date;
+  readonly etag?: string;
+}
+
+const epoch = (): Date => DateTime.toDateUtc(DateTime.makeUnsafe(0));
+
+export const layerTest = (objects: Record<string, TestStoredObject> = {}) =>
+  Layer.sync(Storage.Service, () => {
+    const entries = new Map<string, Required<TestStoredObject>>();
+    for (const [key, object] of Object.entries(objects)) {
+      entries.set(key, {
+        body: object.body,
+        contentType: object.contentType ?? 'application/json',
+        lastModified: object.lastModified ?? epoch(),
+        etag: object.etag ?? `"${key}"`,
+      });
+    }
+
+    const bytes = (body: Uint8Array | string): Uint8Array =>
+      typeof body === 'string' ? new TextEncoder().encode(body) : body;
+    const responseBody = (body: Uint8Array | string): BodyInit =>
+      typeof body === 'string'
+        ? body
+        : new Blob([body as Uint8Array<ArrayBuffer>]);
+
+    const get = Effect.fn('Storage.get')(function* (key: string) {
+      const object = entries.get(key);
+      if (object === undefined) return yield* new NotFound({ key });
+      return {
+        stream:
+          new Response(responseBody(object.body)).body ??
+          new ReadableStream<Uint8Array>(),
+        contentType: object.contentType,
+        size: bytes(object.body).byteLength,
+      };
+    });
+
+    const put = Effect.fn('Storage.put')(function* (
+      key: string,
+      body: Uint8Array | string,
+      contentType: string,
+    ) {
+      const now = yield* Clock.currentTimeMillis;
+      entries.set(key, {
+        body,
+        contentType,
+        lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(now)),
+        etag: `"test-${now}"`,
+      });
+    });
+
+    const head = Effect.fn('Storage.head')((key: string) =>
+      Effect.sync(() => {
+        const object = entries.get(key);
+        if (object === undefined) return Option.none<ObjectHead>();
+        return Option.some<ObjectHead>({
+          size: bytes(object.body).byteLength,
+          contentType: object.contentType,
+          lastModified: object.lastModified,
+          etag: object.etag,
+        });
+      }),
+    );
+
+    const list = Effect.fn('Storage.list')((prefix?: string) =>
+      Effect.sync(() =>
+        [...entries.entries()]
+          .filter(([key]) => prefix === undefined || key.startsWith(prefix))
+          .map(([key, object]) => ({
+            key,
+            size: bytes(object.body).byteLength,
+            lastModified: object.lastModified,
+          })),
+      ),
+    );
+
+    const del = Effect.fn('Storage.delete')((key: string) =>
+      Effect.sync(() => {
+        entries.delete(key);
+      }),
+    );
+
+    return Storage.Service.of({ get, put, head, list, delete: del });
+  });

--- a/app/routes/($lang)+/2024/_index.tsx
+++ b/app/routes/($lang)+/2024/_index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   return { conference: yield* content.getConference(locale, 2024) };
 });
 

--- a/app/routes/($lang)+/2024/form/route.tsx
+++ b/app/routes/($lang)+/2024/form/route.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   const conference = yield* content.getCurrentConference(locale);
   return {
     conference,

--- a/app/routes/($lang)+/2025/_index.tsx
+++ b/app/routes/($lang)+/2025/_index.tsx
@@ -46,7 +46,7 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   return { conference: yield* content.getConference(locale, 2025) };
 });
 

--- a/app/routes/($lang)+/2025/form/route.tsx
+++ b/app/routes/($lang)+/2025/form/route.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   const conference = yield* content.getCurrentConference(locale);
   return {
     conference,

--- a/app/routes/($lang)+/2026/_index.tsx
+++ b/app/routes/($lang)+/2026/_index.tsx
@@ -46,7 +46,7 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   return { conference: yield* content.getConference(locale, 2026) };
 });
 

--- a/app/routes/($lang)+/2026/form/route.tsx
+++ b/app/routes/($lang)+/2026/form/route.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   const conference = yield* content.getCurrentConference(locale);
   return {
     conference,

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   return {
     conference: yield* content.getCurrentConference(locale),
   };
@@ -55,7 +55,7 @@ export const loader = routeHandler(function* () {
 
 export const action = routeAction(function* () {
   const { request, url } = yield* ReactRouterContext;
-  const mailchimp = yield* Mailchimp;
+  const mailchimp = yield* Mailchimp.Service;
 
   const formData = yield* Effect.promise(() => request.formData());
   const submission = parseWithZod(formData, { schema });

--- a/app/routes/($lang)+/_layout.tsx
+++ b/app/routes/($lang)+/_layout.tsx
@@ -29,7 +29,7 @@ import { Portal } from '~/ui/portal';
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const lang = getLocale(params);
-  const content = yield* Content;
+  const content = yield* Content.Service;
   const translation = yield* content.getTranslations(lang);
   const currentConference = yield* content.getCurrentConference(lang);
   return { lang, translation, currentConference };

--- a/app/routes/($lang)+/contact.tsx
+++ b/app/routes/($lang)+/contact.tsx
@@ -102,7 +102,7 @@ export const meta: MetaFunction = ({ params }) => {
 
 export const action = routeAction(function* () {
   const { request, url } = yield* ReactRouterContext;
-  const mailer = yield* Mailer;
+  const mailer = yield* Mailer.Service;
 
   const formData = yield* Effect.promise(() => request.formData());
   const submission = parseWithZod(formData, { schema });

--- a/app/routes/($lang)+/team/_index.tsx
+++ b/app/routes/($lang)+/team/_index.tsx
@@ -21,7 +21,7 @@ export const meta: MetaFunction = ({ params }) => {
 };
 
 export const loader = routeHandler(function* () {
-  const content = yield* Content;
+  const content = yield* Content.Service;
   return yield* content.getTeam();
 });
 

--- a/app/routes/($lang)+/volunteer.tsx
+++ b/app/routes/($lang)+/volunteer.tsx
@@ -150,7 +150,7 @@ export const loader = () => {
 
 export const action = routeAction(function* () {
   const { request, url } = yield* ReactRouterContext;
-  const mailer = yield* Mailer;
+  const mailer = yield* Mailer.Service;
 
   const formData = yield* Effect.promise(() => request.formData());
   const submission = parseWithZod(formData, { schema });

--- a/app/routes/admin/_layout.tsx
+++ b/app/routes/admin/_layout.tsx
@@ -25,13 +25,12 @@ export const headers = adminSecurityHeaders;
  */
 export const loader = routeHandler(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.catchTags({
-      'gycc/lib/auth.server/AdminDisabled': () =>
+      'Auth.Disabled': () =>
         Effect.fail(new Response('Not Found', { status: 404 })),
-      'gycc/lib/auth.server/Unauthorized': () =>
-        Effect.fail(redirect('/admin/login')),
+      'Auth.Unauthorized': () => Effect.fail(redirect('/admin/login')),
     }),
   );
   return null;

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -95,20 +95,19 @@ const issueMessages = (cause: Cause.Cause<unknown>): readonly string[] => {
 
 export const loader = routeHandler(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   // 404 the whole area when disabled; the layout guard already redirected an
   // unauthenticated visitor, but re-checking keeps this route safe on its own.
   yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.catchTags({
-      'gycc/lib/auth.server/AdminDisabled': () =>
+      'Auth.Disabled': () =>
         Effect.fail(new Response('Not Found', { status: 404 })),
-      'gycc/lib/auth.server/Unauthorized': () =>
-        Effect.fail(redirect('/admin/login')),
+      'Auth.Unauthorized': () => Effect.fail(redirect('/admin/login')),
     }),
   );
 
-  const content = yield* Content;
-  const env = yield* Env;
+  const content = yield* Content.Service;
+  const env = yield* Env.Service;
   const { content: document, source } = yield* content.getAdminContent();
   const encoded = yield* encodeDocument(document);
 
@@ -122,18 +121,17 @@ export const loader = routeHandler(function* () {
 
 export const action = routeAction(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.catchTags({
-      'gycc/lib/auth.server/AdminDisabled': () =>
+      'Auth.Disabled': () =>
         Effect.fail(new Response('Not Found', { status: 404 })),
-      'gycc/lib/auth.server/Unauthorized': () =>
-        Effect.fail(redirect('/admin/login')),
+      'Auth.Unauthorized': () => Effect.fail(redirect('/admin/login')),
     }),
   );
 
-  const content = yield* Content;
-  const storage = yield* Storage;
+  const content = yield* Content.Service;
+  const storage = yield* Storage.Service;
   const form = yield* Effect.promise(() => request.formData());
   const intent = String(form.get('intent') ?? 'save-draft');
 

--- a/app/routes/admin/login.tsx
+++ b/app/routes/admin/login.tsx
@@ -17,7 +17,7 @@ export const headers = adminSecurityHeaders;
  */
 export const loader = routeHandler(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   return yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.match({
       onSuccess: () => redirect('/admin'),
@@ -36,7 +36,7 @@ export const loader = routeHandler(function* () {
  */
 export const action = routeAction(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   const form = yield* Effect.promise(() => request.formData());
   const password = String(form.get('password') ?? '');
 

--- a/app/routes/admin/logout.tsx
+++ b/app/routes/admin/logout.tsx
@@ -18,7 +18,7 @@ export const headers = adminSecurityHeaders;
  */
 export const action = routeAction(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   return yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.match({
       onSuccess: () =>
@@ -42,7 +42,7 @@ export const action = routeAction(function* () {
  */
 export const loader = routeHandler(function* () {
   const { request } = yield* ReactRouterContext;
-  const auth = yield* Auth;
+  const auth = yield* Auth.Service;
   return yield* auth.checkCookie(request.headers.get('cookie')).pipe(
     Effect.match({
       onSuccess: () => redirect('/admin'),

--- a/docs/cms-patterns-polish-plan.md
+++ b/docs/cms-patterns-polish-plan.md
@@ -1,0 +1,132 @@
+# CMS Patterns Polish — Plan
+
+**Branch:** `cms/patterns-polish` (stacked on `cms/storage-foundation` PR #11 → `revival/2026-speak` PR #10).
+**Status:** in progress (ultracode workflow `.claude/workflows/gyc-cms-polish.js`).
+
+This document is handed to Codex on **every** `okra counsel` review so it situates each
+sub-commit against the whole effort. Keep it current.
+
+---
+
+## Why
+
+A multi-agent review of the CMS code (PR #11) against `anomalyco/opencode`
+(`/Users/cvr/.cache/repo/anomalyco/opencode` — a mature Effect v4 codebase: 173
+`Context.Service`, 0 `Tag`, 0 `Effect.Service`) found our patterns **strong and broadly
+idiomatic** — matching or beating opencode on deterministic service keys, JSON-codec
+discipline, the empty-string config defense, the semantically-faithful `Storage.layerOptional`,
+and the RR7 `throwCauseError` bridge. This branch closes the **real, justified** gaps the
+review surfaced. It is pure internal-quality work: **no user-facing behavior change** (except
+the cache's documented ≤TTL staleness window — see C1), gate-green per commit, Codex-counseled.
+
+Findings NOT adopted (conscious keeps, do NOT flag): deterministic full-path service keys
+(more collision-safe than opencode's short handles); `registration: OptionFromOptionalKey`
+(against opencode's `Schema.optional` grain but justified by make-impossible-states-
+unrepresentable); `HttpRouter` over `HttpApi` (no public API contract); the `throwCauseError`
+RR7 error bridge (correct for thrown-`Response` control flow).
+
+## End goal
+
+The CMS services read as if written by the opencode team: built-in cache primitive instead
+of a hand-rolled one, branded validated primitives, every service method a traced
+`Effect.fn("Service.method")`, structured (not string-matched) infra errors with preserved
+causes, platform streaming for static files, and module-level `layer`/`defaultLayer` per
+service.
+
+---
+
+## Sub-commit sequence (one wave; each compiles + passes gate + Codex-counseled)
+
+Ordered subtract-before-you-add (the cache deletion first) → safe schema/error hardening →
+mechanical sweeps → convention churn last.
+
+### C1 — Replace hand-rolled cache with `Effect.cachedInvalidateWithTTL`; drop the epoch
+**`use-the-platform`, `subtract-before-you-add`.** Verified: `Effect.cachedInvalidateWithTTL`
+exists (`effect-smol packages/effect/src/Effect.ts:7118`, sig
+`(self, ttl) => Effect<[Effect<A,E,R>, Effect<void>]>`); opencode uses it for the same
+cached-document-with-bust use case (`packages/opencode/src/config/config.ts:281`,
+`packages/core/src/models-dev.ts:215`).
+In `app/lib/content.server.ts` `Content.layer`: delete the `Ref` cache (`:344`), the
+single-permit `Semaphore` (`:345`), the monotonic publish-`epoch` `Ref` (`:359`) and all the
+epoch dance in `getSiteContent` (`:415-460`) + `bust` (`:561-567`), plus the `Semaphore`
+import (`:9`) and `CacheEntry`/`CACHE_TTL_MS` plumbing as appropriate. Replace with:
+```ts
+const [cachedContent, invalidate] =
+  yield* Effect.cachedInvalidateWithTTL(fetchDocument, Duration.millis(CACHE_TTL_MS));
+const getSiteContent = () => cachedContent;
+const bust = () => invalidate;
+```
+**Decision (user-approved):** drop the epoch. The built-in does NOT close the
+bust-during-in-flight-refresh race the epoch guarded; for a 30s-TTL low-write CMS the worst
+case is a publish landing exactly during an in-flight refresh being invisible for ≤1 more
+TTL (≤30s) — within D3's "visible on the next read" contract. **Update the `Content` doc
+comment** to state this explicitly (the staleness window is now a documented property, not a
+bug). Keep `fetchDocument` (decode + fallback) and all derived selectors unchanged.
+VERIFY: `content.server.test.ts` green (adapt the TTL/single-flight tests to the new shape —
+they previously asserted reference-equality within TTL; keep that contract). Boot dev, confirm
+`/`, `/2026` still render from defaults. Net ~-65 lines.
+
+### C2 — Brand the validated primitives
+**`make-impossible-states-unrepresentable`, `boundary-discipline`.** opencode brands every
+validated newtype (`packages/core/src/system-context/index.ts:22` `SystemContext.Key`,
+`packages/core/src/schema.ts:25-31` `AbsolutePath`/`RelativePath`). In
+`app/lib/content/schema.ts`, append `.pipe(Schema.brand("..."))` to `AssetKey` (`:79`),
+`IsoDate` (`:149`), `HexColour` (`:111`), and the conference `slug` (`:253`). Propagate the
+branded types through the boundary signatures that currently take plain `string` —
+`toEndOfDayMs(date: IsoDate)` / `assetUrl(key)` etc. in `content.server.ts` — so the
+validation guarantee is load-bearing past the decoder. Round-trip tests in
+`content/schema.test.ts` should still pass (branding is encode/decode-transparent); add an
+assertion that a raw string is NOT assignable where a brand is required (type-level, or a
+decode-rejects test for a bad value).
+
+### C3 — Structured infra errors: stop string-matching; preserve causes
+**`boundary-discipline`, `correctness-over-pragmatism`.** (a) `Storage.get` not-found
+detection currently does `String(e).includes('NoSuchKey' | 'does not exist' | '404')`
+(`storage.server.ts:236-242`) — brittle. Match the structured Bun error instead
+(`e instanceof Bun.S3Error && e.code === 'NoSuchKey'`, plus `.stat()`/`.exists()` where
+appropriate), mirroring opencode's structured `missing()` predicate
+(`packages/opencode/src/storage/storage.ts:67-74`, `packages/core/src/fs-util.ts:114`). (b)
+Add a `cause: Schema.optional(Schema.Defect)` field to `StorageError` / `MailError` /
+`MailchimpError` and stop flattening to `message: String(e)` at the failure site
+(`storage.server.ts:243,257`; `mailer.server.ts:59`; `mailchimp.server.ts:67`), following
+opencode `packages/core/src/fs-util.ts:14-17`, `packages/core/src/auth.ts:54-57`. Keep the
+useful `key`/`op` discriminants on `StorageError`. VERIFY: storage tests green; the
+disabled-storage `layerOptional` still yields `NotFound`/`StorageError` correctly.
+
+### C4 — `Effect.fn("Service.method")` tracing sweep
+**Observability convention (opencode: 1029 `Effect.fn` uses; every service method is a named
+span — `packages/core/src/git.ts:80` `Effect.fn("Git.find")`).** Wrap every service method in
+`Storage`, `Content`, `Auth`, `Mailer`, `Mailchimp` as
+`Effect.fn("Storage.get")(function* (...) {...})` etc., replacing the bare
+`Effect.gen`-in-`.of({...})` arrows. Use `Effect.fnUntraced` for genuinely-internal helpers
+(opencode reserves it for hot/internal — `git.ts` split). Rename the lone existing
+`Effect.fn('listStoredObjects')` (`storage.server.ts:96`) — it's an internal helper, so
+either `Effect.fnUntraced` or a non-method label. Pure mechanical; no behavior change. Gate
+green (watch the effect LSP `effectFnOpportunity`/`effectFnImplicitAny` diagnostics).
+
+### C5 — Module-level `layer`/`defaultLayer`; error-tag rename; relocate test layer
+**opencode's strongest service convention (137 `export const layer` vs 4 static).** (a)
+Convert `Storage.layer`/`Content.layer`/`Env.layer`/`Auth.layer` (+ `layerOptional`,
+`layerTest`) from `static` members to module-level `export const layer` / `export const
+layerOptional`, and add a per-service `export const defaultLayer` that pre-provides deps
+(`Content`: `defaultLayer = layer.pipe(Layer.provide(Storage.layerOptional))`, mirroring
+`git.ts:347`). Then `effect/runtime.ts` lists `Content.defaultLayer` and drops the inline
+`Content.layer.pipe(Layer.provide(StorageLive))` hand-wiring (keep `Storage` provided
+standalone for the admin write path — a legit second consumer). (b) Shorten error-tag keys
+from path-style `"gycc/lib/storage.server/StorageError"` to domain-namespaced
+`"Storage.Error"`-style (move-stable; opencode `"Session.MessageDecodeError"`
+`packages/core/src/session/error.ts:5`) — update every `catchTag`/`catchTags` string
+(`server.ts`, `routes/admin/content.tsx`, `content.server.ts`). (c) Relocate `Storage.layerTest`
++ its in-memory Map impl out of the production file into a test-local helper (opencode keeps
+test layers under `test/`, per its AGENTS.md "test real impl"), updating
+`content.server.test.ts` + `storage.server.test.ts`. This is the churniest commit — do it last
+so a rename mistake can't block the substantive work above. Gate green incl. all `catchTag`
+strings resolving.
+
+## Verification (prove-it-works)
+
+Gate per commit: `cd /Users/cvr/Developer/personal/gyc && bun run typecheck && bun run lint &&
+bun run build && bun test`. Runtime: C1 — boot dev, `/` + `/2026` render from defaults, and
+the publish→bust→read path (via in-memory layer test) still reflects a change. C3 — confirm
+not-found still falls back to defaults / `public/` files. No user-facing behavior change
+elsewhere; the test suite (103 tests) is the regression guard — keep it green throughout.

--- a/server.ts
+++ b/server.ts
@@ -81,7 +81,7 @@ const fileResponse = Effect.fn('fileResponse')(function* (
 const bucketImageResponse = Effect.fn('bucketImageResponse')(function* (
   key: string,
 ) {
-  const storage = yield* Storage;
+  const storage = yield* Storage.Service;
   const obj = yield* storage.get(key);
   return HttpServerResponse.raw(obj.stream, {
     status: 200,
@@ -105,14 +105,14 @@ const imageResponse = Effect.fn('imageResponse')(function* () {
   // while a bucket-less dev/prod still serves the defaults (D3).
   const publicPath = `${isDev ? 'public' : CLIENT_PATH}/${key}`;
   return yield* bucketImageResponse(key).pipe(
-    Effect.catchTag('gycc/lib/storage.server/NotFound', () =>
+    Effect.catchTag('Storage.NotFound', () =>
       fileResponse(publicPath, mimeFor(key), 'public, max-age=300').pipe(
         Effect.catchTag('gycc/server/FileMissing', () =>
           Effect.succeed(HttpServerResponse.empty({ status: 404 })),
         ),
       ),
     ),
-    Effect.catchTag('gycc/lib/storage.server/StorageError', (e) =>
+    Effect.catchTag('Storage.Error', (e) =>
       Effect.logWarning('image bucket read failed, falling back to public', e).pipe(
         Effect.flatMap(() =>
           fileResponse(publicPath, mimeFor(key), 'public, max-age=300').pipe(
@@ -248,17 +248,17 @@ const RoutesLive = isDev ? DevRoutes : ProdRoutes;
 // (ADR 0004:38-40). Providing `Env.layer` discharges the requirement, so a
 // missing secret fails `Layer.launch` and `BunRuntime.runMain` exits non-zero.
 // In dev / test the env vars are optional, so this is a cheap no-op.
-const StartupCheck = Layer.effectDiscard(Env.asEffect()).pipe(
+const StartupCheck = Layer.effectDiscard(Env.Service.asEffect()).pipe(
   Layer.provide(Env.layer),
 );
 
-// The `/images/*` route reads through `Storage`. `Storage.layerOptional` never
+// The `/images/*` route reads through `Storage`. `Storage.defaultLayer` never
 // fails to build (bucket-less it serves `NotFound`, which the route recovers by
 // falling back to the bundled `public/<key>` file), so providing it here keeps
-// the server booting identically with or without a bucket (D3). It reads its
-// bucket config from `Env`, discharged with `Env.layer` so the storage layer is
-// self-contained.
-const StorageLive = Storage.layerOptional.pipe(Layer.provide(Env.layer));
+// the server booting identically with or without a bucket (D3). It is
+// `Storage.layerOptional` with its `Env` dependency pre-provided, so the
+// storage layer is self-contained.
+const StorageLive = Storage.defaultLayer;
 
 const ServerLive = HttpRouter.serve(RoutesLive).pipe(
   Layer.provide(StorageLive),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -118,7 +118,7 @@
           },
           {
             "target": "error",
-            "pattern": "default",
+            "pattern": "namespace",
             "skipLeadingPath": ["app/"]
           }
         ],


### PR DESCRIPTION
## CMS patterns polish — opencode-aligned Effect v4 patterns

Internal-quality refactor of the GYC CMS services so they read as if written by the opencode team. This came out of a pattern review against `anomalyco/opencode` (a mature Effect v4 codebase: 173 `Context.Service`, 0 `Tag`). The review found our patterns already strong and broadly idiomatic; this branch closes the real, justified gaps.

**Pure pattern-polish: no user-facing behavior change**, with one documented exception (C1's cache, see below). The 106-test suite stays green throughout — it's the regression guard. Gate (typecheck + lint + build + test) is green per commit.

Stacked on #11 (`cms/storage-foundation`).

### The five refactors

- **C1 — Replace hand-rolled content cache with `Effect.cachedInvalidateWithTTL`.** Drops the `Ref` cache, single-permit `Semaphore`, and the monotonic publish-`epoch` dance in favour of the built-in cache primitive (same use case as opencode `config/config.ts:281`). Net ~-65 lines. **One documented behavior change:** the built-in does not close the bust-during-in-flight-refresh race the epoch guarded; for a 30s-TTL low-write CMS the worst case is a publish landing during an in-flight refresh being invisible for ≤1 more TTL (≤30s) — within D3's "visible on the next read" contract. The `Content` doc comment now states this staleness window explicitly as a documented property.
- **C2 — Brand the validated primitives.** `AssetKey`, `IsoDate`, `HexColour`, and the conference `slug` gain `Schema.brand`, propagated through boundary signatures so the validation guarantee is load-bearing past the decoder.
- **C3 — Structured infra errors.** S3 not-found detection stops string-matching `String(e).includes('NoSuchKey' | ...)` and matches the structured Bun S3 error instead. `StorageError`/`MailError`/`MailchimpError` gain a `cause` field instead of flattening to `message: String(e)`, preserving causes.
- **C4 — `Effect.fn("Service.method")` tracing sweep.** Every service method in `Storage`, `Content`, `Auth`, `Mailer`, `Mailchimp` is now a named traced span, replacing bare `Effect.gen` arrows. Internal helpers use `Effect.fnUntraced`.
- **C5 — Module-level `layer`/`defaultLayer`; error-tag rename; relocate test layer.** Converts `static` layer members to module-level `export const layer`/`layerOptional`, adds per-service `defaultLayer` that pre-provides deps (mirroring `git.ts:347`). Shortens error-tag keys from path-style to domain-namespaced (`"Storage.Error"`). Relocates `layerTest` + its in-memory impl out of the production file into a test-local helper.

### Conscious keeps (not regressions — intentional, per the plan)

Deterministic full-path service keys (more collision-safe than opencode's short handles); `registration: OptionFromOptionalKey` (justified by make-impossible-states-unrepresentable); `HttpRouter` over `HttpApi` (no public API contract); the `throwCauseError` RR7 error bridge (correct for thrown-`Response` control flow).

Plan: `docs/cms-patterns-polish-plan.md`.

---

<!-- stacked -->
**Stack: `revival/2026-speak`** (3 of 3)

| # | Branch | PR |
|---|--------|----|
| 1 | `revival/2026-speak` | [#10](https://github.com/GYCCanada/Web/pull/10) |
| 2 | `cms/storage-foundation` | [#11](https://github.com/GYCCanada/Web/pull/11) |
| **3** | **`cms/patterns-polish`** | **#12 ← you are here** |
<!-- /stacked -->