### PR TITLE
fix(forms): idempotent registration persist (no duplicates on retry)

### DIFF
--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { Schema } from 'effect';
 import { nanoid } from 'nanoid';
 
@@ -222,6 +224,40 @@ export type ListItemId = typeof ListItemId.Type;
 
 /** Mint a fresh, schema-valid `ListItemId`. */
 export const newListItemId = (): ListItemId => ListItemId.make(nanoid());
+
+/**
+ * nanoid's URL-safe default alphabet (`A-Za-z0-9_-`, 64 chars) — the alphabet a
+ * {@link ListItemId} validates against. {@link deterministicListItemId} maps a
+ * hash digest into it so a derived id is byte-for-byte a nanoid (same shape the
+ * brand's pattern accepts), not a hex/base64 string the schema would reject.
+ */
+const NANOID_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+
+/**
+ * Derive a **deterministic**, schema-valid `ListItemId` from an idempotency
+ * `key` — the SAME `key` always yields the SAME id. Unlike {@link newListItemId}
+ * (a fresh random nanoid per call), this lets a write be idempotent: a retry of
+ * the same logical record re-derives the same id → the same bucket key → the
+ * `Storage.put` overwrites rather than minting a duplicate object
+ * (registration-launch Branch 7.3 follow-up — the registration multi-registrant
+ * partial-write the deep review escalated). The 21-char output is shaped like a
+ * nanoid (it maps a SHA-256 digest into nanoid's alphabet), so it satisfies the
+ * `ListItemId` pattern; it is NOT a random nanoid and is not meant to be
+ * unguessable — it is a content-addressed id, derived not authored.
+ */
+export const deterministicListItemId = (key: string): ListItemId => {
+  // SHA-256 → 32 bytes; take the first 21 and fold each into nanoid's 64-char
+  // alphabet (a clean `& 63` mask — 64 divides 256, so no modulo bias).
+  const digest = createHash('sha256').update(key).digest();
+  let id = '';
+  for (let i = 0; i < 21; i += 1) {
+    // `digest` is 32 bytes, so `digest[i]` for i<21 is always a byte; `& 63` keeps
+    // the index in `[0, 63]`, always a valid position in the 64-char alphabet.
+    id += NANOID_ALPHABET.charAt((digest[i] ?? 0) & 63);
+  }
+  return ListItemId.make(id);
+};
 
 /**
  * An editable list whose items are addressed by their `id` (ADR 0006). The

--- a/app/lib/forms/registration-action.test.ts
+++ b/app/lib/forms/registration-action.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { Effect, Schema } from 'effect';
+import { DateTime, Effect, Layer, Option, Schema } from 'effect';
 import { RouterContextProvider } from 'react-router';
 
 import { defaultRegistrationForm } from '../content/pages/defaults';
@@ -10,7 +10,7 @@ import {
   type RequestRuntime,
 } from '../effect/runtime';
 import type { RouteArgs } from '../effect/router-context';
-import { Storage } from '../storage.server';
+import { type ObjectHead, NotFound, Storage, StorageError } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
 
 import { registrationAction } from './registration-action';
@@ -185,6 +185,136 @@ describe('registrationAction', () => {
     expect(new Set(notified?.map((s) => s.id)).size).toBe(2);
     const storedIds = new Set(stored.map((entry) => entry.record.id));
     expect(notified?.every((s) => storedIds.has(s.id))).toBe(true);
+  });
+
+  it('a RETRY after a mid-loop persist failure does NOT duplicate the records that landed (idempotency)', async () => {
+    // A `Storage` over a SHARED `Map` (so a retry sees what the first attempt
+    // wrote) whose `put` fails on demand — to simulate the deep review's escalated
+    // partial write: registrant #1 lands, #2's put fails, the loop aborts.
+    const entries = new Map<string, { body: string | Uint8Array; contentType: string }>();
+    let failPutsAfter = Infinity;
+    let puts = 0;
+    const sharedStorage = Layer.sync(Storage.Service, () =>
+      Storage.Service.of({
+        get: Effect.fn('Storage.get')(function* (key: string) {
+          const object = entries.get(key);
+          if (object === undefined) return yield* new NotFound({ key });
+          return {
+            stream:
+              new Response(
+                typeof object.body === 'string'
+                  ? object.body
+                  : new Blob([object.body as Uint8Array<ArrayBuffer>]),
+              ).body ?? new ReadableStream<Uint8Array>(),
+            contentType: object.contentType,
+            size: new TextEncoder().encode(String(object.body)).byteLength,
+          };
+        }),
+        put: Effect.fn('Storage.put')(function* (
+          key: string,
+          body: string | Uint8Array,
+          contentType: string,
+        ) {
+          puts += 1;
+          if (puts > failPutsAfter) {
+            return yield* new StorageError({ key, op: 'put' });
+          }
+          entries.set(key, { body, contentType });
+        }),
+        head: Effect.fn('Storage.head')((key: string) =>
+          Effect.sync(() =>
+            entries.has(key)
+              ? Option.some<ObjectHead>({
+                  size: 0,
+                  contentType: 'application/json',
+                  lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+                  etag: `"${key}"`,
+                })
+              : Option.none<ObjectHead>(),
+          ),
+        ),
+        list: Effect.fn('Storage.list')((prefix?: string) =>
+          Effect.sync(() =>
+            [...entries.keys()]
+              .filter((key) => prefix === undefined || key.startsWith(prefix))
+              .map((key) => ({
+                key,
+                size: 0,
+                lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+              })),
+          ),
+        ),
+        delete: Effect.fn('Storage.delete')((key: string) =>
+          Effect.sync(() => {
+            entries.delete(key);
+          }),
+        ),
+      }),
+    );
+
+    const runtime = makeRequestRuntimeFromLayer(makeAppLayer(sharedStorage));
+    const action = registrationAction({ notify: () => Effect.void, success });
+
+    // Attempt 1: a group of 3 where the 2nd registrant's put fails mid-loop.
+    failPutsAfter = 1; // registrant #0 persists; #1's put fails → loop aborts.
+    const body = registrantsBody(3);
+    let thrown: unknown;
+    try {
+      await action(makeRegistrationArgs(runtime, body));
+    } catch (error) {
+      thrown = error;
+    }
+    // The StorageError aborts the submission — the runtime maps it to a 500, NOT a
+    // 302 success redirect (the submit did not succeed).
+    expect(thrown).toBeInstanceOf(Response);
+    expect((thrown as Response).status).toBe(500);
+    // Exactly one record landed before the failure.
+    const argsForRead = makeRegistrationArgs(runtime, body);
+    const afterFailure = await listRegistrations(runtime, argsForRead);
+    expect(afterFailure.length).toBe(1);
+    const firstKey = afterFailure[0]?.key ?? '';
+
+    // Attempt 2: the user retries the SAME submission, storage now healthy.
+    failPutsAfter = Infinity;
+    const retryThrown = await action(makeRegistrationArgs(runtime, body)).catch(
+      (e) => e,
+    );
+    // Now it completes → redirect.
+    expect(retryThrown).toBeInstanceOf(Response);
+    expect((retryThrown as Response).status).toBe(302);
+
+    // The bucket holds EXACTLY 3 records, not 4 — registrant #0 was OVERWRITTEN in
+    // place (same content-addressed id), not duplicated, and #1/#2 completed.
+    const afterRetry = await listRegistrations(runtime, argsForRead);
+    expect(afterRetry.length).toBe(3);
+    // The record that survived attempt 1 kept its key (idempotent overwrite).
+    expect(afterRetry.map((e) => e.key)).toContain(firstKey);
+    // All three companies present exactly once.
+    const companies = afterRetry
+      .map((e) => e.record.payload['company'])
+      .sort();
+    expect(companies).toEqual([
+      'Booth Co. 0 Ltd.',
+      'Booth Co. 1 Ltd.',
+      'Booth Co. 2 Ltd.',
+    ]);
+  });
+
+  it('the same submission re-derives the SAME record ids (deterministic, content-addressed)', async () => {
+    const ids = async (): Promise<ReadonlyArray<string>> => {
+      const runtime = makeRequestRuntimeFromLayer(makeAppLayer(layerTest({})));
+      const action = registrationAction({ notify: () => Effect.void, success });
+      const body = registrantsBody(2);
+      await action(makeRegistrationArgs(runtime, body)).catch(() => {});
+      const stored = await listRegistrations(
+        runtime,
+        makeRegistrationArgs(runtime, body),
+      );
+      return stored.map((e) => e.record.id).sort();
+    };
+    // Two independent submissions of the identical payload yield the identical
+    // ids — the id is derived from the submission content + index, not random.
+    expect(await ids()).toEqual(await ids());
   });
 
   it('a notify failure still leaves BOTH registration records on the bucket (persist-first)', async () => {

--- a/app/lib/forms/registration-action.ts
+++ b/app/lib/forms/registration-action.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { Effect, Result, Schema } from 'effect';
 
 import { Content } from '../content.server';
@@ -110,9 +112,28 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
     // object apiece, written + returned before any notification runs, so a `notify`
     // failure provably cannot lose a record (settled #8). A `StorageError` aborts the
     // submission (losing a registrant must never look like success).
+    //
+    // Idempotency (the deep review's escalated partial-write): the loop is sequential
+    // and a `StorageError` on registrant K aborts after 0..K-1 are already durable. A
+    // user retry would otherwise re-mint fresh ids and DUPLICATE the records that did
+    // land. Scoping each registrant's id to `<request fingerprint>:<index>` makes the
+    // retry overwrite the same K objects instead: the fingerprint is a stable hash of
+    // THIS submission's payload (identical on a verbatim retry, different for a new
+    // submission even with identical data), and the index pins each registrant to its
+    // position. So retrying a group of 4 that failed at #3 re-writes #1/#2 in place and
+    // completes #3/#4 — no duplicates — while a genuinely new submission gets new ids.
+    const requestFingerprint = createHash('sha256')
+      .update(JSON.stringify(submission.payload))
+      .digest('hex');
     const stored: Array<Submission> = [];
-    for (const registrant of decoded.success.registrants) {
-      stored.push(yield* submissions.persist('registration', registrant));
+    for (const [index, registrant] of decoded.success.registrants.entries()) {
+      stored.push(
+        yield* submissions.persist(
+          'registration',
+          registrant,
+          `${requestFingerprint}:${index}`,
+        ),
+      );
     }
 
     yield* config.notify(stored);

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -4,7 +4,11 @@ import { Clock, Context, DateTime, Effect, Layer, Schema } from 'effect';
 
 import { Content } from '../content.server';
 import { type FormId, submissionKey } from '../content/pages/registry';
-import { IsoDate, newListItemId } from '../content/schema';
+import {
+  deterministicListItemId,
+  IsoDate,
+  newListItemId,
+} from '../content/schema';
 import { Storage, type StorageError } from '../storage.server';
 
 import type { DecodedForm } from './decode';
@@ -66,16 +70,25 @@ export class Service extends Context.Service<
   {
     /**
      * Persist one decoded form as a durable `Submission` object and return the
-     * stored record. Mints a fresh id, stamps `submittedAt` with the current
-     * calendar date, encodes the envelope + the definition-derived payload to JSON,
-     * and `Storage.put`s it at `submissions/<form>/<id>.json`. Persistence ONLY —
-     * the notification is a separate step (Branch 7.3); `persist` returning the
-     * record before any notification runs is what makes the record durable across a
-     * notify failure.
+     * stored record. Stamps `submittedAt` with the current calendar date, encodes
+     * the envelope + the definition-derived payload to JSON, and `Storage.put`s it
+     * at `submissions/<form>/<id>.json`. Persistence ONLY — the notification is a
+     * separate step (Branch 7.3); `persist` returning the record before any
+     * notification runs is what makes the record durable across a notify failure.
+     *
+     * `idempotencyKey` (optional) makes the write retry-safe: when supplied, the
+     * record's `id` is **derived deterministically** from it (`deterministicListItemId`)
+     * instead of a fresh random nanoid, so persisting the same logical record twice
+     * (e.g. a user retrying a partially-failed multi-registrant registration) writes
+     * to the SAME bucket key and overwrites rather than minting a duplicate object.
+     * Omit it for single-record submissions (contact/volunteer) where each submit is
+     * a genuinely new record. The caller owns what makes a record "the same"
+     * (registration scopes by per-request fingerprint + registrant index).
      */
     readonly persist: (
       form: FormId,
       decoded: DecodedForm,
+      idempotencyKey?: string,
     ) => Effect.Effect<Submission, StorageError>;
   }
 >()('gycc/lib/forms/submissions.server/Service') {}
