### PR TITLE
feat(cms): migrate Team route into the per-page CMS model + per-page image upload (Feature A)

### DIFF
--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -13,6 +13,7 @@ import {
   defaultAboutPage,
   defaultContactForm,
   defaultFaqPage,
+  defaultTeamPage,
 } from './content/pages/defaults';
 import { formObjectKey, pageObjectKey } from './content/pages/registry';
 import { AboutPage, FaqPage } from './content/pages/schema';
@@ -575,6 +576,15 @@ describe('Content.getPage / getForm multi-object read path (ADR 0008, Branch 5.3
       // No `content/pages/faq.json` in the (empty) bucket → bundled default.
       const faq = yield* content.getPage('faq');
       expect(faq).toEqual(defaultFaqPage);
+    }).pipe(Effect.provide(Layer.provideMerge(Content.layer, emptyStorage))));
+
+  it.effect('getPage("team") falls back to the bundled team default (read path sees the new page)', () =>
+    Effect.gen(function* () {
+      const content = yield* Content.Service;
+      // No `content/pages/team.json` in the (empty) bucket → bundled default.
+      // Proves `team` is preloaded through `PAGE_IDS` into the eager cache map.
+      const team = yield* content.getPage('team');
+      expect(team).toEqual(defaultTeamPage);
     }).pipe(Effect.provide(Layer.provideMerge(Content.layer, emptyStorage))));
 
   it.effect('getForm falls back to the bundled default when the object is absent', () =>

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -25,9 +25,9 @@ import {
   type PageContent,
   type PageId,
 } from './content/pages/registry';
+import { assetUrl } from './content/asset-url';
 import { SiteContent } from './content/schema';
 import type {
-  AssetKey,
   Conference as DocConference,
   IsoDate,
   Seminar as DocSeminar,
@@ -179,18 +179,9 @@ export type Translation = Record<string, string>;
 // Document → boundary conversion (`derive-dont-sync`, `boundary-discipline`)
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve a bucket object key (`2024/speakers/matt.png`) to the URL the HTML
- * renders (`/images/2024/speakers/matt.png`). Every managed image is served
- * through the Effect server's `GET /images/*` route (C5, mirroring
- * paulo-suzanne's `bucketResponse`): it streams the bucket object when present
- * and falls back to the bundled `public/<key>` file otherwise. So a bucket-less
- * dev/prod still serves today's `public/` art (the default keys map 1:1 onto the
- * `public/` tree), while an uploaded image at the same key transparently
- * overrides it — with no change to any component (`derive-dont-sync`,
- * `boundary-discipline`).
- */
-const assetUrl = (key: AssetKey): string => `/images/${key}`;
+// `assetUrl` (key → `/images/<key>`) is the ONE URL-resolution rule, extracted to
+// the leaf module `./content/asset-url` so the per-page projection (`pages/project`)
+// shares it with no import cycle (`derive-dont-sync`). Imported above.
 
 /**
  * Widen an ISO calendar date to the existing end-of-day-UTC millisecond the

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -597,7 +597,7 @@ export const layer = Layer.effect(
       });
 
     // Build one independent cache per Page and per Form object up front (the id
-    // sets are closed and small — 7 pages + 3 forms). Eager construction keeps
+    // sets are closed and small — 8 pages + 3 forms). Eager construction keeps
     // each `getPage` / `getForm` a pure cache read with no first-call lock, and
     // the bust dispatch a direct record lookup over the closed id.
     const pageCaches = {} as Record<PageId, ObjectCache>;

--- a/app/lib/content/admin-form.test.ts
+++ b/app/lib/content/admin-form.test.ts
@@ -8,13 +8,19 @@ import {
   imageUploadTarget,
   isAcceptedImageType,
   normalizeFaqAnswers,
+  pruneKeylessImageOverrides,
   setAtPath,
   uploadedImageKey,
   type Json,
 } from './admin-form';
 import { defaultContent } from './defaults';
 import { SiteContent, newListItemId } from './schema';
-import { DraftFaqPage, FaqPage } from './pages/schema';
+import {
+  DraftFaqPage,
+  DraftTeamPage,
+  FaqPage,
+  TeamPage,
+} from './pages/schema';
 
 /**
  * The `/admin` editor edits the one `SiteContent` document via a
@@ -183,6 +189,109 @@ describe('normalizeFaqAnswers', () => {
           Schema.decodeUnknownEffect(FaqPage)(merged),
         );
         expect(publishExit._tag).toBe('Failure');
+      }),
+  );
+});
+
+describe('pruneKeylessImageOverrides', () => {
+  test('drops an alt-only image slot with no key on a base that has none', () => {
+    // The Team editor always posts BOTH image slots' alt inputs. On a plain save
+    // with no upload, the override is `{ <slot>: { alt: { en, fr } } }` — no key.
+    // That object is draft-valid but publish-invalid (the strict `ImageRef` needs
+    // a `key`), so it is pruned, leaving the slot ABSENT (section-skip).
+    const override = assembleOverrides(
+      entries({
+        'subtitle.en': 'Sub',
+        'subtitle.fr': 'Sous',
+        'groupPhoto.alt.en': '',
+        'groupPhoto.alt.fr': '',
+        'portrait.alt.en': '',
+        'portrait.alt.fr': '',
+      }),
+    );
+    const pruned = pruneKeylessImageOverrides({}, override) as Record<
+      string,
+      unknown
+    >;
+    expect('groupPhoto' in pruned).toBe(false);
+    expect('portrait' in pruned).toBe(false);
+    expect(pruned['subtitle']).toEqual({ en: 'Sub', fr: 'Sous' });
+  });
+
+  test('keeps an alt edit when the base slot already carries an uploaded key', () => {
+    // Once an image IS uploaded (the draft base has `key`), the alt override must
+    // land onto the existing image — the upload-first / fill-alt-second flow.
+    const base: Json = {
+      groupPhoto: { key: 'images/uploads/group-1.webp' },
+    };
+    const override = assembleOverrides(
+      entries({
+        'groupPhoto.alt.en': 'Group photo',
+        'groupPhoto.alt.fr': 'Photo de groupe',
+        'portrait.alt.en': '',
+        'portrait.alt.fr': '',
+      }),
+    );
+    const pruned = pruneKeylessImageOverrides(base, override) as Record<
+      string,
+      { alt?: { en?: string } }
+    >;
+    expect(pruned['groupPhoto']?.alt?.en).toBe('Group photo');
+    // The untouched portrait (keyless on base + override) is still dropped.
+    expect('portrait' in pruned).toBe(false);
+  });
+
+  test('keeps an override that carries a freshly-uploaded key', () => {
+    const override: Json = {
+      groupPhoto: { key: 'images/uploads/group-1.webp' },
+    };
+    const pruned = pruneKeylessImageOverrides({}, override) as Record<
+      string,
+      unknown
+    >;
+    expect('groupPhoto' in pruned).toBe(true);
+  });
+
+  test('a non-team override (no image slots) passes through verbatim', () => {
+    const override: Json = {
+      title: { en: 'About', fr: 'À propos' },
+      paragraphs: { 'list-id': { text: { en: 'x', fr: 'y' } } },
+    };
+    expect(pruneKeylessImageOverrides({}, override)).toEqual(override);
+  });
+
+  it.effect(
+    'a plain Team save (no image) merges to a draft-valid AND publish-valid doc',
+    () =>
+      Effect.gen(function* () {
+        // The full route invariant: pruned override → merge → decode draft AND
+        // strict. Without the prune, the strict decode fails `groupPhoto.key:
+        // Missing key` (the bug the --deep review caught).
+        const base: Json = {
+          title: [{ _tag: 'text', value: { en: 'Team', fr: 'Équipe' } }],
+          subtitle: { en: 'Old', fr: 'Vieux' },
+          boardHeading: { en: 'Board', fr: 'Conseil' },
+        };
+        const override = pruneKeylessImageOverrides(
+          base,
+          assembleOverrides(
+            entries({
+              'subtitle.en': 'New subtitle',
+              'subtitle.fr': 'Nouveau sous-titre',
+              'groupPhoto.alt.en': '',
+              'groupPhoto.alt.fr': '',
+              'portrait.alt.en': '',
+              'portrait.alt.fr': '',
+            }),
+          ),
+        );
+        const merged = deepMerge(base, override);
+        const draft = yield* Schema.decodeUnknownEffect(DraftTeamPage)(merged);
+        const strict = yield* Schema.decodeUnknownEffect(TeamPage)(merged);
+        expect(draft.subtitle?.en).toBe('New subtitle');
+        expect(strict.subtitle.en).toBe('New subtitle');
+        expect(strict.groupPhoto).toBeUndefined();
+        expect(strict.portrait).toBeUndefined();
       }),
   );
 });

--- a/app/lib/content/admin-form.ts
+++ b/app/lib/content/admin-form.ts
@@ -296,6 +296,53 @@ export const normalizeFaqAnswers = (override: Json): Json => {
   return { ...override, items: rewrittenItems };
 };
 
+/** A non-empty `key` string on an image-slot object (in a base or an override). */
+const hasImageKey = (slot: Json | undefined): boolean =>
+  slot !== undefined &&
+  isPlainObject(slot) &&
+  typeof slot['key'] === 'string' &&
+  slot['key'].trim() !== '';
+
+/**
+ * Drop an optional image-slot override (`groupPhoto` / `portrait` on the Team
+ * page) that carries ONLY alt text and no uploaded `key` — UNLESS the current
+ * draft already has a `key` for that slot (then the alt edit must land onto the
+ * existing image).
+ *
+ * Why this seam (mirrors `normalizeFaqAnswers`, registration-launch Branch 5.5):
+ * the Team editor ALWAYS renders both image slots' alt-text `Bilingual` inputs,
+ * which always post `groupPhoto.alt.en/.fr` + `portrait.alt.en/.fr`. On a plain
+ * save with no image uploaded, `assembleOverrides` therefore produces a
+ * `groupPhoto: { alt: { en, fr } }` object with NO `key`. That is DRAFT-valid
+ * (the lax `DraftImageRef` makes `key` optional) but PUBLISH-INVALID: the strict
+ * `ImageRef` sees the slot as *present* and rejects it with `groupPhoto.key:
+ * Missing key`. Section-skip is for *absence* of the whole slot (ADR 0008), not a
+ * present-but-keyless object — so the keyless alt-only override is pruned, leaving
+ * the slot absent and the save/publish path clean. Once an image IS uploaded (the
+ * draft base carries `key`), the alt override is kept so the upload-first /
+ * fill-alt-second flow completes (ADR 0006). Only the two named image slots are
+ * touched; every other override passes through verbatim.
+ */
+export const pruneKeylessImageOverrides = (base: Json, override: Json): Json => {
+  if (!isPlainObject(override)) return override;
+  const baseObject = isPlainObject(base) ? base : undefined;
+  const result: MutableJsonObject = {};
+  for (const key of Object.keys(override)) {
+    const slot = override[key];
+    if (slot === undefined) continue;
+    if (
+      (key === 'groupPhoto' || key === 'portrait') &&
+      isPlainObject(slot) &&
+      !hasImageKey(slot) &&
+      !hasImageKey(baseObject?.[key])
+    ) {
+      continue; // keyless, no existing image — drop so the slot stays absent
+    }
+    result[key] = slot;
+  }
+  return result;
+};
+
 /**
  * Deep-merge `overrides` onto `base`, returning a new value. `base` and
  * `overrides` are never mutated.

--- a/app/lib/content/asset-url.ts
+++ b/app/lib/content/asset-url.ts
@@ -1,0 +1,18 @@
+import type { AssetKey } from './schema';
+
+/**
+ * Resolve a bucket object key (`2024/speakers/matt.png`) to the URL the HTML
+ * renders (`/images/2024/speakers/matt.png`). Every managed image is served
+ * through the Effect server's `GET /images/*` route: it streams the bucket
+ * object when present and falls back to the bundled `public/<key>` file
+ * otherwise. So a bucket-less dev/prod still serves today's `public/` art (the
+ * default keys map 1:1 onto the `public/` tree), while an uploaded image at the
+ * same key transparently overrides it — with no change to any component.
+ *
+ * This is a LEAF module (it imports only the `AssetKey` type, nothing from
+ * `content.server` or `pages/project`) so BOTH the site read path
+ * (`content.server.ts`) and the per-page projection (`pages/project.ts`) share
+ * ONE URL-resolution rule with no import cycle (`derive-dont-sync`,
+ * `boundary-discipline`).
+ */
+export const assetUrl = (key: AssetKey): string => `/images/${key}`;

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -7,6 +7,7 @@ import { Storage } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
 import {
   assembleOverrides,
+  imageUploadTarget,
   isAcceptedImageType,
   uploadedImageKey,
   type Json,
@@ -614,5 +615,60 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect(result.faqEdited).toBe('Edited?');
     // About's cache survived the FAQ publish — per-object isolation holds.
     expect(result.aboutSameRef).toBe(true);
+  });
+
+  it('upload:groupPhoto.key stores bytes + rewrites the team draft key (REUSED applyImageUpload)', async () => {
+    const teamScope = pageScope('team');
+    // The same `upload:<keyPath>` intent the ImageUpload control posts; the route
+    // derives the target via `imageUploadTarget`, mirroring `content.tsx`.
+    const target = imageUploadTarget('upload:groupPhoto.key');
+    expect(target).toBe('groupPhoto.key');
+
+    const jpg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const contentType = 'image/jpeg';
+    expect(isAcceptedImageType(contentType)).toBe(true);
+
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const storage = yield* Storage.Service;
+
+        const key = uploadedImageKey(target!, contentType, 1_700_000_000_000);
+        yield* storage.put(key, jpg, contentType);
+        // The team page has no bucket object yet — it opens on the bundled default
+        // (which OMITS the image). The upload lands the key BEFORE any alt text,
+        // proving the lax `DraftTeamPage` tolerance (key without alt).
+        yield* editor.applyImageUpload(teamScope, target!, key);
+
+        const draft = yield* editor.load(teamScope);
+        const served = yield* storage.get(key);
+        const bytes = new Uint8Array(
+          yield* Effect.promise(() => new Response(served.stream).arrayBuffer()),
+        );
+        return {
+          key,
+          draftKey: String(draft.content.groupPhoto?.key),
+          draftAlt: draft.content.groupPhoto?.alt,
+          bytes,
+        };
+      }),
+    );
+
+    expect(String(result.key)).toMatch(
+      /^images\/uploads\/groupPhoto-key-1700000000000\.jpg$/,
+    );
+    expect(result.draftKey).toBe(result.key);
+    // Key landed with NO alt yet — the upload-first / fill-alt-second flow.
+    expect(result.draftAlt).toBeUndefined();
+    expect([...result.bytes]).toEqual([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+  });
+
+  it('the route image-upload guards reject a non-image MIME and an empty file', () => {
+    // The per-page action reuses `content.tsx`'s guards verbatim: a non-accepted
+    // MIME is a 400, and `imageUploadTarget` only fires for the `upload:` intent.
+    expect(isAcceptedImageType('application/pdf')).toBe(false);
+    expect(isAcceptedImageType('image/png')).toBe(true);
+    expect(imageUploadTarget('save-draft')).toBeNull();
+    expect(imageUploadTarget('upload:portrait.key')).toBe('portrait.key');
   });
 });

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -663,12 +663,13 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect([...result.bytes]).toEqual([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
   });
 
