### PR TITLE
fix(nav): make mobile menu scrollable; hide Meet the Team link

### DIFF
--- a/app/routes/($lang)+/_layout.tsx
+++ b/app/routes/($lang)+/_layout.tsx
@@ -148,29 +148,34 @@ function PopupNav() {
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.2 }}
-                  className="bg-background text-foreground fixed inset-x-0 top-[60px] flex h-[calc(100%_-_60px)] flex-1 flex-col justify-center gap-10 p-4"
+                  className="bg-background text-foreground fixed inset-x-0 top-[60px] flex h-[calc(100%_-_60px)] flex-1 flex-col overflow-y-auto p-4"
                 >
-                  {[
-                    {
-                      to: `/${new Date().getFullYear()}`,
-                      label: translate("nav.home", {
-                        year: new Date().getFullYear(),
-                      }),
-                    },
-                    { to: "/about", label: translate("nav.about") },
-                    { to: "/team", label: translate("nav.team") },
-                    { to: "/contact", label: translate("nav.contact") },
-                    { to: "/give", label: translate("nav.give") },
-                    { to: "/volunteer", label: translate("nav.volunteer") },
-                  ].map((item, index) => (
-                    <NavItem
-                      key={item.to}
-                      to={item.to}
-                      revealDelay={index * STAGGER_STEP}
-                    >
-                      {item.label}
-                    </NavItem>
-                  ))}
+                  {/* `my-auto` centres the links when they fit and lets them
+                      scroll fully when they don't — flexbox `justify-center`
+                      clips the top of overflowing content past reach. */}
+                  <div className="my-auto flex flex-col gap-10">
+                    {[
+                      {
+                        to: `/${new Date().getFullYear()}`,
+                        label: translate("nav.home", {
+                          year: new Date().getFullYear(),
+                        }),
+                      },
+                      { to: "/about", label: translate("nav.about") },
+                      // { to: "/team", label: translate("nav.team") },
+                      { to: "/contact", label: translate("nav.contact") },
+                      { to: "/give", label: translate("nav.give") },
+                      { to: "/volunteer", label: translate("nav.volunteer") },
+                    ].map((item, index) => (
+                      <NavItem
+                        key={item.to}
+                        to={item.to}
+                        revealDelay={index * STAGGER_STEP}
+                      >
+                        {item.label}
+                      </NavItem>
+                    ))}
+                  </div>
                 </motion.nav>
               ) : null}
             </AnimatePresence>


### PR DESCRIPTION
Two nav fixes, verified live in a real browser at a short mobile viewport (390×420).

## Mobile menu scrolling

The `PopupNav` overlay was a fixed-height flex column (`h-[calc(100%_-_60px)]`) with `justify-center` and **no overflow**. On short viewports the large `text-5xl` links overflowed past the top/bottom edges with no way to reach them — the reported "no scrolling" bug.

Fix: add `overflow-y-auto` and move the links into a `my-auto` wrapper. They stay centred when they fit and scroll fully when they don't — plain `justify-center` clips overflowing flex content past reach.

## Meet the Team link

Commented out the `/team` entry in the mobile menu, matching the already-commented desktop `TopNav` and homepage button.

## Verification (agent-browser @ 390×420)

- Overlay now reports `overflowY: auto`, `scrollHeight 576 > clientHeight 360` → **`isScrollable: true`**.
- Scrolled to bottom — last link ("Become a volunteer") fully visible.
- Menu links: 2026 Conference, About us, Get in Touch, Support the Movement, Become a volunteer — **no Meet the Team** (`hasTeamLink: false`).
- Gate green: 173 tests pass, typecheck clean, lint only pre-existing warnings.