@@ -95,6 +108,7 @@ export const layer = Layer.effect(
     const persist = Effect.fn('Submissions.persist')(function* (
       form: FormId,
       decoded: DecodedForm,
+      idempotencyKey?: string,
     ) {
       // The form's CMS-editable definition (Branch 5.3) — the payload codec is
       // derived from it, never re-declared (`derive-dont-sync`).
@@ -102,7 +116,15 @@ export const layer = Layer.effect(
       const schema = submissionSchema(definition);
 
       const now = yield* Clock.currentTimeMillis;
-      const id = newListItemId();
+      // With an idempotency key the id is content-addressed (a retry of the same
+      // logical record re-derives the same id → the same key → `put` overwrites);
+      // without one, a fresh random id per submit (the default for single-record
+      // forms). `idempotencyKey` is namespaced by `form` so the same key under two
+      // forms cannot collide onto one object.
+      const id =
+        idempotencyKey === undefined
+          ? newListItemId()
+          : deterministicListItemId(`${form}:${idempotencyKey}`);
       // `submittedAt` round-trips through the branded `IsoDate`: a clock-derived
       // `YYYY-MM-DD` is always a real calendar date, so a decode failure here is a
       // bug, not a user error — it dies rather than masquerading as a failure.


### PR DESCRIPTION
## What

The registration server action (`registration-action.ts`) persists each registrant sequentially. A mid-loop `StorageError` aborts the loop after `0..K-1` records are already durable on the bucket — so a user **retry** re-minted fresh ids and **duplicated** the records that already landed.

This is the partial-write the form-engine `--deep` review escalated as a product decision (PR #26). Decision: implement idempotency now while the design is fresh — the on-site path is staged behind `getForm` (RegFox carries the live channel), so this hardens it for whenever the first-party registrar goes live.

## How

Each registrant's `Submission` id is now **content-addressed** by a per-request fingerprint + index, instead of a random nanoid:

- **`deterministicListItemId(key)`** (`schema.ts`) — derives a schema-valid id (21-char, nanoid alphabet) from a SHA-256 digest, so the same key always yields the same id. Stays within the `ListItemId` brand's pattern.
- **`Submissions.persist`** gains an optional `idempotencyKey`. When present the id is deterministic (namespaced by `form`) so a re-persist **overwrites** the same `submissions/<form>/<id>.json` rather than duplicating. Omitted by contact/volunteer — each submit is a genuinely new record; their call sites + tests are unchanged.
- **`registration-action`** — `requestFingerprint = sha256(submission.payload)`; each registrant persists under `${fingerprint}:${index}`. A verbatim retry hits the same keys (idempotent); a genuinely new submission, even with identical data, gets new ids.

### Retry semantics (chosen: per-request fingerprint + index)
- Retrying a group of 4 that failed at #3 → re-writes #1/#2 **in place**, completes #3/#4. No duplicates.
- A new submission (different fingerprint) → new records, even if the data matches.

## Tests
- Retry after a mid-loop persist failure leaves **exactly N** records (not 2N−1); the survivor keeps its key (overwrite, not duplicate).
- The same submission re-derives **identical** ids (deterministic, content-addressed).
- Gate green: typecheck + lint + build + **389 tests / 0 fail**.