### PR TITLE
build: Alpine+Bun Dockerfile with CI image smoke test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# VCS / CI / agent state
+.git
+.github
+.claude
+
+# Dependencies and build output (recreated inside the image)
+node_modules
+build
+
+# Docs and local-only files
+docs
+README.md
+*.md
+.env
+.env.*
+!.env.example
+
+# Tests never run in the image (and nothing in prod code imports them)
+**/*.test.ts
+**/*.test.tsx
+**/*.test-helper.ts
+
+Dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,37 @@ jobs:
 
       - name: Test
         run: bun test
+
+  docker:
+    timeout-minutes: 20
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t gycc:ci .
+
+      # Production boot fail-fasts without MAIL_* / MAILCHIMP_* (ADR 0004);
+      # dummies let the container boot — nothing sends mail during the smoke.
+      - name: Boot + smoke (/healthz, /, /fr)
+        run: |
+          docker run -d --name gycc -p 3000:3000 \
+            -e MAIL_HOST=smtp.example.com -e MAIL_PORT=587 \
+            -e MAIL_USER=ci -e MAIL_PASS=ci \
+            -e MAIL_FROM=ci@example.com -e MAIL_TO=ci@example.com \
+            -e MAILCHIMP_API_KEY=ci-us1 -e MAILCHIMP_LIST_ID=ci \
+            gycc:ci
+          for i in $(seq 1 30); do
+            curl -sf -o /dev/null http://localhost:3000/healthz && break
+            sleep 1
+          done
+          curl -sf http://localhost:3000/healthz
+          curl -sf -o /dev/null http://localhost:3000/
+          curl -sf -o /dev/null http://localhost:3000/fr
+          curl -sf -o /dev/null http://localhost:3000/2026/form
+
+      - name: Container logs
+        if: always()
+        run: docker logs gycc || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ ENV NODE_ENV=production
 
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/build ./build
-COPY package.json server.ts ./
+# tsconfig.json: Bun resolves the `~/*` path alias from it at runtime
+COPY package.json tsconfig.json server.ts ./
 COPY app ./app
 
 USER bun

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# Alpine + Bun image for the GYC Canada site.
+#
+# The runtime image carries three things beside production node_modules:
+#   - build/        the react-router client + server bundles (`bun run build`)
+#   - server.ts     the Bun HTTP entry (Bun runs TypeScript natively)
+#   - app/          server.ts imports app/lib TS (env, runtime, services) at
+#                   runtime, outside the server bundle
+#
+# Production boot REQUIRES MAIL_* + MAILCHIMP_* env vars (fail-fast env Layer,
+# ADR 0004); bucket (BUCKET_*) and admin (ADMIN_PASSWORD/COOKIE_SECRET) env are
+# optional — without them the site serves bundled content and /admin 404s.
+
+# ---- deps: full install for the vite/react-router build ----
+FROM oven/bun:1.3-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+# --ignore-scripts skips `prepare` (effect-tsgo patch) — typecheck-only tooling
+RUN bun install --frozen-lockfile --ignore-scripts
+
+# ---- build: client + server bundles ----
+FROM deps AS build
+COPY . .
+RUN bun run build
+
+# ---- prod-deps: production node_modules only ----
+FROM oven/bun:1.3-alpine AS prod-deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+# ---- runtime ----
+FROM oven/bun:1.3-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/build ./build
+COPY package.json server.ts ./
+COPY app ./app
+
+USER bun
+EXPOSE 3000
+
+# Single-quoted so /bin/sh does not expand the JS (shell-form CMD runs via sh).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD bun -e 'const r = await fetch("http://127.0.0.1:" + (process.env.PORT || 3000) + "/healthz"); if (!r.ok) process.exit(1)'
+
+CMD ["bun", "server.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,12 @@
 FROM oven/bun:1.3-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-# --ignore-scripts skips `prepare` (effect-tsgo patch) — typecheck-only tooling
-RUN bun install --frozen-lockfile --ignore-scripts
+# --ignore-scripts skips `prepare` (effect-tsgo patch) — typecheck-only tooling.
+# It also skips the npm `bun` package's binary download (auto-installed as
+# effect-bun-test's peer dep); `bun run` puts node_modules/.bin first on PATH,
+# so remove the broken shim to fall back to the image's own bun.
+RUN bun install --frozen-lockfile --ignore-scripts \
+ && rm -rf node_modules/bun node_modules/.bin/bun node_modules/.bin/bunx
 
 # ---- build: client + server bundles ----
 FROM deps AS build

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,9 @@
       "name": "gycc",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@conform-to/dom": "^1.19.4",
         "@conform-to/react": "^1.19.4",
+        "@effect/platform-bun": "4.0.0-beta.60",
         "@epic-web/client-hints": "^1.3.2",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
         "@react-router/node": "^7.15.0",
@@ -29,7 +31,6 @@
         "ts-pattern": "^5.2.0",
       },
       "devDependencies": {
-        "@effect/platform-bun": "4.0.0-beta.60",
         "@effect/tsgo": "0.5.2",
         "@react-router/dev": "^7.15.0",
         "@tailwindcss/vite": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@conform-to/dom": "^1.19.4",
     "@conform-to/react": "^1.19.4",
+    "@effect/platform-bun": "4.0.0-beta.60",
     "@epic-web/client-hints": "^1.3.2",
     "@mailchimp/mailchimp_marketing": "^3.0.80",
     "@react-router/node": "^7.15.0",
@@ -39,7 +41,6 @@
     "ts-pattern": "^5.2.0"
   },
   "devDependencies": {
-    "@effect/platform-bun": "4.0.0-beta.60",
     "@effect/tsgo": "0.5.2",
     "@react-router/dev": "^7.15.0",
     "@tailwindcss/vite": "^4.2.4",


### PR DESCRIPTION
## Summary

Multi-stage Dockerfile on `oven/bun:1.3-alpine` (pinned to the Bun minor we develop on — 1.3.14 locally; tag verified on Docker Hub):

1. **deps** — full install with `--ignore-scripts` (the `prepare` script runs `effect-tsgo patch`, which only matters for typechecking, not builds)
2. **build** — `bun run build` (react-router client + server bundles)
3. **prod-deps** — production-only `node_modules`
4. **runtime** — carries `build/`, `server.ts`, and `app/` (the server entry imports `app/lib` TypeScript directly at runtime, outside the server bundle — Bun runs TS natively). Runs as the unprivileged `bun` user, `HEALTHCHECK` against the existing `/healthz`, `CMD ["bun", "server.ts"]` with `NODE_ENV=production` baked in.

`.dockerignore` keeps `node_modules`, `build/`, docs, and test files out of the context (nothing in prod code imports tests/test-helpers).

## Env contract (unchanged)

- `MAIL_*` + `MAILCHIMP_*` **required** in production — the fail-fast env Layer (ADR 0004) exits at boot without them.
- `BUCKET_*` and `ADMIN_PASSWORD`/`COOKIE_SECRET` optional — bucket-less containers serve bundled content and `/admin` 404s.
- `PORT` respected (defaults to 3000).

## Verification

No Docker daemon on the dev machine, so verification is encoded as a **new `docker` CI job**: builds the image, boots it with dummy mail env, and curls `/healthz`, `/`, `/fr`, and `/2026/form` (with container logs dumped on failure). Check the job on this PR for the live run.

## Heads-up

- **Railway behavior changes when this lands**: a repo-root Dockerfile takes precedence over bun auto-detect, so deploys will build this image. That also makes the Alpine runtime the prod environment (Bun's S3 client, nodemailer, and mailchimp are all pure-JS/built-in — no native-module risk).

## What the smoke test caught

Three real issues, each fixed in its own commit:

1. **npm `bun` package shadowing the real bun** — `effect-bun-test` declares `bun` as a peer dep, so it lands in `node_modules`; `bun run` puts `node_modules/.bin` first on PATH, and with `--ignore-scripts` the shim's binary download never ran. The deps stage now removes the shim.
2. **`@effect/platform-bun` was a devDependency** (`package.json` change, not Docker-specific) — `server.ts` imports `BunHttpServer`/`BunRuntime` at runtime, so the production install must include it. Also declared `@conform-to/dom`, which was directly imported but only present transitively.
3. **`tsconfig.json` missing from the runtime image** — Bun resolves the `~/*` path alias from it when `server.ts` imports `app/lib` TS outside the server bundle.

The final image layout was verified locally by staging the exact runtime file set (prod `node_modules` + `build/` + `app/` + `tsconfig.json`) and smoke-testing all four endpoints — then confirmed green in the CI `docker` job.