-  it('the route image-upload guards reject a non-image MIME and an empty file', () => {
-    // The per-page action reuses `content.tsx`'s guards verbatim: a non-accepted
-    // MIME is a 400, and `imageUploadTarget` only fires for the `upload:` intent.
-    expect(isAcceptedImageType('application/pdf')).toBe(false);
-    expect(isAcceptedImageType('image/png')).toBe(true);
+  // The route-level 400 guards (empty file / non-image MIME) are driven against
+  // the REAL action in `app/routes/admin/pages.$page.action.test.ts`; here we
+  // only pin the intent→target derivation the upload branch keys off.
+  it('imageUploadTarget fires only for the upload: intent (else save/publish)', () => {
     expect(imageUploadTarget('save-draft')).toBeNull();
+    expect(imageUploadTarget('publish')).toBeNull();
     expect(imageUploadTarget('upload:portrait.key')).toBe('portrait.key');
+    expect(imageUploadTarget('upload:groupPhoto.key')).toBe('groupPhoto.key');
   });
 });

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -663,6 +663,107 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect([...result.bytes]).toEqual([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
   });
 
+  it('a plain Team save (no image uploaded) PUBLISHES — keyless alt slots pruned', async () => {
+    // The editor ALWAYS renders both image slots' alt `Bilingual` inputs, so a
+    // plain save posts `groupPhoto.alt`/`portrait.alt` with NO key. Before the
+    // prune that produced a present-but-keyless image object — draft-valid but
+    // publish-INVALID (`groupPhoto.key: Missing key`), so the admin could not
+    // publish the team page without uploading BOTH images. This drives the real
+    // editDocument → publish path and asserts publish SUCCEEDS with both slots
+    // section-skipped.
+    const teamScope = pageScope('team');
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const content = yield* Content.Service;
+        const override = assembleOverrides([
+          ['subtitle.en', 'The team subtitle'],
+          ['subtitle.fr', 'Le sous-titre'],
+          ['boardHeading.en', 'Board of Directors'],
+          ['boardHeading.fr', "Conseil d'administration"],
+          ['groupPhoto.alt.en', ''],
+          ['groupPhoto.alt.fr', ''],
+          ['portrait.alt.en', ''],
+          ['portrait.alt.fr', ''],
+        ]) as Json;
+        yield* TestClock.adjust('1 second');
+        yield* editor.editDocument(teamScope, override);
+        const publishExit = yield* Effect.exit(editor.publish(teamScope));
+        const live = yield* content.getPage('team');
+        return {
+          publishTag: publishExit._tag,
+          subtitleEn: live.subtitle.en,
+          groupPhoto: live.groupPhoto,
+          portrait: live.portrait,
+        };
+      }),
+    );
+    expect(result.publishTag).toBe('Success');
+    expect(result.subtitleEn).toBe('The team subtitle');
+    // Both image slots stay absent (section-skip), not present-but-keyless.
+    expect(result.groupPhoto).toBeUndefined();
+    expect(result.portrait).toBeUndefined();
+  });
+
+  it('upload key → fill alt → PUBLISH: the alt lands on the existing image', async () => {
+    // Once an image IS uploaded (draft carries `key`), the alt override is kept
+    // (NOT pruned) so the upload-first / fill-alt-second flow completes through a
+    // strict publish.
+    const teamScope = pageScope('team');
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const content = yield* Content.Service;
+        const storage = yield* Storage.Service;
+
+        const key = uploadedImageKey(
+          'groupPhoto.key',
+          'image/jpeg',
+          1_700_000_000_000,
+        );
+        yield* storage.put(
+          key,
+          new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]),
+          'image/jpeg',
+        );
+        yield* TestClock.adjust('1 second');
+        yield* editor.applyImageUpload(teamScope, 'groupPhoto.key', key);
+
+        // Fill the alt + chrome (the alt override carries NO key — it must merge
+        // onto the just-uploaded key, not be pruned).
+        yield* TestClock.adjust('1 second');
+        yield* editor.editDocument(
+          teamScope,
+          assembleOverrides([
+            ['subtitle.en', 'Sub'],
+            ['subtitle.fr', 'Sous'],
+            ['boardHeading.en', 'Board'],
+            ['boardHeading.fr', 'Conseil'],
+            ['groupPhoto.alt.en', 'The 2022 group photo'],
+            ['groupPhoto.alt.fr', 'La photo de groupe 2022'],
+            ['portrait.alt.en', ''],
+            ['portrait.alt.fr', ''],
+          ]) as Json,
+        );
+        const publishExit = yield* Effect.exit(editor.publish(teamScope));
+        const live = yield* content.getPage('team');
+        return {
+          publishTag: publishExit._tag,
+          groupPhotoKey: String(live.groupPhoto?.key),
+          groupPhotoAltEn: live.groupPhoto?.alt.en,
+          portrait: live.portrait,
+        };
+      }),
+    );
+    expect(result.publishTag).toBe('Success');
+    expect(result.groupPhotoKey).toBe(
+      'images/uploads/groupPhoto-key-1700000000000.jpg',
+    );
+    expect(result.groupPhotoAltEn).toBe('The 2022 group photo');
+    // The portrait (keyless on both base + override) is still section-skipped.
+    expect(result.portrait).toBeUndefined();
+  });
+
   // The route-level 400 guards (empty file / non-image MIME) are driven against
   // the REAL action in `app/routes/admin/pages.$page.action.test.ts`; here we
   // only pin the intent→target derivation the upload branch keys off.

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -11,7 +11,12 @@ import {
   bustSite,
   type BustTarget,
 } from '../content.server';
-import { deepMerge, setAtPath, type Json } from './admin-form';
+import {
+  deepMerge,
+  pruneKeylessImageOverrides,
+  setAtPath,
+  type Json,
+} from './admin-form';
 import { defaultContent } from './defaults';
 import { backfillListItemIds } from './id-backfill';
 import { applyListEdit, type ListOp } from './list-edit';
@@ -596,7 +601,12 @@ export const layer = Layer.effect(
     >(scope: S, override: Json) {
       const codec = resolveScope(scope);
       const base = yield* encodedCurrent(codec, scope);
-      const merged = deepMerge(base, override);
+      // Drop an alt-only image override (Team `groupPhoto` / `portrait` with no
+      // uploaded key and no existing key on the draft) so a present-but-keyless
+      // image object never lands — that object is draft-valid but PUBLISH-invalid
+      // (`<slot>.key: Missing key`). A no-op for every scope without those slots.
+      const pruned = pruneKeylessImageOverrides(base, override);
+      const merged = deepMerge(base, pruned);
       const decoded = yield* decodeOrReject(codec, merged);
       return (yield* storeDraft(codec, decoded)) as ScopeEncoded<S>;
     });

--- a/app/lib/content/pages/defaults.ts
+++ b/app/lib/content/pages/defaults.ts
@@ -9,6 +9,7 @@ import {
   FaqPage,
   GivePage,
   HomePage,
+  TeamPage,
   VolunteerPage,
 } from './schema';
 
@@ -379,6 +380,45 @@ export const defaultHomePage: HomePage = Schema.decodeUnknownSync(HomePage)({
       en: 'Don’t forget to follow us on social media to get to know our team and stay up-to-date!',
       fr: 'N’oubliez pas de nous suivre sur les réseaux sociaux pour faire connaissance avec notre équipe et rester à jour!',
     },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Team (page chrome — the per-member roster stays on site.json via getTeam())
+// ---------------------------------------------------------------------------
+
+/**
+ * The Team page chrome transcribed from today's flat-key copy (`team.title` +
+ * `team.title.movement`, `team.subtitle`, `team.board`). The italic `movement` run
+ * is carried as an `italic` token so the `<span className="italic">…</span>` styling
+ * of the pre-migration route survives without HTML (closed RichText model).
+ *
+ * The two image slots (`groupPhoto` / `portrait`) are OMITTED here (optionalKey ⇒
+ * section-skip): the real photos are uploaded via the CMS at launch, mirroring how
+ * the site defaults map `public/` art only once an upload overrides it. A brand-new
+ * `team.json` therefore renders the roster + copy with NO broken `<img>`; the launch
+ * upload sets `groupPhoto` / `portrait`. (The legacy `public/team/group-van-2022.jpg`
+ * + `public/logo/gycc.png` stay on disk until an upload supersedes them.)
+ */
+export const defaultTeamPage: TeamPage = Schema.decodeUnknownSync(TeamPage)({
+  title: [
+    {
+      _tag: 'text',
+      value: {
+        en: 'The people behind the ',
+        fr: 'Les personnes derrière le ',
+      },
+    },
+    { _tag: 'italic', value: { en: 'movement', fr: 'mouvement' } },
+    { _tag: 'text', value: { en: '.', fr: '.' } },
+  ],
+  subtitle: {
+    en: 'We are GYC Canada, young people dedicated to spreading the Gospel and living the lives that God has planned for us. As ambassadors of Christ in this world, we are fulfilling His purpose for us and go boldly where our Savior leads.',
+    fr: "Nous sommes GYC Canada, des jeunes dédiés à faire connaître l'Évangile et à vivre les vies que Dieu a prévues pour nous. En tant qu'ambassadeurs de Christ dans ce monde, nous accomplissons Sa volonté pour nous et allons avec courage là où notre Seigneur nous conduit.",
+  },
+  boardHeading: {
+    en: 'Board of Directors',
+    fr: 'Conseil d’administration',
   },
 });
 

--- a/app/lib/content/pages/project.test.ts
+++ b/app/lib/content/pages/project.test.ts
@@ -150,7 +150,14 @@ describe('per-page projection', () => {
   it('team: title projects to runs, absent images are undefined (section-skip)', () => {
     // The bundled default omits both image slots.
     const en = toTeamView(defaultTeamPage, Locale.En);
-    expect(en.title.some((run) => run.kind === 'italic')).toBe(true);
+    // Pin the FULL run sequence (not just "some italic run"): a regression that
+    // dropped/reordered the surrounding text runs must fail.
+    expect(en.title).toEqual([
+      { kind: 'text', value: 'The people behind the ' },
+      { kind: 'italic', value: 'movement' },
+      { kind: 'text', value: '.' },
+    ]);
+    expect(en.title).toEqual(toRichText(defaultTeamPage.title, Locale.En));
     expect(en.subtitle).toBe(defaultTeamPage.subtitle.en);
     expect(en.boardHeading).toBe(defaultTeamPage.boardHeading.en);
     expect(en.groupPhoto).toBeUndefined();

--- a/app/lib/content/pages/project.test.ts
+++ b/app/lib/content/pages/project.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { Schema } from 'effect';
 
 import { Locale } from '../../localization/localization';
 import {
@@ -7,6 +8,7 @@ import {
   defaultFaqPage,
   defaultGivePage,
   defaultHomePage,
+  defaultTeamPage,
   defaultVolunteerPage,
 } from './defaults';
 import {
@@ -16,9 +18,10 @@ import {
   toGiveView,
   toHomeView,
   toRichText,
+  toTeamView,
   toVolunteerView,
 } from './project';
-import { MailtoHref, RichText, RichTextNode } from './schema';
+import { MailtoHref, RichText, RichTextNode, TeamPage } from './schema';
 
 /**
  * The per-locale boundary projection (registration-launch Branch 5.4): the
@@ -142,6 +145,46 @@ describe('per-page projection', () => {
     expect(en.title.some((run) => run.kind === 'bold')).toBe(true);
     expect(en.subtitle).toBe(defaultVolunteerPage.subtitle.en);
     expect(en.directions).toBe(defaultVolunteerPage.directions.en);
+  });
+
+  it('team: title projects to runs, absent images are undefined (section-skip)', () => {
+    // The bundled default omits both image slots.
+    const en = toTeamView(defaultTeamPage, Locale.En);
+    expect(en.title.some((run) => run.kind === 'italic')).toBe(true);
+    expect(en.subtitle).toBe(defaultTeamPage.subtitle.en);
+    expect(en.boardHeading).toBe(defaultTeamPage.boardHeading.en);
+    expect(en.groupPhoto).toBeUndefined();
+    expect(en.portrait).toBeUndefined();
+
+    const fr = toTeamView(defaultTeamPage, Locale.Fr);
+    expect(fr.boardHeading).toBe(defaultTeamPage.boardHeading.fr);
+  });
+
+  it('team: a present image projects to /images/<key> + the locale alt', () => {
+    const page = Schema.decodeUnknownSync(TeamPage)({
+      title: [{ _tag: 'text', value: { en: 'Team', fr: 'Équipe' } }],
+      subtitle: { en: 'Sub.', fr: 'Sous.' },
+      boardHeading: { en: 'Board', fr: 'Conseil' },
+      groupPhoto: {
+        key: '2026/team/group.jpg',
+        alt: { en: 'A group photo.', fr: 'Une photo de groupe.' },
+      },
+      portrait: {
+        key: '2026/team/logo.png',
+        alt: { en: 'Logo.', fr: 'Logo FR.' },
+      },
+    });
+
+    const en = toTeamView(page, Locale.En);
+    expect(en.groupPhoto).toEqual({
+      src: '/images/2026/team/group.jpg',
+      alt: 'A group photo.',
+    });
+    expect(en.portrait?.src).toBe('/images/2026/team/logo.png');
+
+    const fr = toTeamView(page, Locale.Fr);
+    expect(fr.groupPhoto?.alt).toBe('Une photo de groupe.');
+    expect(fr.portrait?.alt).toBe('Logo FR.');
   });
 
   it('home: nested evergreen copy collapses to the locale', () => {

--- a/app/lib/content/pages/project.ts
+++ b/app/lib/content/pages/project.ts
@@ -1,4 +1,5 @@
 import type { Locale } from '../../localization/localization';
+import { assetUrl } from '../asset-url';
 import type {
   AboutPage,
   ArchivePage,
@@ -8,6 +9,7 @@ import type {
   HomePage,
   RichText,
   RichTextNode,
+  TeamPage,
   VolunteerPage,
 } from './schema';
 
@@ -130,6 +132,21 @@ export interface HomeView {
   };
 }
 
+/**
+ * The Team page view: the projected RichText title runs, the subtitle + board
+ * heading collapsed to this locale, and EACH image slot projected to a renderable
+ * `{ src, alt }` — or `undefined` when the slot is absent (section-skip). The
+ * route renders `<img>` only for a present slot, so an empty `team.json` shows no
+ * broken image (`make-impossible-states-unrepresentable`, ADR 0008).
+ */
+export interface TeamView {
+  readonly title: readonly RichTextRun[];
+  readonly subtitle: string;
+  readonly boardHeading: string;
+  readonly groupPhoto?: { readonly src: string; readonly alt: string };
+  readonly portrait?: { readonly src: string; readonly alt: string };
+}
+
 // ---------------------------------------------------------------------------
 // Per-page converters (document → this-locale view)
 // ---------------------------------------------------------------------------
@@ -207,4 +224,18 @@ export const toHomeView = (page: HomePage, locale: Locale): HomeView => ({
     subtitle: page.newsletter.subtitle[locale],
     socials: page.newsletter.socials[locale],
   },
+});
+
+export const toTeamView = (page: TeamPage, locale: Locale): TeamView => ({
+  title: toRichText(page.title, locale),
+  subtitle: page.subtitle[locale],
+  boardHeading: page.boardHeading[locale],
+  // Each optional slot projects to `{ src, alt }` or `undefined` (section-skip).
+  // `assetUrl` is the shared leaf-module URL rule (`derive-dont-sync`).
+  groupPhoto: page.groupPhoto
+    ? { src: assetUrl(page.groupPhoto.key), alt: page.groupPhoto.alt[locale] }
+    : undefined,
+  portrait: page.portrait
+    ? { src: assetUrl(page.portrait.key), alt: page.portrait.alt[locale] }
+    : undefined,
 });

--- a/app/lib/content/pages/registry.test.ts
+++ b/app/lib/content/pages/registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { Schema } from 'effect';
+
+import { defaultTeamPage } from './defaults';
+import { PAGE_IDS, PAGE_SPECS } from './registry';
+import { DraftTeamPage, TeamPage } from './schema';
+
+/**
+ * The Page registry is the SINGLE registration point for an evergreen page (its
+ * id, schema, draft boundary, and default). Adding `team` must surface it through
+ * the one closed `PAGE_IDS` set (so the read path, the admin nav, and the editor
+ * all derive it — `derive-dont-sync`) and wire it to the lax `DraftTeamPage` draft
+ * boundary so the upload-first / fill-alt-second flow works (ADR 0006).
+ */
+describe('team page registration (ADR 0008)', () => {
+  test('team is a registered PageId (8 pages total now)', () => {
+    expect(PAGE_IDS).toContain('team');
+    expect(PAGE_IDS.length).toBe(8);
+  });
+
+  test('PAGE_SPECS.team wires the strict + draft schemas and the default', () => {
+    const spec = PAGE_SPECS.team;
+    expect(spec.schema).toBe(TeamPage);
+    expect(spec.draftSchema).toBe(DraftTeamPage);
+    expect(spec.default).toBe(defaultTeamPage);
+    // draft ≠ strict: team carries optional images whose alt may be unfilled.
+    expect(spec.draftSchema).not.toBe(spec.schema);
+  });
+
+  test('the bundled defaultTeamPage decodes at module load (omitted images section-skip)', () => {
+    // `defaults.ts` decodes through `decodeUnknownSync` at import, so a malformed
+    // transcription would already have thrown; re-assert the decode-safe default
+    // carries the chrome and NO image (the launch upload sets them).
+    const reDecoded = Schema.decodeUnknownSync(TeamPage)(
+      Schema.encodeUnknownSync(TeamPage)(defaultTeamPage),
+    );
+    expect(reDecoded.groupPhoto).toBeUndefined();
+    expect(reDecoded.portrait).toBeUndefined();
+    expect(reDecoded.subtitle.en.startsWith('We are GYC Canada')).toBe(true);
+  });
+});

--- a/app/lib/content/pages/registry.ts
+++ b/app/lib/content/pages/registry.ts
@@ -9,6 +9,7 @@ import {
   defaultGivePage,
   defaultHomePage,
   defaultRegistrationForm,
+  defaultTeamPage,
   defaultVolunteerForm,
   defaultVolunteerPage,
 } from './defaults';
@@ -21,9 +22,11 @@ import {
   DraftArchivePage,
   DraftFaqPage,
   DraftGivePage,
+  DraftTeamPage,
   FaqPage,
   GivePage,
   HomePage,
+  TeamPage,
   VolunteerPage,
 } from './schema';
 import { type ListItemId } from '../schema';
@@ -74,6 +77,7 @@ export const PageId = Schema.Literals([
   'volunteer',
   'archive',
   'home',
+  'team',
 ]);
 export type PageId = typeof PageId.Type;
 
@@ -187,6 +191,9 @@ export const PAGE_SPECS = {
   volunteer: pageSpec(VolunteerPage, defaultVolunteerPage),
   archive: draftPageSpec(ArchivePage, DraftArchivePage, defaultArchivePage),
   home: pageSpec(HomePage, defaultHomePage),
+  // Draft ≠ strict: a present image's `alt` may be unfilled in the draft (upload
+  // first, fill alt second), so team wires the laxer `DraftTeamPage` (ADR 0006).
+  team: draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage),
 } as const satisfies { readonly [P in PageId]: ObjectSpec<unknown, unknown> };
 
 /**

--- a/app/lib/content/pages/schema.test.ts
+++ b/app/lib/content/pages/schema.test.ts
@@ -18,12 +18,14 @@ import {
   DraftArchivePage,
   DraftFaqPage,
   DraftGivePage,
+  DraftTeamPage,
   FaqPage,
   GivePage,
   HomePage,
   LinkHref,
   RichText,
   RichTextNode,
+  TeamPage,
   VolunteerPage,
 } from './schema';
 
@@ -65,6 +67,96 @@ describe('per-page default round-trips', () => {
         expect(restored).toEqual(value);
       }));
   }
+});
+
+/**
+ * The Team page carries a RichText title plus TWO optional `ImageRef` slots. These
+ * pin the decode-safety contract the migration depends on:
+ *   - a `team.json` WITHOUT either image still decodes (section-skip default), and
+ *     WITH each present image round-trips losslessly (the present image carries a
+ *     strict `{ key, alt }`);
+ *   - a present image whose `key` is not a valid `AssetKey` (a leading-`/` path)
+ *     is REJECTED — the strict `AssetKey` brand still gates a present slot;
+ *   - a stored JSON missing BOTH optional image fields decodes (the
+ *     required-field-on-an-already-published-doc gate: the fields are
+ *     `optionalKey`, so adding them never breaks an extant object);
+ *   - the DRAFT variant tolerates an uploaded `key` with NO alt yet (the
+ *     upload-first / fill-alt-second flow), while strict publish still requires both.
+ */
+describe('TeamPage (RichText title + two optional ImageRef slots)', () => {
+  const KEY = '2026/team/group.jpg';
+  const baseEncoded = {
+    title: [
+      { _tag: 'text', value: { en: 'The people behind the ', fr: 'Les personnes derrière le ' } },
+      { _tag: 'italic', value: { en: 'movement', fr: 'mouvement' } },
+      { _tag: 'text', value: { en: '.', fr: '.' } },
+    ],
+    subtitle: { en: 'We are GYC Canada.', fr: 'Nous sommes GYC Canada.' },
+    boardHeading: { en: 'Board of Directors', fr: 'Conseil d’administration' },
+  };
+
+  it.effect('round-trips WITHOUT either image (section-skip)', () =>
+    Effect.gen(function* () {
+      const decoded = yield* Schema.decodeUnknownEffect(TeamPage)(baseEncoded);
+      const restored = yield* roundTrips(TeamPage, decoded);
+      expect(restored).toEqual(decoded);
+      expect(restored.groupPhoto).toBeUndefined();
+      expect(restored.portrait).toBeUndefined();
+    }));
+
+  it.effect('round-trips WITH each present image (strict {key, alt})', () =>
+    Effect.gen(function* () {
+      const decoded = yield* Schema.decodeUnknownEffect(TeamPage)({
+        ...baseEncoded,
+        groupPhoto: { key: KEY, alt: { en: 'A group photo.', fr: 'Une photo de groupe.' } },
+        portrait: { key: '2026/team/portrait.png', alt: { en: 'Logo.', fr: 'Logo.' } },
+      });
+      const restored = yield* roundTrips(TeamPage, decoded);
+      expect(restored).toEqual(decoded);
+      expect(String(restored.groupPhoto?.key)).toBe(KEY);
+      expect(restored.portrait?.alt.fr).toBe('Logo.');
+    }));
+
+  test('a present image with a NON-AssetKey key (leading "/") fails decode', () => {
+    const result = Schema.decodeUnknownResult(TeamPage)({
+      ...baseEncoded,
+      groupPhoto: { key: '/team/group.jpg', alt: { en: 'x', fr: 'x' } },
+    });
+    expect(result._tag).toBe('Failure');
+  });
+
+  test('a present image with a blank-locale alt fails decode (skip != half-filled)', () => {
+    const result = Schema.decodeUnknownResult(TeamPage)({
+      ...baseEncoded,
+      groupPhoto: { key: KEY, alt: { en: '', fr: '' } },
+    });
+    expect(result._tag).toBe('Failure');
+  });
+
+  test('a stored team.json missing BOTH optional image fields decodes (decode-migration gate)', () => {
+    // The exact required-field-on-a-published-doc trap: adding `groupPhoto` /
+    // `portrait` must NOT break an object that predates them. `optionalKey` means
+    // an object with neither field still decodes.
+    const result = Schema.decodeUnknownResult(TeamPage)(baseEncoded);
+    expect(result._tag).toBe('Success');
+  });
+
+  test('the DRAFT variant tolerates an uploaded key with NO alt; strict publish requires both', () => {
+    const keyOnly = {
+      ...baseEncoded,
+      groupPhoto: { key: KEY }, // uploaded key, alt not yet typed
+    };
+    expect(Schema.decodeUnknownResult(DraftTeamPage)(keyOnly)._tag).toBe('Success');
+    expect(Schema.decodeUnknownResult(TeamPage)(keyOnly)._tag).toBe('Failure');
+  });
+
+  test('the DRAFT variant still rejects a MALFORMED present key (not merely absent)', () => {
+    const badKey = {
+      ...baseEncoded,
+      groupPhoto: { key: '/leading-slash.jpg' },
+    };
+    expect(Schema.decodeUnknownResult(DraftTeamPage)(badKey)._tag).toBe('Failure');
+  });
 });
 
 const isValidLinkHref = (value: string): boolean =>

--- a/app/lib/content/pages/schema.test.ts
+++ b/app/lib/content/pages/schema.test.ts
@@ -8,6 +8,7 @@ import {
   defaultFaqPage,
   defaultGivePage,
   defaultHomePage,
+  defaultTeamPage,
   defaultVolunteerPage,
 } from './defaults';
 import {
@@ -55,6 +56,7 @@ describe('per-page default round-trips', () => {
     ['VolunteerPage', VolunteerPage, defaultVolunteerPage],
     ['ArchivePage', ArchivePage, defaultArchivePage],
     ['HomePage', HomePage, defaultHomePage],
+    ['TeamPage', TeamPage, defaultTeamPage],
   ] as const;
 
   for (const [name, schema, value] of cases) {

--- a/app/lib/content/pages/schema.ts
+++ b/app/lib/content/pages/schema.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect';
 
-import { ExternalHttpsUrl, ListItemId, Text } from '../schema';
+import { AssetKey, ExternalHttpsUrl, ImageRef, ListItemId, Text } from '../schema';
 
 /**
  * The per-Page + per-Form content schemas (ADR 0008, settled #5; registration-launch
@@ -251,6 +251,37 @@ export const HomePage = Schema.Struct({
 });
 export type HomePage = typeof HomePage.Type;
 
+/**
+ * The Team page CHROME (registration-launch follow-on: the Team route migrated
+ * into the per-page CMS model). It owns the page's evergreen copy — the rich
+ * title, the subtitle blurb, the board heading — plus TWO named, optional image
+ * slots: the group photo banner and the small portrait/logo beside the title.
+ *
+ * The per-member EXECUTIVE ROSTER (`team[]` / `board[]` on `site.json`, served by
+ * `Content.getTeam()`) is conference-executive DATA, not page chrome, and stays
+ * where it lives — this schema models only the page's hand-built chrome.
+ *
+ * Modelling choices (`~/.brain/principles`):
+ *   - `title` is `RichText` (not plain `Text`) so the italic `movement` run from
+ *     the pre-migration `team.title` / `team.title.movement` pair round-trips as a
+ *     closed `italic` token, NOT HTML — exactly as `VolunteerPage.title` does.
+ *   - `groupPhoto` / `portrait` are each `Schema.optionalKey(ImageRef)`: two
+ *     semantically distinct slots (different aspect / role in the layout), so two
+ *     named optional fields beat one list (`make-impossible-states-unrepresentable`).
+ *     Optional-at-key means a stored `team.json` that predates either field (or
+ *     carries only one uploaded image) still decodes, and the route SECTION-SKIPS
+ *     the absent image (ADR 0008) rather than rendering a broken `<img>`. A PRESENT
+ *     image carries a strict `{ key, alt }` (a valid `AssetKey` + both-locales alt).
+ */
+export const TeamPage = Schema.Struct({
+  title: RichText,
+  subtitle: Text,
+  boardHeading: Text,
+  groupPhoto: Schema.optionalKey(ImageRef),
+  portrait: Schema.optionalKey(ImageRef),
+});
+export type TeamPage = typeof TeamPage.Type;
+
 // ---------------------------------------------------------------------------
 // Draft page variants — the laxer admin-draft schemas (ADR 0006, Branch 5.5)
 // ---------------------------------------------------------------------------
@@ -332,4 +363,34 @@ export const DraftArchivePage = Schema.Struct({
   ),
 });
 export type DraftArchivePage = typeof DraftArchivePage.Type;
+
+/**
+ * A draft image reference for the Team page: a present `key` is still a strict
+ * `AssetKey` (an upload always produces a valid one), but `alt` may be unfilled.
+ * Mirrors the site draft's `DraftImageRef` (`schema.ts:638`) so the admin can
+ * upload the photo FIRST (the action rewrites `groupPhoto.key`) and fill the alt
+ * text SECOND — a strict `ImageRef` in the draft would reject the in-between state
+ * where a key exists but no alt has been typed (ADR 0006: an incomplete required
+ * field blocks PUBLISH, not draft save). Strict publish (`ImageRef`) still requires
+ * both halves (`make-impossible-states-unrepresentable` holds for what is set).
+ */
+const DraftImageRef = Schema.Struct({
+  key: Schema.optionalKey(AssetKey),
+  alt: Schema.optionalKey(DraftText),
+});
+
+/**
+ * The DRAFT variant of `TeamPage`. The chrome copy (`title` RichText, `subtitle`,
+ * `boardHeading`) has no id-only add flow, so it stays strict — there is no laxer
+ * intermediate state to represent for it. Only the two image slots relax (to the
+ * lax `DraftImageRef`) so an uploaded `key` can land before its alt text.
+ */
+export const DraftTeamPage = Schema.Struct({
+  title: RichText,
+  subtitle: Text,
+  boardHeading: Text,
+  groupPhoto: Schema.optionalKey(DraftImageRef),
+  portrait: Schema.optionalKey(DraftImageRef),
+});
+export type DraftTeamPage = typeof DraftTeamPage.Type;
 

--- a/app/lib/localization/translations.ts
+++ b/app/lib/localization/translations.ts
@@ -55,13 +55,10 @@ const en = {
     'Your message has been sent successfully! We will take notice of it and answer as soon as possible.',
   'give.directions': "Here's how you can give:",
   'give.continue': 'Continue',
-  'team.title': 'The people behind the {{movement}}.',
-  'team.title.movement': 'movement',
-  'team.image.alt': 'A group of young people smiling and standing together.',
-  'team.logo.alt': 'GYC Canada Logo',
-  'team.subtitle':
-    'We are GYC Canada, young people dedicated to spreading the Gospel and living the lives that God has planned for us. As ambassadors of Christ in this world, we are fulfilling His purpose for us and go boldly where our Savior leads.',
-  'team.board': 'Board of Directors',
+  // `team.title` / `team.title.movement` / `team.image.alt` / `team.logo.alt` /
+  // `team.subtitle` / `team.board` migrated to the CMS `TeamPage` object (the
+  // route renders them from `getPage('team')`). `team.position.*` (the executive
+  // roster, still on `site.json` via `getTeam()`) and `nav.team` stay.
   'team.position.president': 'President',
   'team.position.vice-president': 'General Vice President',
   'team.position.vp-logistics': 'VP of Logistics',
@@ -321,13 +318,8 @@ const fr: Record<TranslationKey, string> = {
     'Votre message a été envoyé avec succès! Nous en prendrons connaissance et vous répondrons dès que possible.',
   'give.directions': 'Voici comment vous pouvez donner :',
   'give.continue': 'Continuer',
-  'team.title': 'Les personnes derrière le {{movement}}.',
-  'team.title.movement': 'mouvement',
-  'team.image.alt': 'Un groupe de jeunes souriants et debout ensemble.',
-  'team.logo.alt': 'Logo GYC Canada',
-  'team.subtitle':
-    "Nous sommes GYC Canada, des jeunes dédiés à faire connaître l'Évangile et à vivre les vies que Dieu a prévues pour nous. En tant qu'ambassadeurs de Christ dans ce monde, nous accomplissons Sa volonté pour nous et allons avec courage là où notre Seigneur nous conduit.",
-  'team.board': 'Conseil d’administration',
+  // Team page chrome (title / movement / image.alt / logo.alt / subtitle / board)
+  // migrated to the CMS `TeamPage`; `team.position.*` + `nav.team` stay (see EN).
   'team.position.president': 'Président',
   'team.position.vice-president': 'Vice-président général',
   'team.position.vp-logistics': 'Vice-président de la logistique',

--- a/app/routes/($lang)+/team/_index.test.tsx
+++ b/app/routes/($lang)+/team/_index.test.tsx
@@ -74,9 +74,10 @@ describe('Team route render-parity (CMS chrome + unchanged roster)', () => {
   it('renders the rich title (with the italic movement run), subtitle, and board heading', () => {
     const html = renderTeam(makeLoaderData());
     expect(html).toContain('The people behind the ');
-    // The italic `movement` run renders inside `<span class="italic">`.
-    expect(html).toContain('movement');
-    expect(html).toContain('class="italic"');
+    // Tie the class AND the text together: the `movement` run must be THE italic
+    // run (parity with the pre-migration `<span className="italic">…movement…</span>`),
+    // not merely both appearing somewhere in the markup.
+    expect(html).toMatch(/<span[^>]*class="italic"[^>]*>movement<\/span>/);
     expect(html).toContain('We are GYC Canada');
     expect(html).toContain('Board of Directors');
   });
@@ -115,7 +116,7 @@ describe('Team route render-parity (CMS chrome + unchanged roster)', () => {
   it('renders French chrome under /fr', () => {
     const html = renderTeam(makeLoaderData(toTeamView(defaultTeamPage, Locale.Fr)), 'fr');
     expect(html).toContain('Les personnes derrière le ');
-    expect(html).toContain('mouvement');
+    expect(html).toMatch(/<span[^>]*class="italic"[^>]*>mouvement<\/span>/);
     expect(html).toContain('Conseil d');
   });
 });

--- a/app/routes/($lang)+/team/_index.test.tsx
+++ b/app/routes/($lang)+/team/_index.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToString } from 'react-dom/server';
+import { createRoutesStub } from 'react-router';
+
+import { toTeamView } from '~/lib/content/pages/project';
+import { defaultTeamPage } from '~/lib/content/pages/defaults';
+import { Schema } from 'effect';
+import { TeamPage } from '~/lib/content/pages/schema';
+import { Locale } from '~/lib/localization/localization';
+import { LocalizationProvider } from '~/lib/localization/provider';
+import { root as translations } from '~/lib/localization/translations';
+
+import Index from './_index';
+
+/**
+ * Render-parity for the Team route after migrating its CHROME into the per-page
+ * CMS `TeamPage` (title / subtitle / board heading / images), keeping the per-
+ * member roster + `member.position` translation untouched. These pin that the
+ * migrated route renders the SAME visible copy/structure as the pre-migration
+ * route given `defaultTeamPage` + a seeded image:
+ *   - the rich title with the italic `movement` run (was `team.title` +
+ *     `<span className="italic">team.title.movement</span>`);
+ *   - the subtitle + board heading (was `team.subtitle` / `team.board`);
+ *   - each roster member's name + translated `position` (UNCHANGED — still on
+ *     `site.json` via `getTeam()`);
+ *   - a present group photo renders its `<img>`; an absent portrait section-skips.
+ */
+
+const member = {
+  name: 'Elijah Example',
+  position: 'team.position.president',
+  image: '/images/team/elijah.jpg',
+} as const;
+
+/**
+ * Render the Team route's default component with supplied loader data. The
+ * component reads `useLoaderData` + `useTranslate`, so it is mounted inside a
+ * `createRoutesStub` route (whose `loader` returns the fixture, satisfying
+ * `useLoaderData`) wrapped in a `LocalizationProvider` (satisfying `useTranslate`).
+ */
+const renderTeam = (
+  loaderData: ReturnType<typeof makeLoaderData>,
+  lang?: 'fr',
+): string => {
+  const Stub = createRoutesStub([
+    {
+      id: 'team',
+      path: ':lang?',
+      Component: () => (
+        <LocalizationProvider
+          translation={translations[lang === 'fr' ? 'fr' : 'en']}
+        >
+          <Index />
+        </LocalizationProvider>
+      ),
+    },
+  ]);
+
+  return renderToString(
+    <Stub
+      initialEntries={[lang === 'fr' ? '/fr' : '/']}
+      hydrationData={{ loaderData: { team: loaderData } }}
+    />,
+  );
+};
+
+const makeLoaderData = (page = toTeamView(defaultTeamPage, Locale.En)) => ({
+  page,
+  team: [member],
+  board: ['Board Member One', 'Board Member Two'],
+});
+
+describe('Team route render-parity (CMS chrome + unchanged roster)', () => {
+  it('renders the rich title (with the italic movement run), subtitle, and board heading', () => {
+    const html = renderTeam(makeLoaderData());
+    expect(html).toContain('The people behind the ');
+    // The italic `movement` run renders inside `<span class="italic">`.
+    expect(html).toContain('movement');
+    expect(html).toContain('class="italic"');
+    expect(html).toContain('We are GYC Canada');
+    expect(html).toContain('Board of Directors');
+  });
+
+  it('renders each roster member name + its translated position (roster unchanged)', () => {
+    const html = renderTeam(makeLoaderData());
+    expect(html).toContain('Elijah Example');
+    expect(html).toContain(member.image);
+    // `member.position` still goes through `translate(...)` → the EN label.
+    expect(html).toContain('President');
+    expect(html).toContain('Board Member One');
+  });
+
+  it('renders a present group photo <img> and section-skips an absent portrait', () => {
+    // Re-encode the bundled default to its JSON, then add a seeded group photo and
+    // re-decode — proving a published team.json WITH a group photo renders its img.
+    const encoded = Schema.encodeUnknownSync(TeamPage)(defaultTeamPage) as Record<
+      string,
+      unknown
+    >;
+    const seeded = Schema.decodeUnknownSync(TeamPage)({
+      ...encoded,
+      groupPhoto: {
+        key: '2026/team/group.jpg',
+        alt: { en: 'A group photo.', fr: 'Une photo de groupe.' },
+      },
+    });
+    const html = renderTeam(makeLoaderData(toTeamView(seeded, Locale.En)));
+    // Present group photo renders.
+    expect(html).toContain('/images/2026/team/group.jpg');
+    expect(html).toContain('A group photo.');
+    // Absent portrait section-skips: no portrait <img> (the old /logo/gycc.png).
+    expect(html).not.toContain('/logo/gycc.png');
+  });
+
+  it('renders French chrome under /fr', () => {
+    const html = renderTeam(makeLoaderData(toTeamView(defaultTeamPage, Locale.Fr)), 'fr');
+    expect(html).toContain('Les personnes derrière le ');
+    expect(html).toContain('mouvement');
+    expect(html).toContain('Conseil d');
+  });
+});

--- a/app/routes/($lang)+/team/_index.tsx
+++ b/app/routes/($lang)+/team/_index.tsx
@@ -1,10 +1,13 @@
 import { type MetaFunction, useLoaderData } from 'react-router';
 
 import { Content } from '~/lib/content.server';
+import { toTeamView } from '~/lib/content/pages/project';
+import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeHandler } from '~/lib/effect/route';
 import { useTranslate } from '~/lib/localization/context';
 import { getLocale } from '~/lib/localization/localization';
 import { Main } from '~/ui/main';
+import { RichText } from '~/ui/rich-text';
 
 export const meta: MetaFunction = ({ params }) => {
   const lang = getLocale(params);
@@ -21,40 +24,47 @@ export const meta: MetaFunction = ({ params }) => {
 };
 
 export const loader = routeHandler(function* () {
+  const { params } = yield* ReactRouterContext;
+  const locale = getLocale(params);
   const content = yield* Content.Service;
-  return yield* content.getTeam();
+  // Page CHROME (title / subtitle / board heading / images) comes from the CMS
+  // `TeamPage` object; the per-member executive roster stays on `site.json` via
+  // `getTeam()` (conference-executive data, not page copy — not migrated here).
+  const page = toTeamView(yield* content.getPage('team'), locale);
+  const { team, board } = yield* content.getTeam();
+  return { page, team, board };
 });
 
 export default function Index() {
+  // `useTranslate` stays for the per-member `member.position` keys (`team.position.*`),
+  // which remain on `site.json` — only the page-chrome translation keys migrated.
   const translate = useTranslate();
-  const { team, board } = useLoaderData<typeof loader>();
+  const { page, team, board } = useLoaderData<typeof loader>();
   return (
     <Main className="gap-10">
       <div className="mx-auto flex h-[700px] w-(--width) flex-col md:h-[478px] md:pt-0">
-        <img
-          src="/team/group-van-2022.jpg"
-          className="absolute inset-0 size-full object-cover md:object-top"
-          alt={translate('team.image.alt') as string}
-        />
+        {page.groupPhoto && (
+          <img
+            src={page.groupPhoto.src}
+            className="absolute inset-0 size-full object-cover md:object-top"
+            alt={page.groupPhoto.alt}
+          />
+        )}
         <div className="flex items-center justify-center gap-6 text-neutral-950 md:pt-8">
           <h1 className="flex-1 shrink text-balance text-2xl sm:text-3xl md:max-w-[30%] md:text-4xl lg:text-5xl">
-            {translate('team.title', {
-              movement: (
-                <span className="italic">
-                  {translate('team.title.movement')}
-                </span>
-              ),
-            })}
+            <RichText runs={page.title} />
           </h1>
-          <img
-            className="block size-[140px] object-contain"
-            src="/logo/gycc.png"
-            alt={translate('team.image.alt') as string}
-          />
+          {page.portrait && (
+            <img
+              className="block size-[140px] object-contain"
+              src={page.portrait.src}
+              alt={page.portrait.alt}
+            />
+          )}
         </div>
       </div>
       <div className="flex flex-col gap-8 p-4">
-        <p>{translate('team.subtitle')}</p>
+        <p>{page.subtitle}</p>
 
         <div className="grid grid-cols-2 gap-4 pb-20 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
           {team.map((member) => (
@@ -74,7 +84,7 @@ export default function Index() {
         </div>
         <hr />
         <div className="flex flex-col gap-7">
-          <h3 className="text-xl font-bold">{translate('team.board')}</h3>
+          <h3 className="text-xl font-bold">{page.boardHeading}</h3>
           <ul className="grid grid-cols-2 gap-2.5 md:grid-cols-3 lg:grid-cols-4">
             {board.map((name, index) => (
               <li key={index}>{name}</li>

--- a/app/routes/admin/_index.tsx
+++ b/app/routes/admin/_index.tsx
@@ -16,6 +16,7 @@ const PAGE_LABELS: Record<string, string> = {
   volunteer: 'Volunteer',
   archive: 'Archive',
   home: 'Home (evergreen)',
+  team: 'Team',
 };
 
 /**

--- a/app/routes/admin/_index.tsx
+++ b/app/routes/admin/_index.tsx
@@ -1,14 +1,18 @@
 import { Link } from 'react-router';
 
 import { adminMeta, adminSecurityHeaders } from '~/lib/admin-headers';
-import { PAGE_IDS } from '~/lib/content/pages/registry';
+import { PAGE_IDS, type PageId } from '~/lib/content/pages/registry';
 
 export const meta = adminMeta;
 
 export const headers = adminSecurityHeaders;
 
-/** Human label per `PageId` for the dashboard's per-page editor links. */
-const PAGE_LABELS: Record<string, string> = {
+/**
+ * Human label per `PageId` for the dashboard's per-page editor links. Exhaustive
+ * over `PageId` so adding a page to the registry without a label fails to compile
+ * (`make-impossible-states-unrepresentable`).
+ */
+const PAGE_LABELS: { readonly [P in PageId]: string } = {
   about: 'About',
   faq: 'FAQ',
   give: 'Give',
@@ -57,7 +61,7 @@ export default function AdminIndex() {
                 to={`/admin/pages/${page}`}
                 className="flex min-h-11 items-center justify-between rounded-md border border-neutral-300 px-4 text-sm font-medium transition-colors hover:bg-neutral-100"
               >
-                <span>{PAGE_LABELS[page] ?? page}</span>
+                <span>{PAGE_LABELS[page]}</span>
                 <span aria-hidden className="text-neutral-400">
                   →
                 </span>

--- a/app/routes/admin/pages.$page.action.test.ts
+++ b/app/routes/admin/pages.$page.action.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'bun:test';
+import { ConfigProvider, Effect, Layer, ManagedRuntime } from 'effect';
+import { RouterContextProvider } from 'react-router';
+
+import { Auth } from '~/lib/auth.server';
+import { makeAppLayer, makeRequestRuntimeFromLayer } from '~/lib/effect/runtime';
+import type { RouteArgs } from '~/lib/effect/router-context';
+import { layerTest } from '~/lib/storage.test-helper';
+
+import { action } from './pages.$page';
+
+/**
+ * The per-page `/admin` editor action's image-upload GUARDS (A.5). The upload
+ * branch reuses `content.tsx`'s validation verbatim: an empty file or a
+ * non-image MIME is a 400 BEFORE any bytes are stored. These drive the REAL
+ * route action (past the auth gate, with a freshly minted admin cookie) over an
+ * in-memory `Storage`, and assert the 400 responses — proving the guards reject
+ * at the route boundary, not merely that the helper predicates are correct.
+ *
+ * The admin secrets are injected through a scoped `ConfigProvider` layer
+ * (`ConfigProvider.fromEnv`), NOT `process.env` (the project's Effect-config
+ * discipline) — so this test never mutates global env and cannot leak the
+ * enabled-admin state into other tests.
+ */
+
+const PASSWORD = 'correct-horse';
+const SECRET = 'a-signing-secret-of-sufficient-length';
+
+/** The admin-enabled config provider injected over the app layer. */
+const adminConfig = ConfigProvider.layer(
+  ConfigProvider.fromEnv({
+    env: { ADMIN_PASSWORD: PASSWORD, COOKIE_SECRET: SECRET },
+  }),
+);
+
+/** Build the app layer (in-memory storage) with the admin config provided. */
+const makeLayer = () =>
+  Layer.provide(makeAppLayer(layerTest({})), adminConfig);
+
+/** Build a request runtime + router context over the admin-enabled app layer. */
+const makeContext = () => {
+  const layer = makeLayer();
+  const context = new RouterContextProvider();
+  context.runtime = makeRequestRuntimeFromLayer(layer);
+  return { layer, context };
+};
+
+/** Mint a valid admin session cookie header by verifying the password. */
+const mintCookie = async (
+  layer: ReturnType<typeof makeLayer>,
+): Promise<string> => {
+  const runtime = ManagedRuntime.make(layer);
+  const header = await runtime.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service;
+      const token = yield* auth.verifyPassword(PASSWORD);
+      return auth.cookieHeader(token);
+    }),
+  );
+  await runtime.dispose();
+  return header;
+};
+
+/** POST an `upload:groupPhoto.key` multipart request to the team page action. */
+const postUpload = async (file: File): Promise<Response> => {
+  const { layer, context } = makeContext();
+  const cookie = await mintCookie(layer);
+
+  const body = new FormData();
+  body.set('intent', 'upload:groupPhoto.key');
+  body.set('file', file);
+
+  const url = 'http://localhost/admin/pages/team';
+  const request = new Request(url, {
+    method: 'POST',
+    body,
+    headers: { cookie },
+  });
+  const args: RouteArgs = {
+    request,
+    url: new URL(url),
+    pattern: '/admin/pages/:page',
+    params: { page: 'team' },
+    context,
+  };
+  return (await action(args)) as Response;
+};
+
+describe('team page editor action — image-upload guards (A.5)', () => {
+  it('an empty file is a 400 (no bytes stored)', async () => {
+    const empty = new File([], 'photo.jpg', { type: 'image/jpeg' });
+    const res = await postUpload(empty);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('Choose an image');
+  });
+
+  it('a non-image MIME (PDF) is a 400', async () => {
+    const pdf = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'doc.pdf', {
+      type: 'application/pdf',
+    });
+    const res = await postUpload(pdf);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('Upload a JPEG');
+  });
+});

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema } from 'effect';
+import { Cause, Clock, Effect, Option, Schema } from 'effect';
 import {
   Form,
   redirect,
@@ -16,7 +16,10 @@ import {
 } from '~/lib/content/draft-editor.server';
 import {
   assembleOverrides,
+  imageUploadTarget,
+  isAcceptedImageType,
   normalizeFaqAnswers,
+  uploadedImageKey,
   type Json,
 } from '~/lib/content/admin-form';
 import { collectListOps, fieldName } from '~/lib/content/list-edit';
@@ -25,10 +28,12 @@ import { ListItemId, newListItemId } from '~/lib/content/schema';
 import { Env } from '~/lib/env.server';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeAction, routeHandler } from '~/lib/effect/route';
+import { Storage } from '~/lib/storage.server';
 import {
   AddItemButton,
   Bilingual,
   type ActionResult,
+  ImageUpload,
   ItemControls,
   Section,
   Text,
@@ -139,9 +144,64 @@ export const action = routeAction(function* () {
   const scope = pageScope(page);
 
   const editor = yield* DraftEditor.Service;
+  const storage = yield* Storage.Service;
   const { request } = yield* ReactRouterContext;
   const form = yield* Effect.promise(() => request.formData());
   const intent = String(form.get('intent') ?? 'save-draft');
+
+  // ---- image upload --------------------------------------------------------
+  // Identical in shape to the site editor (`content.tsx`), scoped to THIS page:
+  // validate the file, store its raw bytes, then `DraftEditor.applyImageUpload`
+  // rewrites the targeted `<image>.key` field on the page draft so the new image
+  // survives a reload and a later publish. The image-upload path is REUSED, not
+  // re-implemented — `applyImageUpload` is scope-generic and `setAtPath` already
+  // navigates `groupPhoto.key` / `portrait.key` as plain object paths.
+  const uploadTarget = imageUploadTarget(intent);
+  if (uploadTarget !== null) {
+    const file = form.get('file');
+    if (!(file instanceof File) || file.size === 0) {
+      return Response.json(
+        { ok: false, error: 'Choose an image before uploading.', issues: [] },
+        { status: 400 },
+      );
+    }
+    if (!isAcceptedImageType(file.type)) {
+      return Response.json(
+        {
+          ok: false,
+          error: 'Upload a JPEG, PNG, WebP, GIF, or AVIF image.',
+          issues: [],
+        },
+        { status: 400 },
+      );
+    }
+
+    const now = yield* Clock.currentTimeMillis;
+    const key = uploadedImageKey(uploadTarget, file.type, now);
+    const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
+
+    const putExit = yield* Effect.exit(storage.put(key, bytes, file.type));
+    if (putExit._tag === 'Failure') {
+      return Response.json(
+        {
+          ok: false,
+          error:
+            'Image upload failed — is the bucket configured? ' +
+            Cause.pretty(putExit.cause),
+          issues: [],
+        },
+        { status: 502 },
+      );
+    }
+
+    const applied = yield* editor
+      .applyImageUpload(scope, uploadTarget, key)
+      .pipe(Effect.result);
+    if (applied._tag === 'Failure') return issueResponse(applied.failure);
+    return redirect(
+      `/admin/pages/${page}?status=${encodeURIComponent(`Image uploaded: ${key}`)}`,
+    );
+  }
 
   // ---- list op (add / remove / reorder) ------------------------------------
   if (intent === 'list-op') {
@@ -526,7 +586,11 @@ function PageEditor({
         </>
       );
     }
-    case 'team':
+    case 'team': {
+      // The encoded draft carries each image slot as `{ key?, alt? }` (the lax
+      // `DraftImageRef`); read the current key + alt off whichever is present.
+      const groupPhoto = (encoded['groupPhoto'] ?? {}) as Record<string, unknown>;
+      const portrait = (encoded['portrait'] ?? {}) as Record<string, unknown>;
       return (
         <>
           <RichTextPreview
@@ -544,8 +608,37 @@ function PageEditor({
             name="boardHeading"
             value={text(encoded['boardHeading'] as DraftText)}
           />
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-neutral-800">
+              Group photo
+            </legend>
+            <ImageUpload
+              keyPath="groupPhoto.key"
+              currentKey={String(groupPhoto['key'] ?? '')}
+            />
+            <Bilingual
+              label="Group photo alt"
+              name="groupPhoto.alt"
+              value={text(groupPhoto['alt'] as DraftText)}
+            />
+          </fieldset>
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-neutral-800">
+              Portrait
+            </legend>
+            <ImageUpload
+              keyPath="portrait.key"
+              currentKey={String(portrait['key'] ?? '')}
+            />
+            <Bilingual
+              label="Portrait alt"
+              name="portrait.alt"
+              value={text(portrait['alt'] as DraftText)}
+            />
+          </fieldset>
         </>
       );
+    }
     default:
       // Exhaustive over `PageId`: if a new page is added to the registry without a
       // branch here, `page` is no longer `never` and `satisfies never` fails to

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -82,6 +82,7 @@ const PAGE_LABELS: { readonly [P in PageId]: string } = {
   volunteer: 'Volunteer',
   archive: 'Archive',
   home: 'Home (evergreen sections)',
+  team: 'Team',
 };
 
 type ActionResponse = ActionResult;
@@ -525,6 +526,26 @@ function PageEditor({
         </>
       );
     }
+    case 'team':
+      return (
+        <>
+          <RichTextPreview
+            label="Title"
+            nodes={encoded['title'] as ReadonlyArray<Record<string, unknown>> | undefined}
+          />
+          <Bilingual
+            label="Subtitle"
+            name="subtitle"
+            value={text(encoded['subtitle'] as DraftText)}
+            multiline
+          />
+          <Bilingual
+            label="Board heading"
+            name="boardHeading"
+            value={text(encoded['boardHeading'] as DraftText)}
+          />
+        </>
+      );
     default:
       // Exhaustive over `PageId`: if a new page is added to the registry without a
       // branch here, `page` is no longer `never` and `satisfies never` fails to

--- a/docs/cms-images-enable-plan.md
+++ b/docs/cms-images-enable-plan.md
@@ -1,0 +1,706 @@
+# CMS: per-page images + resize-on-upload + per-page `enabled` flag
+
+Synthesized implementation plan (one stacked-PR set off `main`, feature granularity).
+Author: Claude (Opus 4.8). Grounded against the live code as of `9887ca8`.
+
+This is the FINAL synthesis of the two dual plans + the two adversarial reviews, with the
+**user decision applied**: the CMS image fields go on the **TEAM page**, not About/Home (settles
+Codex blocking critique #2). Team is the only evergreen page that renders images today (a
+hardcoded group photo `/team/group-van-2022.jpg` + a logo/portrait at
+`app/routes/($lang)+/team/_index.tsx:33-53`) and it is the page Feature C's `enabled` flag hides
+— so when it is re-enabled, its photos are swapped via CMS upload. That redirection makes Feature A
+a **CMS migration of the Team route into the per-page model**, not a bolt-on of an image field to
+an already-migrated page.
+
+| # | Branch | Feature |
+|---|--------|---------|
+| A | `cms/team-cms-image-upload` | Migrate the Team route into the per-page CMS model (new `TeamPage`), add its two optional `ImageRef` fields + RichText title, wire the `upload:` intent into the per-page editor. |
+| B | `cms/image-resize-on-upload` | Shrink + re-encode uploads with `Bun.Image` at ONE shared upload boundary both editors call. |
+| C | `cms/page-enabled-flag` | A decode-safe per-page `enabled` boolean (incl. the now-CMS team); data-driven nav + route AND action 404; delete every hardcoded team hide. |
+
+## Branch order + dependency reasoning (re-derived with Team's CMS migration in A)
+
+**A → B → C, and C MUST follow A.**
+
+- **A is first and is the keystone.** It introduces the per-page image field, the new `TeamPage`
+  Page object, AND the per-page-editor `upload:` wiring that B's resize boundary plugs into. The
+  user decision moves the image content-model decision (Team's two image fields) *into A*, so A now
+  depends on the per-page CMS machinery (`getPage`, `PAGE_SPECS`, `DraftEditor`'s page scope) —
+  all of which already exist (registration-launch Branch 5). A adds `team` to the closed `PageId`
+  set and migrates the route.
+- **B is second.** It factors the *validate file → read bytes → `storage.put` raw bytes* step
+  (today in `content.tsx`, newly added by A in `pages.$page.tsx`) into one `prepareImage` boundary
+  and inserts the resize there. The boundary it shares is only co-owned by both editors *after* A
+  gives `pages.$page.tsx` an upload branch. B is decoupled from C.
+- **C MUST follow A** (not independent). The prior plan treated C as independent and put team's
+  flag on `SiteContent` (a `teamEnabled` field). The user decision makes **team a `PageId`**, so
+  team's visibility is just the per-page `enabled` flag on the now-CMS `TeamPage` — there is no
+  separate `teamEnabled`. C therefore consumes A's `TeamPage` (its `enabled` flag gates the team
+  route + nav link). C cannot be cut before A without re-introducing the rejected "team on
+  site.json" path. This also *removes* a whole risk class (the prior plan's `teamEnabled`-on-
+  `SiteContent` split, prior-plan Risk 6) — `derive-dont-sync`: team's flag lives in the object
+  team-page copy now lives in.
+
+Each branch's gate is per-sub-commit:
+`cd /Users/cvr/Developer/personal/gyc && bun run typecheck && bun run lint && bun run build && bun test`.
+
+---
+
+## Settled-decision realization (do not re-open)
+
+- **Reuse, no parallel path.** The existing `AssetKey` brand (`app/lib/content/schema.ts:82`),
+  `ImageRef` (`schema.ts:105`) / `DraftImageRef` (`schema.ts:638`), the `ImageUpload` component
+  (`app/routes/admin/controls.tsx:131`), the `upload:<keyPath>` intent (`IMAGE_UPLOAD_INTENT_PREFIX`,
+  `admin-form.ts:54`), `uploadedImageKey` (`admin-form.ts:111`), and `DraftEditor.applyImageUpload`
+  (`draft-editor.server.ts:604`) are reused verbatim. No new upload path, no second AssetKey.
+- **Resize at ONE boundary (B)**, called by both `content.tsx` and `pages.$page.tsx`.
+- **Image fields go on TEAM** (user decision), each `Schema.optionalKey(ImageRef)`, section-skippable
+  (absent ⇒ renders nothing, ADR 0008), decode-safe (a stored `team.json` without the field still
+  decodes), with a **lax `DraftImageRef`** so a key can land before alt text (Codex #3).
+- **`enabled` flag** on every Page incl. the now-CMS team, decode-safe via
+  `Schema.withDecodingDefaultKey(Effect.succeed(true))` (Codex #4), data-driven nav, route AND action
+  404 (Codex #6), an explicit boolean admin control with `assembleOverrides` coercion (Codex #5/#12),
+  and EVERY hardcoded team hide DELETED — the two `_layout.tsx` nav comments AND the commented `/team`
+  CTA in `_index.tsx:115-120` (Codex R1).
+
+---
+
+# Feature A — Team CMS migration + per-page image upload
+
+**Branch:** `cms/team-cms-image-upload`
+
+## A.0 — The content-model decision: TEAM gains the image fields (About/Home get NONE)
+
+Today the Team route (`app/routes/($lang)+/team/_index.tsx`) is a **separate hand-built route** with:
+- a hardcoded group photo `src="/team/group-van-2022.jpg"` (`_index.tsx:35`),
+- a hardcoded logo/portrait `src="/logo/gycc.png"` (`_index.tsx:50`),
+- a rich italic title from translation keys `team.title` + `team.title.movement`
+  (`"The people behind the {{movement}}."`, `translations.ts:58-59`),
+- subtitle/board headings from `team.subtitle` / `team.board` (`translations.ts:62-64`),
+- and the per-member executive list, which is **separate `site.json` data** read via
+  `content.getTeam()` (`content.server.ts:656`) — NOT touched by this migration.
+
+The migration creates a **`TeamPage` Page object** that owns the page CHROME (title, subtitle,
+board heading, and the two images). The per-member roster (`team[]` + `board[]` on `site.json`)
+stays where it is — it is conference-executive data, not evergreen page copy, and `getTeam()`
+already serves it. So:
+
+| Page | Image field? | Field(s) | Justification |
+|------|-------------|----------|---------------|
+| **Team** | YES | `groupPhoto?: ImageRef`, `portrait?: ImageRef` | The only evergreen page that renders images today (group photo + logo/portrait). Each OPTIONAL ⇒ absent renders nothing (section-skip). When the page is re-enabled (Feature C), its photos are swapped via CMS upload. |
+| **About** | NO | — | Per the user decision. About renders no image today; adding one is gratuitous. |
+| **Home** | NO | — | Per the user decision. |
+| FAQ / Give / Contact / Volunteer / Archive | NO | — | No image in any of these content models. |
+
+**Why two fields, both optional `ImageRef`:** the group photo and the portrait are semantically
+distinct slots (different aspect/role in the layout), so two named `optionalKey(ImageRef)` fields
+beat one list — `make-impossible-states-unrepresentable`. Optional-at-key means a `team.json`
+that predates either field (or has only one uploaded) still decodes and the layout section-skips
+the missing image.
+
+## A.1 — Add `team` to the closed `PageId` set + the `TeamPage` schema
+
+`PageId` (`pages/registry.ts:69`) is the closed `Schema.Literals` of evergreen pages. Add `'team'`.
+This is the single registration point (`derive-dont-sync`); the admin labels, the read-path caches,
+the `DraftEditor` scope, and the `PageEditor` switch all derive from it. Adding `'team'` forces a
+compile error in `PageEditor`'s exhaustive switch (`pages.$page.tsx:528-536`) and in `PAGE_LABELS`
+(`pages.$page.tsx:77`) and `PAGE_SPECS` (`registry.ts:182`) until each gets a team arm — that
+type-error IS the checklist.
+
+`pages/schema.ts` — the new strict schema (decode-safe images, RichText title per Codex #8):
+
+```ts
+export const TeamPage = Schema.Struct({
+  // RichText so the italic 'movement' run (team.title.movement) round-trips as a token,
+  // NOT HTML — exactly like VolunteerPage.title (schema.ts:205). Resolves Codex #8.
+  title: RichText,
+  subtitle: Text,
+  boardHeading: Text,
+  groupPhoto: Schema.optionalKey(ImageRef),   // absent ⇒ section-skip; present ⇒ strict {key, alt}
+  portrait: Schema.optionalKey(ImageRef),
+});
+export type TeamPage = typeof TeamPage.Type;
+```
+
+`ImageRef` (`schema.ts:105`) must be imported into `pages/schema.ts` (it currently imports only
+`ExternalHttpsUrl`, `ListItemId`, `Text` from `../schema`; add `ImageRef`).
+
+`pages/schema.ts` — the DRAFT variant (lax image so the uploaded key lands before alt text, Codex #3):
+
+```ts
+// Reuse the SAME laxity DraftImageRef encodes (schema.ts:638): a present key is a strict
+// AssetKey, alt may be unfilled. Define a local DraftImageRef in pages/schema.ts mirroring
+// schema.ts:638 (key: optionalKey(AssetKey), alt: optionalKey(DraftText)) — pages/schema.ts
+// already has its own DraftText (schema.ts pages-file line 281), so the draft image ref is:
+const DraftImageRef = Schema.Struct({
+  key: Schema.optionalKey(AssetKey),
+  alt: Schema.optionalKey(DraftText),
+});
+
+export const DraftTeamPage = Schema.Struct({
+  title: RichText,            // title has no id-only-add flow; stays strict (RichText is draft-safe as a whole value)
+  subtitle: Text,
+  boardHeading: Text,
+  groupPhoto: Schema.optionalKey(DraftImageRef),
+  portrait: Schema.optionalKey(DraftImageRef),
+});
+export type DraftTeamPage = typeof DraftTeamPage.Type;
+```
+
+`AssetKey` is imported from `../schema` for the draft image ref.
+
+**Why `draftPageSpec` (draft ≠ strict) for team:** the strict `groupPhoto`/`portrait` require a
+*present* image to carry a strict `{key, alt}` (both `Text` halves non-empty); the draft tolerates
+an uploaded `key` with an empty `alt` (the admin uploads first, fills alt second — same flow as
+speaker photos). So `team` wires `draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage)` in
+`PAGE_SPECS`. This is the existing `DraftEditor` codec path (`draft-editor.server.ts:350` `objectCodec`)
+— no new machinery.
+
+## A.2 — `defaultTeamPage` (decode-safe, transcribes today's chrome) + registry wiring
+
+`pages/defaults.ts` — transcribe today's translation-key chrome into the typed object, OMITTING the
+image keys (optional ⇒ section-skip default; the real images are uploaded via CMS, mirroring how the
+site defaults map `public/` art):
+
+```ts
+export const defaultTeamPage: TeamPage = Schema.decodeUnknownSync(TeamPage)({
+  // team.title "The people behind the {{movement}}." with the italic 'movement' run as tokens
+  title: [
+    { _tag: 'text', value: { en: 'The people behind the ', fr: 'Les personnes derrière le ' } },
+    { _tag: 'italic', value: { en: 'movement', fr: 'mouvement' } },   // team.title.movement
+    { _tag: 'text', value: { en: '.', fr: '.' } },
+  ],
+  subtitle: { en: <team.subtitle EN>, fr: <team.subtitle FR> },       // translations.ts:62/328
+  boardHeading: { en: 'Board of Directors', fr: 'Conseil d’administration' }, // team.board
+  // groupPhoto / portrait omitted (optional) — uploaded via CMS; route falls back to no image,
+  // OR the default group photo is seeded by setting groupPhoto.key to the in-public path on first
+  // publish. Decision: OMIT in the default so a brand-new team.json renders the roster without a
+  // broken <img>; the launch upload sets it. (The old /team/group-van-2022.jpg stays in public/
+  // until an upload overrides it — see A.5 deletions.)
+});
+```
+
+`pages/registry.ts`:
+- import `TeamPage`, `DraftTeamPage` from `./schema`, `defaultTeamPage` from `./defaults`;
+- add `team: draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage)` to `PAGE_SPECS`.
+
+`routes.ts:39` already maps `team` to `routes/($lang)+/team/_index.tsx`; that route stays, its
+loader is rewritten in A.4.
+
+## A.3 — Project `TeamPage` to a per-locale view (`project.ts`)
+
+`pages/project.ts` adds a `TeamView` + `toTeamView` mirroring the other converters, projecting the
+RichText title to runs and each image to a `{ src, alt }` (or `undefined`):
+
+```ts
+export interface TeamView {
+  readonly title: readonly RichTextRun[];
+  readonly subtitle: string;
+  readonly boardHeading: string;
+  readonly groupPhoto?: { readonly src: string; readonly alt: string };
+  readonly portrait?: { readonly src: string; readonly alt: string };
+}
+
+export const toTeamView = (page: TeamPage, locale: Locale): TeamView => ({
+  title: toRichText(page.title, locale),
+  subtitle: page.subtitle[locale],
+  boardHeading: page.boardHeading[locale],
+  groupPhoto: page.groupPhoto
+    ? { src: assetUrl(page.groupPhoto.key), alt: page.groupPhoto.alt[locale] }
+    : undefined,
+  portrait: page.portrait
+    ? { src: assetUrl(page.portrait.key), alt: page.portrait.alt[locale] }
+    : undefined,
+});
+```
+
+`assetUrl(key) = /images/${key}` is currently **private** to `content.server.ts:193`. Export it
+from a shared module (or define a tiny `app/lib/content/asset-url.ts` `export const assetUrl = (key) =>
+\`/images/${key}\``) and have BOTH `content.server.ts` and `project.ts` import it — `derive-dont-sync`,
+one URL-resolution rule. (The other page projections that will eventually carry images reuse the
+same helper.)
+
+## A.4 — Migrate the Team route to `getPage('team')` + render CMS images
+
+`team/_index.tsx`: the loader currently returns only `getTeam()` (roster). Change it to fetch BOTH
+the new `TeamPage` chrome AND the roster:
+
+```ts
+export const loader = routeHandler(function* () {
+  const { params } = yield* ReactRouterContext;
+  const locale = getLocale(params);
+  const content = yield* Content.Service;
+  const page = toTeamView(yield* content.getPage('team'), locale);
+  const { team, board } = yield* content.getTeam();
+  return { page, team, board };
+});
+```
+
+The JSX:
+- the hardcoded `<img src="/team/group-van-2022.jpg" …>` (`_index.tsx:34-38`) becomes
+  `{page.groupPhoto && <img src={page.groupPhoto.src} alt={page.groupPhoto.alt} …/>}` (section-skip);
+- the hardcoded `<img src="/logo/gycc.png" …>` (`_index.tsx:49-53`) becomes
+  `{page.portrait && <img src={page.portrait.src} alt={page.portrait.alt} …/>}`;
+- the `translate('team.title', { movement: <span className="italic">…</span> })` block
+  (`_index.tsx:40-48`) becomes a `<RichText runs={page.title} />` render (reuse `~/ui/rich-text`,
+  the renderer `project.ts` runs feed — the same one About/FAQ/Contact use);
+- `translate('team.subtitle')` (`_index.tsx:57`) → `{page.subtitle}`;
+- `translate('team.board')` (`_index.tsx:77`) → `{page.boardHeading}`;
+- the per-member roster map (`_index.tsx:60-73`) is UNCHANGED — it renders `team` from `getTeam()`,
+  and `member.position` still goes through `translate(...)` (the executive positions stay on
+  `site.json`'s `TeamPosition` keys, not migrated here — `subtract-before-you-add`, this feature
+  migrates page chrome only).
+
+The `useTranslate()` import is removed from this route only if no translate call remains (the
+`member.position` translate keeps it — so `useTranslate` stays, but the `team.title`/`team.subtitle`/
+`team.board`/`team.image.alt` keys are no longer referenced HERE).
+
+## A.5 — Wire the `upload:` intent into the per-page editor action + render the controls
+
+`pages.$page.tsx`'s action does NOT handle `upload:` today (only `list-op`/`save-draft`/`publish`).
+Add the upload branch IDENTICAL in shape to `content.tsx:135-180`, scoped via `pageScope(page)`:
+
+```ts
+const uploadTarget = imageUploadTarget(intent);
+if (uploadTarget !== null) {
+  const file = form.get('file');
+  if (!(file instanceof File) || file.size === 0) { /* 400 'Choose an image…' */ }
+  if (!isAcceptedImageType(file.type)) { /* 400 'Upload a JPEG, PNG, WebP, GIF, or AVIF…' */ }
+  const now = yield* Clock.currentTimeMillis;
+  const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
+  const key = uploadedImageKey(uploadTarget, file.type, now);   // B replaces file.type w/ prepared.contentType
+  const putExit = yield* Effect.exit(storage.put(key, bytes, file.type));  // B replaces this trio w/ prepareImage
+  if (putExit._tag === 'Failure') { /* 502 */ }
+  const applied = yield* editor.applyImageUpload(scope, uploadTarget, key).pipe(Effect.result);
+  if (applied._tag === 'Failure') return issueResponse(applied.failure);
+  return redirect(`/admin/pages/${page}?status=${encodeURIComponent(`Image uploaded: ${key}`)}`);
+}
+```
+
+This needs `Storage`, `Clock`, `imageUploadTarget`, `isAcceptedImageType`, `uploadedImageKey`
+imported into `pages.$page.tsx` (all already exported). `applyImageUpload` is already
+scope-generic (`<S extends ContentScope>`, `draft-editor.server.ts:604`); `setAtPath`
+(`admin-form.ts:354`) already navigates `groupPhoto.key` / `portrait.key` as plain object paths
+(no array identity); `DraftImageRef.key: optionalKey(AssetKey)` already accepts the rewritten key.
+**No `DraftEditor` change** — A is route + schema + view + registry wiring.
+
+`PageEditor`'s new `team` arm renders the reused `ImageUpload` control + a `Bilingual` alt input
+per image, plus the editable `subtitle`/`boardHeading` (the RichText `title` is shown read-only via
+`RichTextPreview`, consistent with volunteer/contact, `pages.$page.tsx:459-478`):
+
+```tsx
+case 'team': {
+  return (
+    <>
+      <RichTextPreview label="Title" nodes={encoded['title'] as …} />
+      <Bilingual label="Subtitle" name="subtitle" value={text(encoded['subtitle'] as DraftText)} multiline />
+      <Bilingual label="Board heading" name="boardHeading" value={text(encoded['boardHeading'] as DraftText)} />
+      <fieldset className="space-y-2">
+        <legend>Group photo</legend>
+        <ImageUpload keyPath="groupPhoto.key" currentKey={String((encoded['groupPhoto'] as any)?.key ?? '')} />
+        <Bilingual label="Group photo alt" name="groupPhoto.alt" value={text((encoded['groupPhoto'] as any)?.alt as DraftText)} />
+      </fieldset>
+      <fieldset className="space-y-2">
+        <legend>Portrait</legend>
+        <ImageUpload keyPath="portrait.key" currentKey={String((encoded['portrait'] as any)?.key ?? '')} />
+        <Bilingual label="Portrait alt" name="portrait.alt" value={text((encoded['portrait'] as any)?.alt as DraftText)} />
+      </fieldset>
+    </>
+  );
+}
+```
+
+`PAGE_LABELS` gains `team: 'Team'`. The alt-text + subtitle ride the normal save/publish path
+(`assembleOverrides` → `editDocument`), no new merge logic. The `ImageUpload` component is unchanged.
+
+## Module interface (A)
+- `pages/registry.ts`: `'team'` added to closed `PageId`; `PAGE_SPECS.team = draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage)`.
+- `pages/schema.ts`: `TeamPage` (`title: RichText`, `subtitle`/`boardHeading: Text`, `groupPhoto?/portrait?: ImageRef`) + `DraftTeamPage` (lax `DraftImageRef`); import `ImageRef`, `AssetKey`.
+- `pages/defaults.ts`: `defaultTeamPage` (title tokens, subtitle/boardHeading transcribed, images omitted).
+- `pages/project.ts`: `TeamView` + `toTeamView`; shared `assetUrl` helper extracted + exported (consumed by `content.server.ts` too).
+- `team/_index.tsx`: loader → `getPage('team')` + `getTeam()`; JSX renders CMS title/subtitle/board/images, roster unchanged.
+- `pages.$page.tsx`: new `upload:` action branch (mirrors `content.tsx`); `PageEditor` `team` arm with `ImageUpload` + alt `Bilingual`; `PAGE_LABELS.team`.
+
+## Sub-commits (A) — each gate-green
+- **A.1** `feat(pages): add TeamPage schema (RichText title + optional images)` — `TeamPage` + `DraftTeamPage` + the local `DraftImageRef`; `pages/schema.test.ts` round-trips WITH and WITHOUT each image, asserts a present image needs a strict `AssetKey`, asserts an `image`-less stored JSON decodes (the required-field-on-published-doc gate).
+- **A.2** `feat(pages): register team page + default chrome` — `PageId` `'team'`, `PAGE_SPECS.team`, `defaultTeamPage`; defaults decode at module load; `pages/registry`/read-path tests see 8 pages.
+- **A.3** `feat(pages): project team page to a per-locale view` — `TeamView` + `toTeamView` + extracted `assetUrl`; `project.test.ts` (title runs, image → `/images/<key>`, absent ⇒ `undefined`, locale-correct alt).
+- **A.4** `feat(team): render team route from the CMS page` — `team/_index.tsx` loader + JSX migration; delete the in-route `team.title`/`team.subtitle`/`team.board`/`team.image.alt` translate calls (roster + `member.position` unchanged); render-parity test vs the pre-migration markup.
+- **A.5** `feat(admin): upload images in the team page editor` — `pages.$page.tsx` `upload:` branch + `PageEditor` `team` arm + `PAGE_LABELS.team`; action test (POST `intent=upload:groupPhoto.key` + fake `File` → draft `team.json` carries `groupPhoto.key` under `images/uploads/…`).
+- **A.6** `chore(i18n): delete migrated team translation keys` — remove `team.title`, `team.title.movement`, `team.subtitle`, `team.image.alt`, `team.logo.alt`, `team.board` from `translations.ts` (EN + FR); KEEP `team.position.*` (roster) and `nav.team` (Feature C still renders the nav label). Grep proves no remaining reference (`subtract-before-you-add`).
+
+## Deletions (A)
+- The hardcoded `src="/team/group-van-2022.jpg"` and `src="/logo/gycc.png"` `<img>`s in `team/_index.tsx:34-38, 49-53` (replaced by CMS `groupPhoto`/`portrait`).
+- The `translate('team.title', { movement: … })` interpolation block (`_index.tsx:40-48`) → `<RichText>`.
+- The translation keys `team.title`, `team.title.movement`, `team.subtitle`, `team.image.alt`, `team.logo.alt`, `team.board` (A.6). `team.position.*` and `nav.team` stay.
+
+## Test surface (A)
+- `pages/schema.test.ts`: TeamPage decode WITH / WITHOUT each image; a present image requires a strict `AssetKey` (leading-`/` key rejected); a field-less stored JSON decodes (decode-migration gate); DraftTeamPage tolerates `groupPhoto.key` with no `alt`.
+- `pages/project.test.ts`: title→runs, image→`/images/<key>`, absent→`undefined`, locale alt.
+- `team/_index` render-parity test: the migrated route renders the same visible copy/structure as the pre-migration route given `defaultTeamPage` + a seeded image.
+- `pages.$page` action test (extend `cms-e2e.test.ts`): `intent=upload:groupPhoto.key` + fake `File` → draft `team.json` has `groupPhoto.key`; non-image MIME → 400; empty file → 400 (reusing the `content.tsx` guards).
+
+## Runtime proof (A)
+Boot dev, open `/admin/pages/team`, upload a JPEG to the group photo, confirm the draft stores the
+key, publish, and the `/team` route renders the uploaded `<img>` (and the portrait slot section-skips
+while empty). Confirm About/Home/FAQ editors show NO image control.
+
+---
+
+# Feature B — Image resize-on-upload (one shared boundary)
+
+**Branch:** `cms/image-resize-on-upload`
+
+## B.0 — The one shared upload boundary
+
+The *validate → read bytes → `storage.put` raw bytes* sequence lives in `content.tsx:155-159` and,
+after A, in `pages.$page.tsx`. B factors that into ONE helper both actions call, inserting the
+resize so it is applied EXACTLY ONCE regardless of which editor uploaded.
+
+New module `app/lib/content/image-optimize.server.ts`:
+
+```ts
+import { Effect } from 'effect';
+import { extensionForType } from './admin-form';
+
+export const MAX_WIDTH = 1600;          // cap; never upscale
+export const WEBP_QUALITY = 80;
+
+export interface PreparedImage {
+  readonly bytes: Uint8Array;
+  readonly contentType: string;         // 'image/webp' after re-encode, else the original
+  readonly extension: string;           // 'webp' after re-encode, else extensionForType(original)
+}
+
+export const prepareImage = (
+  bytes: Uint8Array,
+  sourceType: string,
+): Effect.Effect<PreparedImage> =>
+  Effect.gen(function* () {
+    // GIF passthrough (decision below): never decode/re-encode — would drop all but frame 1.
+    if (sourceType.toLowerCase() === 'image/gif') {
+      return { bytes, contentType: 'image/gif', extension: 'gif' };
+    }
+    return yield* Effect.tryPromise(async () => {
+      const img = new Bun.Image(bytes);
+      // CRITICAL (Codex #1): `img.width` is -1 until metadata() resolves in Bun 1.3.14.
+      // Guard the no-upscale decision on `metadata().width`, NOT `img.width`.
+      const meta = await img.metadata();
+      const chain = meta.width > MAX_WIDTH ? img.resize(MAX_WIDTH) : img;
+      const out = new Uint8Array(await chain.webp({ quality: WEBP_QUALITY }).toBuffer());
+      return { bytes: out, contentType: 'image/webp', extension: 'webp' } satisfies PreparedImage;
+    }).pipe(
+      // Optimizer-failure fallback: store ORIGINAL bytes/type — never fail an upload (Codex fallback).
+      Effect.catchAll(() =>
+        Effect.succeed({ bytes, contentType: sourceType, extension: extensionForType(sourceType) }),
+      ),
+    );
+  });
+```
+
+**VERIFIED in Bun 1.3.14** (this environment, no new dependency):
+`new Bun.Image(bytes).resize(1600).webp({quality:80}).toBuffer()` runs; `img.width === -1` before
+`metadata()` but `(await img.metadata()).width` is correct (1 for a 1×1 test PNG); the chain yields
+encoded bytes. The `metadata().width` guard (Codex #1) is the load-bearing correction over the
+prior plan, which read `img.width` (always -1) and would therefore have NEVER resized — every
+upload would have been re-encoded full-size. Note the chain is `await`-based because `metadata()`
+and `toBuffer()` are async, so the helper uses `Effect.tryPromise` (not `Effect.try`).
+
+### GIF decision (settled-#3 caveat): **skip-resize-passthrough**.
+`image/gif` is stored verbatim (original bytes, `image/gif`, `.gif`). Rationale: animated GIFs
+become a single still frame under a `Bun.Image` decode/re-encode (unrequested data loss), and an
+animated promo GIF is a legitimate use. Static GIFs pay only the original-size cost. The more
+conservative of the two allowed options (vs first-frame flatten); never surprises the admin.
+
+## B.1 — Key / extension / content-type follow the RE-ENCODED type (Codex #2 / R2)
+
+`uploadedImageKey(targetPath, contentType, seed)` builds the key with `extensionForType(contentType)`.
+The actions today pass `file.type` (SOURCE). After resize the stored object IS WebP, so the key's
+extension AND `storage.put`'s content-type must be `image/webp`, or the served object's type/extension
+lie. The boundary order becomes:
+
+```ts
+const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
+const prepared = yield* prepareImage(bytes, file.type);
+const now = yield* Clock.currentTimeMillis;
+const key = uploadedImageKey(uploadTarget, prepared.contentType, now);  // .webp (or .gif passthrough)
+const putExit = yield* Effect.exit(storage.put(key, prepared.bytes, prepared.contentType));
+```
+
+`isAcceptedImageType(file.type)` still gates the SOURCE (jpeg/png/webp/gif/avif) BEFORE `prepareImage`,
+so a PDF never reaches the optimizer. A WebP source is re-encoded to WebP (a recompress that still
+applies the width cap) — acceptable, keeps the boundary single-path.
+
+## B.2 — Apply the boundary in BOTH actions
+
+Replace the raw `storage.put(key, bytes, file.type)` trio in `content.tsx` AND `pages.$page.tsx`
+(the branch A added) with the `prepareImage` sequence. Neither route hand-rolls resize after B;
+both call the one helper (`subtract-before-you-add`: the duplicated raw-put is REPLACED, not
+paralleled). Update the now-false "the resize/WebP pipeline is deferred" comment in
+`admin-form.ts:60-66`.
+
+## Module interface (B)
+- `image-optimize.server.ts`: `prepareImage(bytes, sourceType) → Effect<PreparedImage>`, `MAX_WIDTH`, `WEBP_QUALITY`.
+- Both editor actions call `prepareImage` and key/put off `prepared.contentType`.
+
+## Sub-commits (B) — each gate-green
+- **B.1** `feat(content): add prepareImage resize-to-webp boundary` — the module + `image-optimize.server.test.ts` (resize-if-larger via `metadata().width`; no-upscale of a narrow image; GIF passthrough byte-identical; decode-failure fallback to original bytes+type; WebP-source recompress). Pure, no route change.
+- **B.2** `refactor(admin): route uploads through prepareImage in both editors` — swap both actions onto the boundary; key + put follow `prepared.contentType`; update the stale `admin-form.ts:60-66` comment; action test asserts a wide JPEG → `.webp` key + `image/webp` put.
+
+## Deletions (B)
+- The duplicated raw `storage.put(..., file.type)` step in `content.tsx` and `pages.$page.tsx` (subsumed by `prepareImage` + key-from-`prepared.contentType`).
+- The "the resize/WebP pipeline is deferred" wording in `admin-form.ts:60-61`.
+
+## Test surface (B)
+- `image-optimize.server.test.ts`: a >1600px JPEG → smaller WebP (`contentType==='image/webp'`, decoded width === 1600); a ≤1600px image is NOT upscaled (width unchanged, still re-encoded to webp); `image/gif` passes through byte-identical with `image/gif`; a corrupt buffer falls back to original bytes + original type (no throw). Use real fixture bytes decoded back through `Bun.Image().metadata()` to assert the resulting width.
+- Action-level (against `storage.test-helper.ts` in-memory `Storage`): upload a 2400px JPEG → stored key ends `.webp`, `put` got `image/webp`.
+
+## Runtime proof (B)
+Boot dev, upload a large JPEG in `/admin/pages/team` (group photo) AND in `/admin/content` (speaker
+photo): confirm BOTH store `images/uploads/…​.webp` (resized smaller), the served `/images/…` renders,
+and a `.gif` upload is stored as `.gif` unchanged.
+
+---
+
+# Feature C — Per-page `enabled` flag
+
+**Branch:** `cms/page-enabled-flag` (stacks on A; independent of B)
+
+## C.0 — Decode-safe flag on every Page (incl. the now-CMS team)
+
+Add `enabled: boolean` to EVERY Page schema — about/faq/give/contact/volunteer/archive/home **and
+team** — defaulting to `true` so an already-published doc that predates the flag still decodes, via
+`Schema.withDecodingDefaultKey` (**confirmed present in `effect@4.0.0-beta.60`**, `Schema.d.ts:3223`;
+signature `withDecodingDefaultKey<S>(defaultValue: Effect.Effect<S["Encoded"]>)`):
+
+```ts
+import { Effect, Schema } from 'effect';
+// added to each Page Struct AND each Draft* variant:
+enabled: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true))),
+```
+
+`withDecodingDefaultKey` makes the key OPTIONAL on the encoded side and supplies `true` when absent
+during decode — the same class of fix the registration launch needed twice
+(`OptionFromOptionalKey`, `schema.ts:466-489`); here a `true`-by-default boolean is the honest model
+(a page is enabled unless turned off). Because the default is identical in draft and publish, every
+Page's `draftSchema` gets the same field (the draft must round-trip it); a defaulted-optional key
+keeps draft ≡ strict for the `pageSpec` pages (contact/volunteer/home), so no new `draftPageSpec`
+is introduced for them. The list-bearing pages and `team` already use `draftPageSpec`; they get the
+field in both the strict and draft struct.
+
+`pages/defaults.ts`: set `enabled: true` explicitly in each default for self-describing seeds;
+legacy stored objects rely on the decode default.
+
+**Team's flag is just this flag.** Because A made team a `PageId`, team's visibility is
+`TeamPage.enabled` — there is NO separate `teamEnabled` on `SiteContent`. The published `team.json`
+ships `enabled: false` to preserve today's hidden-team behavior (now data-driven, not a code
+comment). This is the prior-plan's awkward `teamEnabled`-on-`SiteContent` split eliminated
+(`derive-dont-sync`).
+
+## C.1 — Read the flag to the boundary; data-driven nav (Codex R1 deletions)
+
+`Content.getPage` returns `PageContent<P>`, which now carries `enabled`. Two consumers:
+
+1. **Nav (data-driven; replaces the hardcoded team hide).** `_layout.tsx`'s loader returns
+   `{ lang, translation, currentConference }`. Extend it to also fetch the enabled set for the pages
+   the nav links — add a thin `Content.getEnabledPages()` returning `Record<PageId, boolean>` (it
+   reads the already-cached per-page objects; cheap), folded into the loader as `enabled`. Then:
+   - **DELETE** `_layout.tsx:99` `{/* <NavItem to="/team">…</NavItem> */}` (TopNav) and
+     `_layout.tsx:165` `// { to: "/team", … },` (PopupNav). Replace with a **real**
+     `NavItem to="/team"` gated on `enabled.team` — so when `team.enabled` flips true the link
+     appears, driven by data.
+   - The other nav links (about/contact/give/volunteer in `TopNav`/`PopupNav`, faq in the footer)
+     each render only when `enabled[page]` is true. No second hardcoded page list
+     (`derive-dont-sync`).
+   - **DELETE** the commented `/team` CTA block in `_index.tsx:115-120` (the `main.meet_the_team`
+     button) — Codex R1. It is dead commented code beside the flag; `subtract-before-you-add`.
+
+2. **Route AND action 404 (Codex #6).** A disabled page must 404 BOTH its public GET route AND any
+   action it owns:
+   - Each `($lang)+` page route loader checks the flag and fails with a 404 `Response`:
+     ```ts
+     const page = yield* content.getPage('give');
+     if (!page.enabled) return yield* Effect.fail(new Response('Not Found', { status: 404 }));
+     ```
+   - The team route 404s on `!page.enabled` (team is a `PageId` now).
+   - **404, not redirect** (Codex review choice): a disabled evergreen page genuinely does not exist
+     for the public; a redirect-to-home would mask a stale bookmark as a soft success. Mirrors the
+     admin routes' own `404 when disabled` (`content.tsx:96-99`).
+   - "Action 404" (Codex #6): pages with form actions (contact/volunteer post to their own route
+     actions) must ALSO 404 the action when disabled, not just the loader — otherwise a disabled
+     contact page still accepts POSTs. Each such route's `action` re-checks `getPage(id).enabled`
+     and 404s first. (Pure-content pages with no action — about/give/faq/archive/home/team — need
+     only the loader check.)
+
+## C.2 — Edit the flag in the admin editor (Codex #5/#12 coercion)
+
+`PageEditor` (`pages.$page.tsx`) gains an `enabled` checkbox per page — a new tiny `Checkbox`
+control in `controls.tsx`:
+
+```tsx
+export function Checkbox({ label, name, defaultChecked }: {
+  readonly label: string; readonly name: string; readonly defaultChecked: boolean;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <input type="checkbox" name={name} defaultChecked={defaultChecked} value="true" />
+      {label}
+    </label>
+  );
+}
+```
+
+The field rides the normal `assembleOverrides` → `editDocument` save path. `assembleOverrides`
+(`admin-form.ts:217`) today coerces only `chapter`/`verse` to numbers and treats every other leaf
+as a string; an unchecked checkbox is **absent** from FormData and a checked one posts `"true"`.
+A bare string `"true"`/absent would NOT decode as `Schema.Boolean`. Two-part fix (Codex #5/#12):
+
+- **Explicit boolean coercion in `assembleOverrides`**: a leaf named `enabled` coerces
+  `value === 'true'` → `true`, symmetric with the numeric `chapter`/`verse` coercion — keeps the
+  schema a plain `Schema.Boolean`.
+- **Absent-means-false**: an unchecked box sends nothing, so the override omits `enabled` and
+  `deepMerge` leaves the base value — which would make "uncheck + save" a no-op. To make unchecking
+  effective, the editor renders a **hidden `enabled=false` companion field before the checkbox**
+  (the classic checkbox pattern): FormData then always carries an `enabled` value (`"false"` when
+  unchecked, the checkbox's `"true"` overriding when checked — last-wins in `form.entries()` order).
+  `assembleOverrides` coerces whichever lands. This guarantees a deterministic boolean override
+  every save (Codex #5: the explicit boolean control with reliable coercion).
+
+`PageEditor` renders `<Checkbox label="Page enabled (visible in nav + routable)" name="enabled"
+defaultChecked={Boolean(encoded['enabled'] ?? true)} />` (with the hidden companion) in EVERY page
+arm — including `team`.
+
+## Module interface (C)
+- Each Page schema + Draft variant: `enabled: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true)))`.
+- `pages/defaults.ts`: explicit `enabled: true` in each default; the published `team.json` seed ships `enabled: false`.
+- `Content`: `getEnabledPages(): Effect<Record<PageId, boolean>>` (thin read over the cached page objects).
+- `pages/project.ts`: each `*View` carries `enabled: boolean` (so routes read it post-projection); `toTeamView` etc. pass it through.
+- `_layout.tsx`: loader fetches `enabled`; `TopNav`/`PopupNav` filter links; real `/team` `NavItem` gated on `enabled.team`; hardcoded team hides DELETED.
+- Each `($lang)+` page route loader (and form-bearing actions): `if (!page.enabled) → 404`.
+- `admin-form.ts`: `enabled`-leaf boolean coercion in `assembleOverrides`.
+- `controls.tsx`: `Checkbox` (+ hidden companion); `PageEditor` renders it per page.
+
+## Sub-commits (C) — each gate-green
+- **C.1** `feat(pages): add decode-safe enabled flag to every Page schema` — strict + draft + defaults; `pages/schema.test.ts`: a stored doc WITHOUT `enabled` decodes to `enabled:true`; `enabled:false` round-trips encode→decode; draft variant same; covers `team`.
+- **C.2** `feat(content): read enabled flags + project through views` — `getEnabledPages()` + `enabled` on each `*View` + converters; `content.server`/`project` tests.
+- **C.3** `feat(nav): drive nav links off enabled flags; delete hardcoded team hide` — `_layout.tsx` loader + `TopNav`/`PopupNav` filtering + real `/team` `NavItem`; DELETE the two `_layout.tsx` team comments AND the `_index.tsx:115-120` team CTA comment (Codex R1).
+- **C.4** `feat(routes): 404 disabled pages (loader + action)` — every `($lang)+` page route loader 404s when disabled; contact/volunteer ACTIONS 404 when disabled (Codex #6); team route 404s on `!enabled`.
+- **C.5** `feat(admin): edit the enabled flag` — `Checkbox` + hidden companion + `assembleOverrides` boolean coercion + `PageEditor` wiring (every page incl. team) + action test (toggle off → draft `enabled:false`; publish → route 404s).
+
+## Deletions (C)
+- `_layout.tsx:99` `{/* <NavItem to="/team">…</NavItem> */}` (TopNav hardcoded team hide).
+- `_layout.tsx:165` `// { to: "/team", … },` (PopupNav hardcoded team hide).
+- `_index.tsx:115-120` the commented `/team` CTA button (`main.meet_the_team`) — Codex R1.
+- The implicit "team is hidden" knowledge in those comments — now `enabled:false` data on `team.json`.
+
+## Test surface (C)
+- `pages/schema.test.ts`: decode `{…no enabled…}` ⇒ `enabled:true`; `enabled:false` round-trips; draft same; team covered.
+- A nav/route test (extend `cms-e2e.test.ts`): with `give.enabled=false` the give nav link is absent AND `/give` loader 404s; with `team.enabled=false` `/team` 404s and the team link is absent; flip `team.enabled=true` → link + page return.
+- Action-404 test: a POST to the contact route action while `contact.enabled=false` returns 404.
+- `admin-form.test.ts`: `assembleOverrides` coerces an `enabled` leaf to boolean (checked→true, hidden-companion→false); `editDocument` round-trips a flag toggle.
+
+## Runtime proof (C)
+Boot dev. In `/admin/pages/give` toggle `enabled` off + publish; confirm the give nav link
+disappears and `/give` returns 404; toggle back on; link + page return. Confirm team is hidden
+(driven by `team.json` `enabled:false`) with NO code comment; flip `enabled` on in `/admin/pages/team`
++ publish → the team nav link AND `/team` route return, rendering the CMS-uploaded photos from A.
+
+---
+
+# Risks (decode-migration hazards lead)
+
+1. **Required-field-on-published-doc decode break (A + C).** Adding a non-optional field to a Page
+   schema breaks every already-published `content/pages/<page>.json` that predates it — the exact
+   trap the registration launch hit TWICE. MITIGATION: A's `groupPhoto`/`portrait` are
+   `Schema.optionalKey(ImageRef)` (absent decodes fine); C's `enabled` uses
+   `withDecodingDefaultKey(Effect.succeed(true))` (absent decodes to `true`). Each is gated by a
+   schema test that decodes a field-LESS JSON and asserts success. For TEAM specifically: a `team.json`
+   stored before this work would not exist yet (team is newly a Page), but the test still pins the
+   property for forward safety.
+2. **Bun.Image `width === -1` until `metadata()` (B) — Codex #1.** The prior plan read `img.width`
+   (always -1 in Bun 1.3.14), so the no-upscale guard `width > MAX_WIDTH` was always false → NOTHING
+   would ever resize; every upload would re-encode at full resolution. MITIGATION: guard on
+   `(await img.metadata()).width`. VERIFIED in this environment. The helper is `Effect.tryPromise`
+   (metadata/toBuffer are async).
+3. **Extension/content-type lie after resize (B) — Codex #2 / R2.** Key built from `file.type` but
+   bytes are WebP ⇒ served object's extension/type mismatch. MITIGATION: key + `storage.put` both use
+   `prepared.contentType` (B.1); action test asserts `.webp` + `image/webp`.
+4. **`Bun.Image` decode/encode throw (B).** A corrupt/exotic upload could throw. MITIGATION:
+   `Effect.catchAll` fallback stores ORIGINAL bytes + original type — an upload never fails because
+   the optimizer choked. Unit-tested with a non-decodable buffer.
+5. **Animated GIF frame loss (B).** A `Bun.Image` re-encode keeps only frame 1. MITIGATION:
+   `image/gif` passthrough (stored verbatim) — no flatten, no surprise data loss.
+6. **Lax DraftImageRef so a key lands before alt (A) — Codex #3.** A strict `ImageRef` in the DRAFT
+   schema would reject an uploaded `key` with an empty `alt` (the admin uploads first, fills alt
+   second). MITIGATION: `DraftTeamPage` uses the lax `DraftImageRef` (`key: optionalKey(AssetKey)`,
+   `alt: optionalKey(DraftText)`), mirroring `schema.ts:638`. Strict publish still requires both.
+7. **`withDecodingDefaultKey` encode behavior (C).** The flag must be written back on publish so
+   re-published objects are self-describing while legacy objects keep decoding. Default
+   `encodingStrategy:'passthrough'` writes it back; a round-trip encode→decode test pins it. (If a
+   future need wants legacy objects key-less, switch to `'omit'` — noted, not used.)
+8. **Draft schema drift (A + C).** A field added to the strict schema but not its `Draft*` variant
+   makes the draft editor's encode/decode reject. MITIGATION: every schema sub-commit edits BOTH the
+   strict and draft variant in the same commit; `pages/schema.test.ts` exercises both.
+9. **`assembleOverrides` boolean coercion + unchecked-checkbox (C) — Codex #5/#12.** A non-coerced
+   `"true"` won't decode `Schema.Boolean`, and an unchecked box (absent from FormData) would make
+   "uncheck + save" a no-op. MITIGATION: explicit `enabled`-leaf coercion in `assembleOverrides`
+   (symmetric with numeric) + a hidden `enabled=false` companion field so the override is always
+   present and deterministic.
+10. **Team's per-member roster vs. page chrome confusion (A).** The migration moves only page CHROME
+    (title/subtitle/board-heading/images) to `TeamPage`; the executive roster (`team[]`/`board[]` +
+    `team.position.*` keys) stays on `site.json` via `getTeam()`. MITIGATION: A.4 leaves the roster
+    map + `member.position` translate untouched; A.6 deletes ONLY the migrated chrome keys, keeping
+    `team.position.*` and `nav.team`. A grep gate proves no dangling reference.
+11. **Action-route 404 gap (C) — Codex #6.** A disabled page whose route owns a form action (contact,
+    volunteer) would still accept POSTs if only the loader 404s. MITIGATION: those actions re-check
+    `getPage(id).enabled` and 404 first (C.4).
+12. **Shared `assetUrl` extraction (A).** Exporting `assetUrl` from `content.server.ts` (or a new tiny
+    module) must not create an import cycle (`content.server` ↔ `project`). MITIGATION: put `assetUrl`
+    in a leaf module `app/lib/content/asset-url.ts` that imports nothing from either; both import it.
+
+---
+
+# Resolved-critiques log
+
+How each blocking critique from BOTH adversarial reviews + the user decision is addressed.
+
+- **USER DECISION — image fields on TEAM, not About/Home (settles Codex #2 image-placement).**
+  Resolved: Feature A is re-scoped to a CMS migration of the Team route — new `TeamPage` with
+  `groupPhoto?`/`portrait?` optional `ImageRef`s, RichText title, `getPage('team')` loader, deleted
+  hardcoded srcs + migrated translation keys. About/Home get NO image field (A.0). The redirection
+  is logged in the branch-order reasoning and Risk 10.
+- **Codex #1 — guard on `metadata.width`, not `.width` (−1 in Bun 1.3.14).** Resolved: `prepareImage`
+  reads `(await img.metadata()).width`; verified; `Effect.tryPromise` for the async chain (B.0, Risk 2).
+- **Codex #2 — key/extension/content-type follow the re-encoded WebP.** Resolved: key + put from
+  `prepared.contentType` (B.1, Risk 3).
+- **Codex #3 — lax DraftImageRef so a key can land before alt text.** Resolved: `DraftTeamPage` uses
+  `DraftImageRef` (`key: optionalKey(AssetKey)`, `alt: optionalKey(DraftText)`) (A.1, Risk 6).
+- **Codex #4 — `enabled` defaulted via `withDecodingDefaultKey(true)` for ALL evergreen pages incl.
+  team.** Resolved: confirmed in `effect@4.0.0-beta.60`; applied to every Page strict + draft (C.0,
+  Risk 1/7).
+- **Codex #5 / #12 — explicit boolean admin control + `assembleOverrides` coercion.** Resolved:
+  `Checkbox` control + hidden `enabled=false` companion + `enabled`-leaf boolean coercion in
+  `assembleOverrides` (C.2, Risk 9).
+- **Codex #6 — route AND action 404 for disabled pages.** Resolved: every page loader 404s; form-
+  bearing actions (contact/volunteer) re-check and 404 (C.1/C.4, Risk 11). 404 chosen over redirect.
+- **Codex #8 — migrate the rich italic 'movement' title to RichText.** Resolved: `TeamPage.title` is
+  `RichText`; `defaultTeamPage` transcribes `team.title`/`team.title.movement` as `text`/`italic`
+  tokens; the route renders `<RichText>` (A.0/A.2/A.4).
+- **Codex R1 — delete every hardcoded team hide.** Resolved: both `_layout.tsx` nav comments (`:99`,
+  `:165`) AND the commented `/team` CTA in `_index.tsx:115-120` DELETED; team visibility is the
+  `TeamPage.enabled` flag (C.1/C.3, Risk 10).
+- **R2 — single shared resize boundary, duplicated raw-put deleted.** Resolved: one `prepareImage`
+  in `image-optimize.server.ts`, both actions call it; raw-put removed (B.0/B.2,
+  subtract-before-you-add).
+- **R3 — optimizer failure must not fail the upload.** Resolved: `Effect.catchAll` → original bytes
+  fallback (B.0, Risk 4).
+- **R4 — animated GIF silently flattened.** Resolved: GIF passthrough, no flatten (B.0, Risk 5).
+- **R5 — reuse the existing AssetKey/ImageUpload/upload:/applyImageUpload, no parallel path.**
+  Resolved: A reuses all four verbatim; the per-page action mirrors `content.tsx` (A.5, R5/settled #2).
+- **R6 — nav must be data-driven, not a second hardcoded list.** Resolved: nav filters off the
+  `getEnabledPages()` read in the layout loader; no parallel page list (C.1, derive-dont-sync).
+- **Branch-order critique — does C depend on A, or is the flag independent of team's CMS-ness?**
+  RESOLVED: because team is now a `PageId` (A), team's flag IS the per-page `enabled` flag on the
+  CMS `TeamPage` — so C consumes A and MUST follow it. There is no separate `teamEnabled` on
+  `SiteContent` (the prior plan's path), which removes that risk class entirely (branch-order
+  reasoning; C.0).


### PR DESCRIPTION
## Feature A — Team CMS migration + per-page image upload

Migrates the hand-built Team route into the per-page CMS model (`docs/cms-images-enable-plan.md` §A.0–A.6). A new `TeamPage` Page object owns the page **chrome** (RichText title with the italic `movement` run, subtitle, board heading, and two optional `ImageRef` image slots); the per-member executive roster stays on `site.json` via `getTeam()`. The `upload:` intent is wired into the per-page editor, **reusing the existing upload path verbatim** — no parallel path.

### What landed (plan module interface)
- `pages/schema.ts`: `TeamPage` (`title: RichText`, `subtitle`/`boardHeading: Text`, `groupPhoto?`/`portrait?: Schema.optionalKey(ImageRef)`) + lax `DraftTeamPage` (`DraftImageRef`: `key`+`alt` both optional, so an uploaded key can land before alt text). Decode-safe: a stored `team.json` without an image slot still decodes (section-skip, ADR 0008).
- `pages/registry.ts`: `'team'` added to the closed `PageId`; `PAGE_SPECS.team = draftPageSpec(...)`.
- `pages/defaults.ts`: `defaultTeamPage` transcribes today's translation-key chrome (title tokens, subtitle, board heading); image slots omitted (uploaded via CMS).
- `pages/project.ts`: `TeamView` + `toTeamView`; shared `assetUrl` helper extracted to `app/lib/content/asset-url.ts` (consumed by `content.server.ts` too — `derive-dont-sync`, no import cycle).
- `team/_index.tsx`: loader → `getPage('team')` + `getTeam()`; JSX renders CMS title/subtitle/board/images (section-skip on absent image); roster + `member.position` translate unchanged.
- `pages.$page.tsx`: new `upload:` action branch mirroring `content.tsx`; `PageEditor` `team` arm with reused `ImageUpload` + alt `Bilingual`; `PAGE_LABELS.team`.
- `translations.ts`: migrated team chrome keys deleted; `team.position.*` (roster) + `nav.team` kept.

**Upload path is the existing one:** `AssetKey` → `ImageUpload` → `upload:<keyPath>` intent → `uploadedImageKey` → `DraftEditor.applyImageUpload`. No new AssetKey, no second upload path. (Confirmed by the --deep review's passed checks.)

## Counsel cadence

**Per-commit (standard) counsel** ran on each of the 9 sub-commits (A.1–A.6 + the test-tightening commits) during implementation, applying blocking feedback per commit.

**Final --deep whole-PR counsel (this PR):** Verdict **Block → resolved**. One blocking integration bug a per-commit review missed:

> Publishing Team after a normal save can fail when images are intentionally omitted. The editor always renders both alt-text `Bilingual` controls, so a plain save creates `groupPhoto: { alt: { en:"", fr:"" } }` with no `key` — draft-valid but strict publish rejects it with `Missing key at ["groupPhoto"]["key"]`.

(The review's second finding — Features B/C absent — is **out of scope**: this is the A-only branch of the A→B→C stack per the plan; the reviewer explicitly noted "If this branch is scoped strictly to A.0-A.6, treat B/C as out-of-scope, not a blocker.")

### Fix (commit `7ccfb54`)
`pruneKeylessImageOverrides(base, override)` (mirrors the existing `normalizeFaqAnswers` precedent) drops an alt-only image slot at the `editDocument` merge boundary **unless** the draft already carries a `key` for that slot (so the upload-first / fill-alt-second flow still lands the alt onto the existing image). Section-skip is for absence of the whole slot, not a present-but-keyless object.

Reproduced the bug first (real `editDocument` → `publish` failed `groupPhoto.key: Missing key`), then verified the fix on both paths. Regression-tested at:
- **unit** — `pruneKeylessImageOverrides` (drop keyless / keep when base has key / keep fresh-upload key / non-team pass-through / full merge→draft+strict decode);
- **e2e** — real `editDocument` → `publish` over in-memory storage: plain Team save publishes with both slots section-skipped; upload-key→fill-alt→publish lands the alt on the existing image.

## Gate (green after fix)
- `bun run typecheck` — clean
- `bun run lint` — clean (one pre-existing unrelated warning in `app/lib/effect/form.test.ts`)
- `bun run build` — ✓
- `bun test` — **418 pass / 0 fail** (was 411; +7 regression tests)

A human merges.
