### PR TITLE
feat(cms): per-page enabled flag (Feature C)

### DIFF
--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -13,10 +13,11 @@ import {
   defaultAboutPage,
   defaultContactForm,
   defaultFaqPage,
+  defaultGivePage,
   defaultTeamPage,
 } from './content/pages/defaults';
 import { formObjectKey, pageObjectKey } from './content/pages/registry';
-import { AboutPage, FaqPage } from './content/pages/schema';
+import { AboutPage, FaqPage, GivePage, TeamPage } from './content/pages/schema';
 import { FormDefinition } from './forms/definition';
 import { HexColour, SiteContent } from './content/schema';
 import type { SiteContent as SiteContentType } from './content/schema';
@@ -586,6 +587,57 @@ describe('Content.getPage / getForm multi-object read path (ADR 0008, Branch 5.3
       const team = yield* content.getPage('team');
       expect(team).toEqual(defaultTeamPage);
     }).pipe(Effect.provide(Layer.provideMerge(Content.layer, emptyStorage))));
+
+  it.effect('getEnabledPages returns the per-page flag for every page (defaults: team false, rest true)', () =>
+    Effect.gen(function* () {
+      const content = yield* Content.Service;
+      // Empty bucket → every page falls back to its bundled default's flag.
+      const enabled = yield* content.getEnabledPages();
+      expect(enabled).toEqual({
+        about: true,
+        faq: true,
+        give: true,
+        contact: true,
+        volunteer: true,
+        archive: true,
+        home: true,
+        // The bundled team default ships enabled:false (hidden by data).
+        team: false,
+      });
+    }).pipe(Effect.provide(Layer.provideMerge(Content.layer, emptyStorage))));
+
+  it.effect('getEnabledPages reflects a published object whose enabled flag is flipped', () =>
+    Effect.gen(function* () {
+      const content = yield* Content.Service;
+      const enabled = yield* content.getEnabledPages();
+      // A published give.json with enabled:false flips give off; team.json with
+      // enabled:true flips team on — both data-driven, read off the page objects.
+      expect(enabled.give).toBe(false);
+      expect(enabled.team).toBe(true);
+      expect(enabled.about).toBe(true);
+    }).pipe(
+      Effect.provide(
+        Layer.provideMerge(
+          Content.layer,
+          Layer.unwrap(
+            Effect.gen(function* () {
+              const giveJson = yield* seedJson(
+                Schema.encodeUnknownEffect(Schema.fromJsonString(GivePage)),
+                GivePage.make({ ...defaultGivePage, enabled: false }),
+              );
+              const teamJson = yield* seedJson(
+                Schema.encodeUnknownEffect(Schema.fromJsonString(TeamPage)),
+                TeamPage.make({ ...defaultTeamPage, enabled: true }),
+              );
+              return layerTest({
+                [pageObjectKey('give')]: { body: giveJson },
+                [pageObjectKey('team')]: { body: teamJson },
+              });
+            }),
+          ),
+        ),
+      ),
+    ));
 
   it.effect('getForm falls back to the bundled default when the object is absent', () =>
     Effect.gen(function* () {

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -431,6 +431,18 @@ export class Service extends Context.Service<
       page: P,
     ) => Effect.Effect<PageContent<P>>;
     /**
+     * The per-page `enabled` visibility flag for EVERY page, read off the same
+     * cached page objects `getPage` reads (Feature C). The nav layout loader folds
+     * this into its data so links render data-driven — a page's link appears iff
+     * its `enabled` is true — with NO second hardcoded page list (`derive-dont-sync`,
+     * the rejected "team-hide nav comment" path). A disabled page's route + action
+     * 404 off the same flag (read via `getPage`). Returns a total
+     * `Record<PageId, boolean>` over the closed page set; a page whose object is
+     * absent/malformed falls back to its bundled default's flag (team's default is
+     * `false`, every other is `true`).
+     */
+    readonly getEnabledPages: () => Effect.Effect<Record<PageId, boolean>>;
+    /**
      * Read one Form definition object (`forms/<form>.json`), decoded at its own
      * boundary through the registry schema, with the same per-object fallback +
      * cache as `getPage`. This is the read path Branch 6's form engine reads its
@@ -618,6 +630,18 @@ export const layer = Layer.effect(
       return (yield* formCaches[form].read) as FormContent<F>;
     });
 
+    // Read every page's cached object and project to its `enabled` flag — a thin
+    // derived read over the SAME per-object caches `getPage` uses (no new cache,
+    // no parallel source). The nav drives off this; a disabled page also 404s its
+    // route/action off the per-page flag (`derive-dont-sync`).
+    const getEnabledPages = Effect.fn('Content.getEnabledPages')(function* () {
+      const enabled = {} as Record<PageId, boolean>;
+      for (const page of PAGE_IDS) {
+        enabled[page] = (yield* getPage(page)).enabled;
+      }
+      return enabled;
+    });
+
     const getConference = Effect.fn('Content.getConference')(function* (
       locale: Locale,
       year?: number,
@@ -687,6 +711,7 @@ export const layer = Layer.effect(
       getTranslations,
       getTeam,
       getPage,
+      getEnabledPages,
       getForm,
       bust,
     });

--- a/app/lib/content/admin-form.test.ts
+++ b/app/lib/content/admin-form.test.ts
@@ -67,6 +67,24 @@ describe('assembleOverrides', () => {
     expect(result.conferences['/2024']?.bible.chapter).toBe(12);
     expect(result.conferences['/2024']?.bible.verse).toBe(3);
   });
+
+  test('coerces an `enabled` leaf to a real boolean (Feature C, Codex #5/#12)', () => {
+    // A CHECKED box posts the hidden `enabled=false` companion FIRST, then the
+    // checkbox `enabled=true` — `form.entries()` yields BOTH in order, and
+    // `setPath`'s last-wins gives `true`. A bare `"true"` string would NOT decode
+    // as `Schema.Boolean`, so it must coerce to a real boolean.
+    const checked = assembleOverrides([
+      ['enabled', 'false'],
+      ['enabled', 'true'],
+    ]) as { enabled: unknown };
+    expect(checked.enabled).toBe(true);
+
+    // An UNCHECKED box posts only the hidden `enabled=false` companion.
+    const unchecked = assembleOverrides([['enabled', 'false']]) as {
+      enabled: unknown;
+    };
+    expect(unchecked.enabled).toBe(false);
+  });
 });
 
 describe('normalizeFaqAnswers', () => {

--- a/app/lib/content/admin-form.ts
+++ b/app/lib/content/admin-form.ts
@@ -207,10 +207,17 @@ export const assembleOverrides = (
     if (isTranslationField(name)) continue;
     const path = name.split('.');
     const leaf = path[path.length - 1];
+    // Leaf-name coercion so the form's string FormData decodes at the typed schema
+    // boundary: `chapter`/`verse` are numbers; `enabled` (the per-page visibility
+    // checkbox, Feature C) is a real boolean — a bare `"true"`/`"false"` string
+    // would NOT decode as `Schema.Boolean` (Codex #5/#12). The hidden-companion +
+    // checkbox always post an `enabled` value, so this coercion is deterministic.
     const coerced: Json =
       (leaf === 'chapter' || leaf === 'verse') && value.trim() !== ''
         ? Number(value)
-        : value;
+        : leaf === 'enabled'
+          ? value === 'true'
+          : value;
     setPath(root, path, coerced);
   }
   return root;

--- a/app/lib/content/page-guard.server.test.ts
+++ b/app/lib/content/page-guard.server.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Exit, Layer, Schema } from 'effect';
+
+import { Content } from '../content.server';
+import { NotFoundError } from '../effect/errors';
+import { Storage } from '../storage.server';
+import { layerTest } from '../storage.test-helper';
+import { defaultGivePage, defaultTeamPage } from './pages/defaults';
+import { pageObjectKey } from './pages/registry';
+import { GivePage, TeamPage } from './pages/schema';
+import { getEnabledPageOr404 } from './page-guard.server';
+
+/**
+ * `getEnabledPageOr404` is the shared 404 gate every public page route loader (and,
+ * via `formAction`, the contact/volunteer actions) reads through (Feature C, Codex
+ * #6). These pin its contract: an ENABLED page is returned (its decoded content,
+ * carrying `enabled: true`); a DISABLED page fails with `NotFoundError` (mapped to a
+ * 404 by the runtime) — a disabled evergreen page genuinely does not exist for the
+ * public. Driven off the SAME per-page object the nav reads (`derive-dont-sync`).
+ */
+
+const seedJson = <A>(
+  schema: Schema.Codec<A, unknown>,
+  value: A,
+): Effect.Effect<string> =>
+  Schema.encodeUnknownEffect(Schema.fromJsonString(schema))(value).pipe(
+    Effect.orDie,
+  );
+
+const provide = (storage: Layer.Layer<Storage.Service>) =>
+  Effect.provide(Layer.provideMerge(Content.layer, storage));
+
+/** True iff the exit failed with a `NotFoundError` (the 404 the runtime maps). */
+const failedWithNotFound = (exit: Exit.Exit<unknown, unknown>): boolean =>
+  Exit.isFailure(exit) &&
+  exit.cause.reasons.some(
+    (reason) => reason._tag === 'Fail' && NotFoundError.is(reason.error),
+  );
+
+describe('getEnabledPageOr404', () => {
+  it.effect('returns the page when enabled (give default is enabled:true)', () =>
+    Effect.gen(function* () {
+      // Empty bucket → bundled default give page, which is enabled:true.
+      const give = yield* getEnabledPageOr404('give');
+      expect(give.enabled).toBe(true);
+      expect(give.donateUrl).toBe(defaultGivePage.donateUrl);
+    }).pipe(provide(layerTest({}))));
+
+  it.effect('fails with NotFoundError when the page is disabled (give.enabled=false)', () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(getEnabledPageOr404('give'));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(failedWithNotFound(exit)).toBe(true);
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.provideMerge(
+          Content.layer,
+          Layer.unwrap(
+            seedJson(
+              GivePage,
+              GivePage.make({ ...defaultGivePage, enabled: false }),
+            ).pipe(
+              Effect.map((json) =>
+                layerTest({ [pageObjectKey('give')]: { body: json } }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+  it.effect('team default is hidden (404s) until flipped enabled:true', () =>
+    Effect.gen(function* () {
+      // Empty bucket → bundled team default, which ships enabled:false → 404.
+      const exit = yield* Effect.exit(getEnabledPageOr404('team'));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(failedWithNotFound(exit)).toBe(true);
+      }
+    }).pipe(provide(layerTest({}))));
+
+  it.effect('a published team.json with enabled:true is returned (the page exists again)', () =>
+    Effect.gen(function* () {
+      const team = yield* getEnabledPageOr404('team');
+      expect(team.enabled).toBe(true);
+      expect(team.subtitle).toEqual(defaultTeamPage.subtitle);
+    }).pipe(
+      Effect.provide(
+        Layer.provideMerge(
+          Content.layer,
+          Layer.unwrap(
+            seedJson(
+              TeamPage,
+              TeamPage.make({ ...defaultTeamPage, enabled: true }),
+            ).pipe(
+              Effect.map((json) =>
+                layerTest({ [pageObjectKey('team')]: { body: json } }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+});

--- a/app/lib/content/page-guard.server.ts
+++ b/app/lib/content/page-guard.server.ts
@@ -1,0 +1,32 @@
+import { Effect } from 'effect';
+
+import { Content } from '../content.server';
+import type { PageContent, PageId } from './pages/registry';
+import { type NotFoundError, notFound } from '../effect/errors';
+
+/**
+ * Read an evergreen Page object and 404 it when the page is DISABLED (Feature C).
+ *
+ * A page's `enabled` flag is the single source of its public visibility: a disabled
+ * page genuinely does not exist for the public, so its route GET — AND any action it
+ * owns — must 404, not soft-redirect a stale bookmark to home (Codex #6; mirrors the
+ * admin area's own 404-when-disabled). The flag is read off the SAME cached page
+ * object the route renders, so the guard and the nav (`getEnabledPages`) never
+ * diverge (`derive-dont-sync`). The runtime maps the yielded `NotFoundError` to a
+ * `404` response for both loaders and actions.
+ *
+ * Returns the decoded `PageContent<P>` on success, so a loader does
+ * `const page = yield* getEnabledPageOr404('give')` and projects it — one read, one
+ * gate, no second `getPage` call.
+ */
+export const getEnabledPageOr404 = <P extends PageId>(
+  page: P,
+): Effect.Effect<PageContent<P>, NotFoundError, Content.Service> =>
+  Effect.gen(function* () {
+    const content = yield* Content.Service;
+    const pageContent = yield* content.getPage(page);
+    if (!pageContent.enabled) {
+      return yield* notFound();
+    }
+    return pageContent;
+  });

--- a/app/lib/content/pages/defaults.ts
+++ b/app/lib/content/pages/defaults.ts
@@ -51,6 +51,7 @@ const PAYPAL_DONATE =
 // ---------------------------------------------------------------------------
 
 export const defaultAboutPage: AboutPage = Schema.decodeUnknownSync(AboutPage)({
+  enabled: true,
   title: { en: 'About Us', fr: 'Notre histoire' },
   paragraphs: [
     {
@@ -111,6 +112,7 @@ export const defaultAboutPage: AboutPage = Schema.decodeUnknownSync(AboutPage)({
 // ---------------------------------------------------------------------------
 
 export const defaultFaqPage: FaqPage = Schema.decodeUnknownSync(FaqPage)({
+  enabled: true,
   title: { en: 'Frequently Asked Questions', fr: 'Foire aux questions' },
   items: [
     {
@@ -247,6 +249,7 @@ export const defaultFaqPage: FaqPage = Schema.decodeUnknownSync(FaqPage)({
 // ---------------------------------------------------------------------------
 
 export const defaultGivePage: GivePage = Schema.decodeUnknownSync(GivePage)({
+  enabled: true,
   title: { en: 'Support the movement.', fr: 'Soutenez le mouvement.' },
   reason: {
     en: "Our call to mission, is to be the light of the world. Our Savior calls us to a worldwide mission of spreading the gospel of Christ's love in this world filled with darkness. This light should not be hidden, covered by the humdrum of life, but out in the open, where all can see and hear. GYC Canada wants to magnify that light, to bring it to all of Canada and the world.",
@@ -292,6 +295,7 @@ export const defaultGivePage: GivePage = Schema.decodeUnknownSync(GivePage)({
 export const defaultContactPage: ContactPage = Schema.decodeUnknownSync(
   ContactPage,
 )({
+  enabled: true,
   title: { en: 'Get in touch with us!', fr: 'Entrez en contact avec nous!' },
   directions: [
     {
@@ -323,6 +327,7 @@ export const defaultContactPage: ContactPage = Schema.decodeUnknownSync(
 export const defaultVolunteerPage: VolunteerPage = Schema.decodeUnknownSync(
   VolunteerPage,
 )({
+  enabled: true,
   title: [
     { _tag: 'text', value: { en: 'Become a part of the ', fr: 'Faites partie du ' } },
     { _tag: 'bold', value: { en: 'movement', fr: 'mouvement' } },
@@ -345,6 +350,7 @@ export const defaultVolunteerPage: VolunteerPage = Schema.decodeUnknownSync(
 export const defaultArchivePage: ArchivePage = Schema.decodeUnknownSync(
   ArchivePage,
 )({
+  enabled: true,
   title: { en: 'Archive', fr: 'Archives' },
   entries: [],
 });
@@ -354,6 +360,7 @@ export const defaultArchivePage: ArchivePage = Schema.decodeUnknownSync(
 // ---------------------------------------------------------------------------
 
 export const defaultHomePage: HomePage = Schema.decodeUnknownSync(HomePage)({
+  enabled: true,
   tagline: {
     en: 'GYC Canada is a movement founded by young people for young people.',
     fr: 'GYC Canada est un mouvement fondé par des jeunes pour des jeunes.',
@@ -399,8 +406,15 @@ export const defaultHomePage: HomePage = Schema.decodeUnknownSync(HomePage)({
  * `team.json` therefore renders the roster + copy with NO broken `<img>`; the launch
  * upload sets `groupPhoto` / `portrait`. (The legacy `public/team/group-van-2022.jpg`
  * + `public/logo/gycc.png` stay on disk until an upload supersedes them.)
+ *
+ * `enabled: false`: the Team page ships HIDDEN — preserving today's hidden-team
+ * behavior as DATA (the seed `team.json`'s own flag), not a hardcoded nav comment
+ * (Feature C, `derive-dont-sync`). The launch flips it on in `/admin/pages/team`
+ * once the photos are uploaded; until then the route 404s and the nav link is
+ * absent, driven entirely off this flag.
  */
 export const defaultTeamPage: TeamPage = Schema.decodeUnknownSync(TeamPage)({
+  enabled: false,
   title: [
     {
       _tag: 'text',

--- a/app/lib/content/pages/project.test.ts
+++ b/app/lib/content/pages/project.test.ts
@@ -4,6 +4,7 @@ import { Schema } from 'effect';
 import { Locale } from '../../localization/localization';
 import {
   defaultAboutPage,
+  defaultArchivePage,
   defaultContactPage,
   defaultFaqPage,
   defaultGivePage,
@@ -13,6 +14,7 @@ import {
 } from './defaults';
 import {
   toAboutView,
+  toArchiveView,
   toContactView,
   toFaqView,
   toGiveView,
@@ -204,6 +206,7 @@ describe('per-page projection', () => {
     expect(toGiveView(defaultGivePage, Locale.En).enabled).toBe(true);
     expect(toContactView(defaultContactPage, Locale.En).enabled).toBe(true);
     expect(toVolunteerView(defaultVolunteerPage, Locale.En).enabled).toBe(true);
+    expect(toArchiveView(defaultArchivePage, Locale.En).enabled).toBe(true);
     expect(toHomeView(defaultHomePage, Locale.En).enabled).toBe(true);
     expect(toTeamView(defaultTeamPage, Locale.En).enabled).toBe(false);
 

--- a/app/lib/content/pages/project.test.ts
+++ b/app/lib/content/pages/project.test.ts
@@ -194,6 +194,29 @@ describe('per-page projection', () => {
     expect(fr.portrait?.alt).toBe('Logo FR.');
   });
 
+  it('every converter projects the page `enabled` flag through verbatim (Feature C)', () => {
+    // The flag is read off the projected view by the route (404 when !enabled) and
+    // by the nav loader (via getEnabledPages). Each converter must carry the
+    // decoded object's flag, not re-declare one (`derive-dont-sync`). Team's
+    // default ships `false`; every other ships `true`.
+    expect(toAboutView(defaultAboutPage, Locale.En).enabled).toBe(true);
+    expect(toFaqView(defaultFaqPage, Locale.En).enabled).toBe(true);
+    expect(toGiveView(defaultGivePage, Locale.En).enabled).toBe(true);
+    expect(toContactView(defaultContactPage, Locale.En).enabled).toBe(true);
+    expect(toVolunteerView(defaultVolunteerPage, Locale.En).enabled).toBe(true);
+    expect(toHomeView(defaultHomePage, Locale.En).enabled).toBe(true);
+    expect(toTeamView(defaultTeamPage, Locale.En).enabled).toBe(false);
+
+    // A flipped flag projects through: a team page decoded with enabled:true.
+    const enabledTeam = Schema.decodeUnknownSync(TeamPage)({
+      enabled: true,
+      title: [{ _tag: 'text', value: { en: 'Team', fr: 'Équipe' } }],
+      subtitle: { en: 'Sub.', fr: 'Sous.' },
+      boardHeading: { en: 'Board', fr: 'Conseil' },
+    });
+    expect(toTeamView(enabledTeam, Locale.En).enabled).toBe(true);
+  });
+
   it('home: nested evergreen copy collapses to the locale', () => {
     const en = toHomeView(defaultHomePage, Locale.En);
     expect(en.tagline).toBe(defaultHomePage.tagline.en);

--- a/app/lib/content/pages/project.ts
+++ b/app/lib/content/pages/project.ts
@@ -69,7 +69,14 @@ export const toRichText = (
 // Per-page view types (what the routes render — plain per-locale strings)
 // ---------------------------------------------------------------------------
 
+/**
+ * Every page view carries the page's `enabled` flag (Feature C) so a route can read
+ * it POST-projection — the route 404s when `!view.enabled`, and the nav layout
+ * derives its links from `getEnabledPages()`. Projected through verbatim by each
+ * converter (`derive-dont-sync`: the flag is the decoded object's, not re-declared).
+ */
 export interface AboutView {
+  readonly enabled: boolean;
   readonly title: string;
   readonly paragraphs: readonly { readonly id: string; readonly text: string }[];
   readonly disclaimer: string;
@@ -81,6 +88,7 @@ export interface AboutView {
 }
 
 export interface FaqView {
+  readonly enabled: boolean;
   readonly title: string;
   readonly items: readonly {
     readonly id: string;
@@ -90,6 +98,7 @@ export interface FaqView {
 }
 
 export interface GiveView {
+  readonly enabled: boolean;
   readonly title: string;
   readonly reason: string;
   readonly directions: readonly { readonly id: string; readonly text: string }[];
@@ -97,17 +106,20 @@ export interface GiveView {
 }
 
 export interface ContactView {
+  readonly enabled: boolean;
   readonly title: string;
   readonly directions: readonly RichTextRun[];
 }
 
 export interface VolunteerView {
+  readonly enabled: boolean;
   readonly title: readonly RichTextRun[];
   readonly subtitle: string;
   readonly directions: string;
 }
 
 export interface ArchiveView {
+  readonly enabled: boolean;
   readonly title: string;
   readonly entries: readonly {
     readonly id: string;
@@ -117,6 +129,7 @@ export interface ArchiveView {
 }
 
 export interface HomeView {
+  readonly enabled: boolean;
   readonly tagline: string;
   readonly mission: { readonly readStoryLabel: string };
   readonly join: {
@@ -140,6 +153,7 @@ export interface HomeView {
  * broken image (`make-impossible-states-unrepresentable`, ADR 0008).
  */
 export interface TeamView {
+  readonly enabled: boolean;
   readonly title: readonly RichTextRun[];
   readonly subtitle: string;
   readonly boardHeading: string;
@@ -152,6 +166,7 @@ export interface TeamView {
 // ---------------------------------------------------------------------------
 
 export const toAboutView = (page: AboutPage, locale: Locale): AboutView => ({
+  enabled: page.enabled,
   title: page.title[locale],
   paragraphs: page.paragraphs.map((p) => ({
     id: p.id,
@@ -166,6 +181,7 @@ export const toAboutView = (page: AboutPage, locale: Locale): AboutView => ({
 });
 
 export const toFaqView = (page: FaqPage, locale: Locale): FaqView => ({
+  enabled: page.enabled,
   title: page.title[locale],
   items: page.items.map((item) => ({
     id: item.id,
@@ -175,6 +191,7 @@ export const toFaqView = (page: FaqPage, locale: Locale): FaqView => ({
 });
 
 export const toGiveView = (page: GivePage, locale: Locale): GiveView => ({
+  enabled: page.enabled,
   title: page.title[locale],
   reason: page.reason[locale],
   directions: page.directions.map((d) => ({ id: d.id, text: d.text[locale] })),
@@ -185,6 +202,7 @@ export const toContactView = (
   page: ContactPage,
   locale: Locale,
 ): ContactView => ({
+  enabled: page.enabled,
   title: page.title[locale],
   directions: toRichText(page.directions, locale),
 });
@@ -193,6 +211,7 @@ export const toVolunteerView = (
   page: VolunteerPage,
   locale: Locale,
 ): VolunteerView => ({
+  enabled: page.enabled,
   title: toRichText(page.title, locale),
   subtitle: page.subtitle[locale],
   directions: page.directions[locale],
@@ -202,6 +221,7 @@ export const toArchiveView = (
   page: ArchivePage,
   locale: Locale,
 ): ArchiveView => ({
+  enabled: page.enabled,
   title: page.title[locale],
   entries: page.entries.map((e) => ({
     id: e.id,
@@ -211,6 +231,7 @@ export const toArchiveView = (
 });
 
 export const toHomeView = (page: HomePage, locale: Locale): HomeView => ({
+  enabled: page.enabled,
   tagline: page.tagline[locale],
   mission: { readStoryLabel: page.mission.readStoryLabel[locale] },
   join: {
@@ -227,6 +248,7 @@ export const toHomeView = (page: HomePage, locale: Locale): HomeView => ({
 });
 
 export const toTeamView = (page: TeamPage, locale: Locale): TeamView => ({
+  enabled: page.enabled,
   title: toRichText(page.title, locale),
   subtitle: page.subtitle[locale],
   boardHeading: page.boardHeading[locale],

--- a/app/lib/content/pages/schema.test.ts
+++ b/app/lib/content/pages/schema.test.ts
@@ -349,3 +349,94 @@ describe('draft page variants tolerate id-only adds; strict schema blocks publis
     expect(Schema.decodeUnknownResult(FaqPage)(filled)._tag).toBe('Success');
   });
 });
+
+/**
+ * The per-page `enabled` flag (Feature C) is decode-safe via
+ * `withDecodingDefaultKey(Effect.succeed(true))`: a stored `content/pages/<page>.json`
+ * that PREDATES the flag (no `enabled` key) must still decode — to `enabled: true` —
+ * so adding the field can never break an already-published doc (the
+ * required-field-on-a-published-doc hazard the registration launch hit twice). An
+ * explicit `enabled: false` round-trips encode→decode (the passthrough writes it
+ * back, so a re-published object is self-describing). The flag lives on BOTH the
+ * strict and the draft schema (no draft drift), covered across every page incl. team.
+ */
+describe('per-page enabled flag (decode-safe, default true)', () => {
+  // Every page's strict schema, plus a minimal valid encoded body MISSING `enabled`.
+  const strictCases = [
+    ['AboutPage', AboutPage, { title: { en: 'A', fr: 'A' }, paragraphs: [], disclaimer: { en: 'd', fr: 'd' }, quotes: [] }],
+    ['FaqPage', FaqPage, { title: { en: 'F', fr: 'F' }, items: [] }],
+    ['GivePage', GivePage, { title: { en: 'G', fr: 'G' }, reason: { en: 'r', fr: 'r' }, directions: [], donateUrl: 'https://example.org/donate' }],
+    ['ContactPage', ContactPage, { title: { en: 'C', fr: 'C' }, directions: [] }],
+    ['VolunteerPage', VolunteerPage, { title: [], subtitle: { en: 's', fr: 's' }, directions: { en: 'd', fr: 'd' } }],
+    ['ArchivePage', ArchivePage, { title: { en: 'Ar', fr: 'Ar' }, entries: [] }],
+    ['HomePage', HomePage, {
+      tagline: { en: 't', fr: 't' },
+      mission: { readStoryLabel: { en: 'r', fr: 'r' } },
+      join: { title: { en: 'j', fr: 'j' }, subtitle: { en: 's', fr: 's' }, donateLabel: { en: 'd', fr: 'd' }, volunteerLabel: { en: 'v', fr: 'v' } },
+      newsletter: { title: { en: 'n', fr: 'n' }, subtitle: { en: 's', fr: 's' }, socials: { en: 'so', fr: 'so' } },
+    }],
+    ['TeamPage', TeamPage, { title: [], subtitle: { en: 's', fr: 's' }, boardHeading: { en: 'b', fr: 'b' } }],
+  ] as const;
+
+  for (const [name, schema, bodyNoEnabled] of strictCases) {
+    test(`${name}: a stored doc WITHOUT enabled decodes to enabled:true (decode-migration gate)`, () => {
+      const result = Schema.decodeUnknownResult(
+        schema as Schema.Codec<{ readonly enabled: boolean }, unknown>,
+      )(bodyNoEnabled);
+      expect(result._tag).toBe('Success');
+      if (result._tag === 'Success') {
+        expect(result.success.enabled).toBe(true);
+      }
+    });
+
+    it.effect(`${name}: enabled:false round-trips encode→decode`, () =>
+      Effect.gen(function* () {
+        const codec = schema as Schema.Codec<
+          { readonly enabled: boolean },
+          unknown
+        >;
+        const decoded = yield* Schema.decodeUnknownEffect(codec)({
+          ...bodyNoEnabled,
+          enabled: false,
+        });
+        expect(decoded.enabled).toBe(false);
+        const roundtripped = yield* roundTrips(codec, decoded);
+        expect(roundtripped.enabled).toBe(false);
+      }));
+  }
+
+  // The DRAFT variants carry the same defaulted flag (no draft-schema drift).
+  const draftCases = [
+    ['DraftAboutPage', DraftAboutPage, { title: { en: 'A', fr: 'A' }, paragraphs: [], disclaimer: { en: 'd', fr: 'd' }, quotes: [] }],
+    ['DraftFaqPage', DraftFaqPage, { title: { en: 'F', fr: 'F' }, items: [] }],
+    ['DraftGivePage', DraftGivePage, { title: { en: 'G', fr: 'G' }, reason: { en: 'r', fr: 'r' }, directions: [], donateUrl: 'https://example.org/donate' }],
+    ['DraftArchivePage', DraftArchivePage, { title: { en: 'Ar', fr: 'Ar' }, entries: [] }],
+    ['DraftTeamPage', DraftTeamPage, { title: [], subtitle: { en: 's', fr: 's' }, boardHeading: { en: 'b', fr: 'b' } }],
+  ] as const;
+
+  for (const [name, schema, bodyNoEnabled] of draftCases) {
+    test(`${name}: a draft doc WITHOUT enabled decodes to enabled:true`, () => {
+      const result = Schema.decodeUnknownResult(
+        schema as Schema.Codec<{ readonly enabled: boolean }, unknown>,
+      )(bodyNoEnabled);
+      expect(result._tag).toBe('Success');
+      if (result._tag === 'Success') {
+        expect(result.success.enabled).toBe(true);
+      }
+    });
+  }
+
+  test('the bundled defaultTeamPage ships enabled:false (hidden by data, not a code comment)', () => {
+    expect(defaultTeamPage.enabled).toBe(false);
+  });
+
+  test('every other bundled default ships enabled:true', () => {
+    expect(defaultAboutPage.enabled).toBe(true);
+    expect(defaultFaqPage.enabled).toBe(true);
+    expect(defaultGivePage.enabled).toBe(true);
+    expect(defaultContactPage.enabled).toBe(true);
+    expect(defaultVolunteerPage.enabled).toBe(true);
+    expect(defaultArchivePage.enabled).toBe(true);
+    expect(defaultHomePage.enabled).toBe(true);
+  });
+});

--- a/app/lib/content/pages/schema.ts
+++ b/app/lib/content/pages/schema.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect';
+import { Effect, Schema } from 'effect';
 
 import { AssetKey, ExternalHttpsUrl, ImageRef, ListItemId, Text } from '../schema';
 
@@ -137,6 +137,31 @@ const IdListArray = <S extends Schema.Codec<{ readonly id: string }, unknown>>(
 ) => Schema.Array(item).check(uniqueListItemIds);
 
 // ---------------------------------------------------------------------------
+// EnabledFlag — the decode-safe per-page visibility boolean (Feature C)
+// ---------------------------------------------------------------------------
+
+/**
+ * The per-page `enabled` boolean: whether the page is visible in the nav AND
+ * routable (a disabled page 404s its public loader + any action it owns, and its
+ * nav link is absent). Modelled with `withDecodingDefaultKey(Effect.succeed(true))`
+ * so the key is OPTIONAL on the encoded (stored-JSON) side and supplies `true` when
+ * absent during decode — an already-published `content/pages/<page>.json` that
+ * predates this field still decodes to `enabled: true` (the
+ * required-field-on-an-already-published-doc decode hazard the registration launch
+ * hit twice — here a `true`-by-default boolean is the honest model: a page is
+ * enabled unless explicitly turned off).
+ *
+ * The default `encodingStrategy: 'passthrough'` writes the flag back on encode, so a
+ * re-published object is self-describing (carries its own `enabled`) while a legacy
+ * key-less object keeps decoding to `true`. Identical in the strict and draft
+ * schemas so a page's draft round-trips the flag (no draft-schema drift). Reused by
+ * EVERY page — `derive-dont-sync`, one flag definition.
+ */
+const EnabledFlag = Schema.Boolean.pipe(
+  Schema.withDecodingDefaultKey(Effect.succeed(true)),
+);
+
+// ---------------------------------------------------------------------------
 // Pages
 // ---------------------------------------------------------------------------
 
@@ -148,6 +173,7 @@ const IdListArray = <S extends Schema.Codec<{ readonly id: string }, unknown>>(
  * `about.quote.N.verse`/`.source` pair).
  */
 export const AboutPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   paragraphs: IdListArray(Schema.Struct({ id: ListItemId, text: Text })),
   disclaimer: Text,
@@ -164,6 +190,7 @@ export type AboutPage = typeof AboutPage.Type;
  * runs round-trip without HTML.
  */
 export const FaqPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   items: IdListArray(
     Schema.Struct({ id: ListItemId, question: Text, answer: RichText }),
@@ -178,6 +205,7 @@ export type FaqPage = typeof FaqPage.Type;
  * boundary as the conference URLs).
  */
 export const GivePage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   reason: Text,
   directions: IdListArray(Schema.Struct({ id: ListItemId, text: Text })),
@@ -192,6 +220,7 @@ export type GivePage = typeof GivePage.Type;
  * the settled boundary (#5, CONTEXT §Page / §Form definition).
  */
 export const ContactPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   directions: RichText,
 });
@@ -203,6 +232,7 @@ export type ContactPage = typeof ContactPage.Type;
  * form. As with Contact, the form fields belong to the `FormDefinition`, not here.
  */
 export const VolunteerPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: RichText,
   subtitle: Text,
   directions: Text,
@@ -217,6 +247,7 @@ export type VolunteerPage = typeof VolunteerPage.Type;
  * nothing). `url` is an `ExternalHttpsUrl` (an archive link may point off-site).
  */
 export const ArchivePage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   entries: IdListArray(
     Schema.Struct({ id: ListItemId, label: Text, url: ExternalHttpsUrl }),
@@ -233,6 +264,7 @@ export type ArchivePage = typeof ArchivePage.Type;
  * home here, or the retirement regresses (plan, Branch 5).
  */
 export const HomePage = Schema.Struct({
+  enabled: EnabledFlag,
   tagline: Text,
   mission: Schema.Struct({
     readStoryLabel: Text,
@@ -274,6 +306,7 @@ export type HomePage = typeof HomePage.Type;
  *     image carries a strict `{ key, alt }` (a valid `AssetKey` + both-locales alt).
  */
 export const TeamPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: RichText,
   subtitle: Text,
   boardHeading: Text,
@@ -315,6 +348,7 @@ const DraftText = Schema.Struct({
 });
 
 export const DraftAboutPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   paragraphs: IdListArray(
     Schema.Struct({ id: ListItemId, text: Schema.optionalKey(DraftText) }),
@@ -331,6 +365,7 @@ export const DraftAboutPage = Schema.Struct({
 export type DraftAboutPage = typeof DraftAboutPage.Type;
 
 export const DraftFaqPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   items: IdListArray(
     Schema.Struct({
@@ -343,6 +378,7 @@ export const DraftFaqPage = Schema.Struct({
 export type DraftFaqPage = typeof DraftFaqPage.Type;
 
 export const DraftGivePage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   reason: Text,
   directions: IdListArray(
@@ -353,6 +389,7 @@ export const DraftGivePage = Schema.Struct({
 export type DraftGivePage = typeof DraftGivePage.Type;
 
 export const DraftArchivePage = Schema.Struct({
+  enabled: EnabledFlag,
   title: Text,
   entries: IdListArray(
     Schema.Struct({
@@ -386,6 +423,7 @@ const DraftImageRef = Schema.Struct({
  * lax `DraftImageRef`) so an uploaded `key` can land before its alt text.
  */
 export const DraftTeamPage = Schema.Struct({
+  enabled: EnabledFlag,
   title: RichText,
   subtitle: Text,
   boardHeading: Text,

--- a/app/lib/effect/form.ts
+++ b/app/lib/effect/form.ts
@@ -137,6 +137,21 @@ const handleFormError = (
 export const routeFormAction =
   <Eff extends Effect.Yieldable<any, any, any, FormServices>>(
     body: () => Generator<Eff, FormSuccess, never>,
+    options?: {
+      /**
+       * A ROUTE-LEVEL guard run BEFORE form-data parse + honeypot handling. Its
+       * failure propagates straight to the runtime (it is NOT bucketed by
+       * {@link handleFormError}), so a `NotFoundError` here becomes a real 404 for
+       * EVERY POST — including a honeypot-filled one. This is the seam a disabled
+       * page's action 404 uses (Feature C, Codex #6): the page does not exist, so
+       * no submission is even read.
+       */
+      readonly guard?: Effect.Effect<
+        void,
+        AppError,
+        AppServices | ReactRouterContext
+      >;
+    },
   ) =>
   (args: RouteArgs): Promise<FormResult> => {
     const pipeline: Effect.Effect<
@@ -144,6 +159,9 @@ export const routeFormAction =
       AppError,
       AppServices | ReactRouterContext
     > = Effect.gen(function* () {
+      if (options?.guard !== undefined) {
+        yield* options.guard;
+      }
       const reactRouter = yield* ReactRouterContext;
       const formData = yield* Effect.tryPromise({
         try: () => reactRouter.request.formData(),

--- a/app/lib/effect/form.ts
+++ b/app/lib/effect/form.ts
@@ -105,8 +105,13 @@ const handleFormError = (
       formLevelError(submission, error.message || 'Bad request'),
     );
   }
+  // A 404 is a route-level outcome, not a form-validation outcome: a disabled
+  // page's action (Feature C) and a disabled feature's action (the newsletter
+  // when SendGrid is unconfigured) both `notFound()`, and the public must see a
+  // real 404 — not a 200 form-error report against a page that doesn't exist.
+  // Re-fail so the runtime maps it to a 404 Response (the C1 mapping).
   if (NotFoundError.is(error)) {
-    return Effect.succeed(formLevelError(submission, 'Not found'));
+    return Effect.fail(error);
   }
   if (InternalServerError.is(error)) {
     return Effect.succeed(formLevelError(submission, 'An error occurred'));

--- a/app/lib/forms/action.test.ts
+++ b/app/lib/forms/action.test.ts
@@ -5,8 +5,12 @@ import { RouterContextProvider } from 'react-router';
 import { Schema } from 'effect';
 
 import { Content } from '../content.server';
-import { defaultContactForm } from '../content/pages/defaults';
-import { formObjectKey } from '../content/pages/registry';
+import {
+  defaultContactForm,
+  defaultContactPage,
+} from '../content/pages/defaults';
+import { formObjectKey, pageObjectKey } from '../content/pages/registry';
+import { ContactPage } from '../content/pages/schema';
 import { formValidationError } from '../effect/errors';
 import { makeAppLayer, makeRequestRuntimeFromLayer } from '../effect/runtime';
 import { ReactRouterContext, type RouteArgs } from '../effect/router-context';
@@ -68,6 +72,7 @@ describe('formAction', () => {
     let notified: Submission | undefined;
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: (submission) =>
         Effect.sync(() => {
           notified = submission;
@@ -125,6 +130,7 @@ describe('formAction', () => {
     let notified: Submission | undefined;
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: (submission) =>
         Effect.sync(() => {
           notified = submission;
@@ -162,6 +168,7 @@ describe('formAction', () => {
   it('a present-blank inactive field (the pre-fix unconditional render) FAILS — why the renderer must gate it', async () => {
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: () => Effect.void,
       success: {
         title: 'contact.form.success.title',
@@ -191,6 +198,7 @@ describe('formAction', () => {
   it('a notify failure aborts the redirect and reports a form-level error', async () => {
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: () =>
         Effect.fail(formValidationError({ formErrors: ['contact.form.error'] })),
       success: {
@@ -240,6 +248,7 @@ describe('formAction', () => {
 
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: () =>
         Effect.fail(formValidationError({ formErrors: ['contact.form.error'] })),
       success: {
@@ -294,10 +303,75 @@ describe('formAction', () => {
     expect(form.title.en).toBe(editedTitle);
   });
 
+  it('404s the action when the owning page is DISABLED (Feature C, Codex #6)', async () => {
+    // Seed a published contact page object with enabled:false. The action must
+    // 404 BEFORE decode/persist/notify — a disabled page rejects POSTs too, not
+    // only its GET. Encode the default contact page with the flag flipped off.
+    const encodePage = Schema.encodeUnknownEffect(
+      Schema.fromJsonString(ContactPage),
+    );
+    const pageJson = await Effect.runPromise(
+      encodePage(ContactPage.make({ ...defaultContactPage, enabled: false })),
+    );
+
+    let notifyRan = false;
+    const action = formAction({
+      form: 'contact',
+      page: 'contact',
+      notify: () =>
+        Effect.sync(() => {
+          notifyRan = true;
+        }),
+      success: {
+        title: 'contact.form.success.title',
+        description: 'contact.form.success.description',
+      },
+    });
+
+    const url = 'http://localhost/contact';
+    const request = new Request(url, {
+      method: 'POST',
+      body: new URLSearchParams({
+        method: 'email',
+        name: 'Ada',
+        email: 'ada@example.com',
+        message: 'hi',
+      }),
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    });
+    const context = new RouterContextProvider();
+    context.runtime = makeRequestRuntimeFromLayer(
+      makeAppLayer(
+        layerTest({ [pageObjectKey('contact')]: { body: pageJson } }),
+      ),
+    );
+
+    let thrown: unknown;
+    try {
+      await action({
+        request,
+        url: new URL(url),
+        pattern: '/contact',
+        params: {},
+        context,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    // The runtime maps the yielded NotFoundError to a 404 (React Router's
+    // `data('Not Found', { status: 404 })`, a `DataWithResponseInit`), and the
+    // body (decode/persist/notify) never ran.
+    const status = (thrown as { init?: { status?: number } })?.init?.status;
+    expect(status).toBe(404);
+    expect(notifyRan).toBe(false);
+  });
+
   it('skips the body (no notify) when the honeypot is filled', async () => {
     let notifyRan = false;
     const action = formAction({
       form: 'contact',
+      page: 'contact',
       notify: () =>
         Effect.sync(() => {
           notifyRan = true;

--- a/app/lib/forms/action.test.ts
+++ b/app/lib/forms/action.test.ts
@@ -303,10 +303,13 @@ describe('formAction', () => {
     expect(form.title.en).toBe(editedTitle);
   });
 
-  it('404s the action when the owning page is DISABLED (Feature C, Codex #6)', async () => {
-    // Seed a published contact page object with enabled:false. The action must
-    // 404 BEFORE decode/persist/notify — a disabled page rejects POSTs too, not
-    // only its GET. Encode the default contact page with the flag flipped off.
+  // Run a contact `formAction` whose owning page is seeded DISABLED, against the
+  // given POST body. Returns the thrown 404 (a `DataWithResponseInit`) + whether
+  // notify ran. The gate must 404 EVERY POST, including a honeypot-filled one, so
+  // both bodies route through this helper.
+  const runDisabledPagePost = async (
+    body: Record<string, string>,
+  ): Promise<{ thrown: unknown; notifyRan: boolean }> => {
     const encodePage = Schema.encodeUnknownEffect(
       Schema.fromJsonString(ContactPage),
     );
@@ -331,19 +334,12 @@ describe('formAction', () => {
     const url = 'http://localhost/contact';
     const request = new Request(url, {
       method: 'POST',
-      body: new URLSearchParams({
-        method: 'email',
-        name: 'Ada',
-        email: 'ada@example.com',
-        message: 'hi',
-      }),
+      body: new URLSearchParams(body),
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });
     const context = new RouterContextProvider();
     context.runtime = makeRequestRuntimeFromLayer(
-      makeAppLayer(
-        layerTest({ [pageObjectKey('contact')]: { body: pageJson } }),
-      ),
+      makeAppLayer(layerTest({ [pageObjectKey('contact')]: { body: pageJson } })),
     );
 
     let thrown: unknown;
@@ -358,10 +354,32 @@ describe('formAction', () => {
     } catch (error) {
       thrown = error;
     }
+    return { thrown, notifyRan };
+  };
 
-    // The runtime maps the yielded NotFoundError to a 404 (React Router's
-    // `data('Not Found', { status: 404 })`, a `DataWithResponseInit`), and the
-    // body (decode/persist/notify) never ran.
+  it('404s the action when the owning page is DISABLED (Feature C, Codex #6)', async () => {
+    // A disabled page rejects POSTs too, not only its GET. The runtime maps the
+    // yielded NotFoundError to a 404 (React Router's `data('Not Found', { status:
+    // 404 })`, a `DataWithResponseInit`), and the body never ran.
+    const { thrown, notifyRan } = await runDisabledPagePost({
+      method: 'email',
+      name: 'Ada',
+      email: 'ada@example.com',
+      message: 'hi',
+    });
+    const status = (thrown as { init?: { status?: number } })?.init?.status;
+    expect(status).toBe(404);
+    expect(notifyRan).toBe(false);
+  });
+
+  it('404s a HONEYPOT-filled POST to a disabled page (gate runs before honeypot)', async () => {
+    // The route-level gate runs BEFORE form-data parse + honeypot handling, so a
+    // honeypot-filled POST to a disabled page 404s too — it must NOT short-circuit
+    // to a 200-ish honeypot "success" that masks the disabled page (Codex #6).
+    const { thrown, notifyRan } = await runDisabledPagePost({
+      name: 'Ada',
+      website: 'https://spam.example', // honeypot
+    });
     const status = (thrown as { init?: { status?: number } })?.init?.status;
     expect(status).toBe(404);
     expect(notifyRan).toBe(false);

--- a/app/lib/forms/action.ts
+++ b/app/lib/forms/action.ts
@@ -1,8 +1,8 @@
 import { Effect, Result } from 'effect';
 
 import { Content } from '../content.server';
-import type { FormId } from '../content/pages/registry';
-import { formValidationError } from '../effect/errors';
+import type { FormId, PageId } from '../content/pages/registry';
+import { formValidationError, notFound } from '../effect/errors';
 import {
   type FormSuccess,
   routeFormAction,
@@ -83,6 +83,14 @@ export interface SuccessToast {
  */
 export interface FormActionConfig<E> {
   readonly form: FormId;
+  /**
+   * The evergreen `PageId` that OWNS this form's route (contact ↔ contact page,
+   * volunteer ↔ volunteer page). The action 404s when that page is DISABLED
+   * (Feature C, Codex #6): a disabled page must reject POSTs too, not only its GET
+   * — otherwise a disabled contact page would still accept submissions. Gated off
+   * the SAME per-page `enabled` flag the loader/nav read (`derive-dont-sync`).
+   */
+  readonly page: PageId;
   readonly notify: (
     submission: Submission,
   ) => Effect.Effect<
@@ -120,6 +128,13 @@ export const formAction = <E>(config: FormActionConfig<E>) =>
     const content = yield* Content.Service;
     const submissions = yield* Submissions.Service;
     const toast = yield* Toast;
+
+    // 404 the action when the owning page is disabled (Feature C, Codex #6): a
+    // disabled page rejects POSTs too, not only its GET. Read off the same
+    // per-page `enabled` flag the loader/nav use.
+    if (!(yield* content.getPage(config.page)).enabled) {
+      return yield* notFound();
+    }
 
     const definition = yield* content.getForm(config.form);
 

--- a/app/lib/forms/action.ts
+++ b/app/lib/forms/action.ts
@@ -122,40 +122,47 @@ export interface FormActionConfig<E> {
  *   5. `toast.redirect(pathname, { success copy, form })`.
  */
 export const formAction = <E>(config: FormActionConfig<E>) =>
-  routeFormAction(function* () {
-    const { url } = yield* ReactRouterContext;
-    const submission = yield* SubmissionContext;
-    const content = yield* Content.Service;
-    const submissions = yield* Submissions.Service;
-    const toast = yield* Toast;
+  routeFormAction(
+    function* () {
+      const { url } = yield* ReactRouterContext;
+      const submission = yield* SubmissionContext;
+      const content = yield* Content.Service;
+      const submissions = yield* Submissions.Service;
+      const toast = yield* Toast;
 
-    // 404 the action when the owning page is disabled (Feature C, Codex #6): a
-    // disabled page rejects POSTs too, not only its GET. Read off the same
-    // per-page `enabled` flag the loader/nav use.
-    if (!(yield* content.getPage(config.page)).enabled) {
-      return yield* notFound();
-    }
+      const definition = yield* content.getForm(config.form);
 
-    const definition = yield* content.getForm(config.form);
+      const decoded = decodeForm(definition, submission.payload);
+      if (Result.isFailure(decoded)) {
+        return yield* formValidationError(formatSchemaResult(decoded) ?? {});
+      }
 
-    const decoded = decodeForm(definition, submission.payload);
-    if (Result.isFailure(decoded)) {
-      return yield* formValidationError(formatSchemaResult(decoded) ?? {});
-    }
+      // Persist FIRST: the durable `submissions/<form>/<id>.json` object is
+      // written and returned before any notification runs, so a `notify` failure
+      // provably cannot lose the record (settled #8). A `StorageError` here aborts
+      // the submission (losing a record must never look like success).
+      const stored = yield* submissions.persist(config.form, decoded.success);
 
-    // Persist FIRST: the durable `submissions/<form>/<id>.json` object is written
-    // and returned before any notification runs, so a `notify` failure provably
-    // cannot lose the record (settled #8). A `StorageError` here aborts the
-    // submission (losing a record must never look like success).
-    const stored = yield* submissions.persist(config.form, decoded.success);
+      yield* config.notify(stored);
 
-    yield* config.notify(stored);
-
-    yield* toast.redirect(url.pathname, {
-      title: config.success.title,
-      description: config.success.description,
-      type: 'success',
-      form: config.form,
-    });
-    return { reset: true } satisfies FormSuccess;
-  });
+      yield* toast.redirect(url.pathname, {
+        title: config.success.title,
+        description: config.success.description,
+        type: 'success',
+        form: config.form,
+      });
+      return { reset: true } satisfies FormSuccess;
+    },
+    {
+      // ROUTE-LEVEL 404 gate, run BEFORE form-data parse + honeypot handling so a
+      // disabled page rejects EVERY POST (incl. a honeypot-filled one), not only
+      // the normal body path (Feature C, Codex #6, Risk 11). Read off the same
+      // per-page `enabled` flag the loader/nav use (`derive-dont-sync`).
+      guard: Effect.gen(function* () {
+        const content = yield* Content.Service;
+        if (!(yield* content.getPage(config.page)).enabled) {
+          return yield* notFound();
+        }
+      }),
+    },
+  );

--- a/app/lib/localization/translations.ts
+++ b/app/lib/localization/translations.ts
@@ -4,7 +4,6 @@ const en = {
   'main.reserve': 'Learn More',
   'main.read_bible': 'Read in Context',
   'main.time_left': 'See you in {{days}} days',
-  'main.meet_the_team': 'Meet the team',
   'main.newsletter.name.label': 'Full Name',
   'main.newsletter.name.placeholder': 'Full Name',
   'main.newsletter.email.label': 'Email',
@@ -267,7 +266,6 @@ const fr: Record<TranslationKey, string> = {
 
   'main.time_left': 'Rendez-vous dans {{days}} jours',
 
-  'main.meet_the_team': 'Rencontrez l’équipe',
   'main.newsletter.name.label': 'Nom complet',
   'main.newsletter.name.placeholder': 'Nom complet',
   'main.newsletter.email.placeholder': 'Courriel',

--- a/app/routes/($lang)+/_index.action.test.ts
+++ b/app/routes/($lang)+/_index.action.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import { Effect, Schema } from 'effect';
+import { RouterContextProvider } from 'react-router';
+
+import { defaultHomePage } from '~/lib/content/pages/defaults';
+import { pageObjectKey } from '~/lib/content/pages/registry';
+import { HomePage } from '~/lib/content/pages/schema';
+import { makeAppLayer, makeRequestRuntimeFromLayer } from '~/lib/effect/runtime';
+import type { RouteArgs } from '~/lib/effect/router-context';
+import { layerTest } from '~/lib/storage.test-helper';
+
+import { action } from './_index';
+
+/**
+ * The home route owns the newsletter POST action. Feature C / Codex #6 require a
+ * disabled page to 404 its OWNED action too, not only its GET — and the 404 gate
+ * must run BEFORE honeypot handling so a honeypot-filled POST cannot short-circuit
+ * to a 200-ish "success" that masks the 404. These pin that contract for the home
+ * action specifically (the contact/volunteer formAction path is pinned in
+ * `forms/action.test.ts`).
+ */
+
+const seedDisabledHome = async (): Promise<RouteArgs['context']> => {
+  const json = await Effect.runPromise(
+    Schema.encodeUnknownEffect(Schema.fromJsonString(HomePage))(
+      HomePage.make({ ...defaultHomePage, enabled: false }),
+    ),
+  );
+  const context = new RouterContextProvider();
+  context.runtime = makeRequestRuntimeFromLayer(
+    makeAppLayer(layerTest({ [pageObjectKey('home')]: { body: json } })),
+  );
+  return context;
+};
+
+const postHome = async (
+  body: Record<string, string>,
+): Promise<{ init?: { status?: number } } | undefined> => {
+  const url = 'http://localhost/';
+  const request = new Request(url, {
+    method: 'POST',
+    body: new URLSearchParams(body),
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  });
+  let thrown: unknown;
+  try {
+    await action({
+      request,
+      url: new URL(url),
+      pattern: '/',
+      params: {},
+      context: await seedDisabledHome(),
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  return thrown as { init?: { status?: number } } | undefined;
+};
+
+describe('home newsletter action 404s when the home page is disabled', () => {
+  it('404s a normal newsletter POST to a disabled home page', async () => {
+    const thrown = await postHome({
+      name: 'Ada',
+      email: 'ada@example.com',
+    });
+    expect(thrown?.init?.status).toBe(404);
+  });
+
+  it('404s a HONEYPOT-filled POST to a disabled home page (gate before honeypot)', async () => {
+    const thrown = await postHome({
+      name: 'Ada',
+      // The honeypot field; if the gate ran AFTER honeypot handling this would
+      // short-circuit to success and mask the 404.
+      website: 'https://spam.example',
+    });
+    expect(thrown?.init?.status).toBe(404);
+  });
+});

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -61,37 +61,49 @@ export const loader = routeHandler(function* () {
   };
 });
 
-export const action = routeFormAction(function* () {
-  const { url } = yield* ReactRouterContext;
-  const submission = yield* SubmissionContext;
-  const env = yield* Env.Service;
-  if (Option.isNone(env.sendgrid)) {
-    return yield* notFound();
-  }
-  const sendgrid = yield* Sendgrid.Service;
-  const toast = yield* Toast;
+export const action = routeFormAction(
+  function* () {
+    const { url } = yield* ReactRouterContext;
+    const submission = yield* SubmissionContext;
+    const sendgrid = yield* Sendgrid.Service;
+    const toast = yield* Toast;
 
-  const parsed = parseSchema(schema, submission.payload);
-  if (Result.isFailure(parsed)) {
-    return yield* formValidationError(formatSchemaResult(parsed) ?? {});
-  }
-  const data = parsed.success;
+    const parsed = parseSchema(schema, submission.payload);
+    if (Result.isFailure(parsed)) {
+      return yield* formValidationError(formatSchemaResult(parsed) ?? {});
+    }
+    const data = parsed.success;
 
-  const result = yield* Effect.exit(sendgrid.subscribe(data.email, data.name));
-  if (result._tag === "Failure") {
-    yield* Effect.logError("newsletter subscribe failed", result.cause);
-    return yield* formValidationError({
-      formErrors: ["main.newsletter.error" satisfies TranslationKey],
+    const result = yield* Effect.exit(sendgrid.subscribe(data.email, data.name));
+    if (result._tag === "Failure") {
+      yield* Effect.logError("newsletter subscribe failed", result.cause);
+      return yield* formValidationError({
+        formErrors: ["main.newsletter.error" satisfies TranslationKey],
+      });
+    }
+
+    return yield* toast.redirect(url.pathname, {
+      type: "success",
+      title: "main.newsletter.success.title" satisfies TranslationKey,
+      description: "main.newsletter.success.description" satisfies TranslationKey,
+      form: "newsletter-form",
     });
-  }
-
-  return yield* toast.redirect(url.pathname, {
-    type: "success",
-    title: "main.newsletter.success.title" satisfies TranslationKey,
-    description: "main.newsletter.success.description" satisfies TranslationKey,
-    form: "newsletter-form",
-  });
-});
+  },
+  {
+    // ROUTE-LEVEL 404 gate, run BEFORE form-data parse + honeypot handling so a
+    // honeypot-filled POST cannot short-circuit to success and mask a 404 (Codex
+    // #6). The newsletter action 404s when (a) the home page is DISABLED (Feature
+    // C — same flag the loader/nav read), or (b) SendGrid is unconfigured (the
+    // feature does not exist). Both are route-level outcomes, not form errors.
+    guard: Effect.gen(function* () {
+      yield* getEnabledPageOr404("home");
+      const env = yield* Env.Service;
+      if (Option.isNone(env.sendgrid)) {
+        return yield* notFound();
+      }
+    }),
+  },
+);
 
 export default function Index() {
   const { newsletterEnabled, page } = useLoaderData<typeof loader>();

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -12,6 +12,7 @@ import { match } from "ts-pattern";
 import { Breakpoint, useBreakpoint } from "~/lib/client-hints";
 import { FormProvider, useForm } from "~/lib/conform";
 import { Content } from "~/lib/content.server";
+import { getEnabledPageOr404 } from "~/lib/content/page-guard.server";
 import { toHomeView } from "~/lib/content/pages/project";
 import { dayjs } from "~/lib/dayjs";
 import { formValidationError, notFound } from "~/lib/effect/errors";
@@ -54,7 +55,8 @@ export const loader = routeHandler(function* () {
   const env = yield* Env.Service;
   return {
     conference: yield* content.getCurrentConference(locale),
-    page: toHomeView(yield* content.getPage("home"), locale),
+    // 404 when the home page is disabled (Feature C); else project the decoded page.
+    page: toHomeView(yield* getEnabledPageOr404("home"), locale),
     newsletterEnabled: Option.isSome(env.sendgrid),
   };
 });

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -113,11 +113,6 @@ export default function Index() {
               {page.mission.readStoryLabel}
             </Link>
           </div>
-          {/* <div>
-            <Link to="/team" className={buttonStyle} data-variant="positive">
-              {translate("main.meet_the_team")}
-            </Link>
-          </div> */}
         </div>
       </section>
       {newsletterEnabled ? (

--- a/app/routes/($lang)+/_layout.test.tsx
+++ b/app/routes/($lang)+/_layout.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToString } from 'react-dom/server';
+import { createRoutesStub } from 'react-router';
+
+import type { PageId } from '~/lib/content/pages/registry';
+import { LocalizationProvider } from '~/lib/localization/provider';
+import { root as translations } from '~/lib/localization/translations';
+
+import { Footer, TopNav } from './_layout';
+
+/**
+ * The nav is DATA-DRIVEN off the per-page `enabled` flags (Feature C, Codex R6):
+ * every consumer (desktop TopNav + footer) derives its links from one nav model
+ * filtered by `enabled[page]` — there is no hardcoded team-hide. These render
+ * tests pin the observable contract: a disabled page's link is ABSENT from the
+ * markup, and flipping `team.enabled` makes the `/team` link appear/disappear with
+ * NO code change. (The mobile PopupNav maps the same `visibleLinks(PRIMARY_NAV)`
+ * source, so the desktop assertion covers the shared filter.)
+ */
+
+/** Every page enabled (the all-on baseline); override per test. */
+const allEnabled = (): Record<PageId, boolean> => ({
+  about: true,
+  faq: true,
+  give: true,
+  contact: true,
+  volunteer: true,
+  archive: true,
+  home: true,
+  team: true,
+});
+
+const currentConference = {
+  title: 'SPEAK',
+  dates: ['2026-08-12T00:00:00.000Z'],
+} as const;
+
+/**
+ * Render a nav component (`TopNav` / `Footer`) with supplied `enabled` loader data.
+ * Both read `useLoaderData` + `useTranslate`, so they mount inside a
+ * `createRoutesStub` route (whose `loader` data satisfies `useLoaderData`) wrapped
+ * in a `LocalizationProvider` (satisfying `useTranslate`).
+ */
+const renderNav = (
+  Component: typeof TopNav | typeof Footer,
+  enabled: Record<PageId, boolean>,
+): string => {
+  const Stub = createRoutesStub([
+    {
+      id: 'layout',
+      path: ':lang?',
+      Component: () => (
+        <LocalizationProvider translation={translations.en}>
+          <Component />
+        </LocalizationProvider>
+      ),
+    },
+  ]);
+
+  return renderToString(
+    <Stub
+      initialEntries={['/']}
+      hydrationData={{
+        loaderData: {
+          layout: { lang: 'en', enabled, currentConference },
+        },
+      }}
+    />,
+  );
+};
+
+describe('TopNav data-driven links (enabled flags)', () => {
+  it('renders every primary link when all pages are enabled', () => {
+    const html = renderNav(TopNav, allEnabled());
+    expect(html).toContain('href="/about"');
+    expect(html).toContain('href="/team"');
+    expect(html).toContain('href="/contact"');
+    expect(html).toContain('href="/give"');
+    expect(html).toContain('href="/volunteer"');
+  });
+
+  it('omits a disabled page link (give.enabled=false → no /give link)', () => {
+    const html = renderNav(TopNav, { ...allEnabled(), give: false });
+    expect(html).not.toContain('href="/give"');
+    // Sibling links are unaffected.
+    expect(html).toContain('href="/about"');
+    expect(html).toContain('href="/volunteer"');
+  });
+
+  it('hides /team when team.enabled=false and shows it when true (no code change)', () => {
+    const hidden = renderNav(TopNav, { ...allEnabled(), team: false });
+    expect(hidden).not.toContain('href="/team"');
+
+    const shown = renderNav(TopNav, { ...allEnabled(), team: true });
+    expect(shown).toContain('href="/team"');
+  });
+});
+
+describe('Footer data-driven links (enabled flags)', () => {
+  it('renders the footer page links when enabled, omitting a disabled FAQ', () => {
+    const html = renderNav(Footer, { ...allEnabled(), faq: false });
+    expect(html).toContain('href="/about"');
+    expect(html).toContain('href="/contact"');
+    expect(html).toContain('href="/give"');
+    // FAQ is footer-only and disabled here → absent.
+    expect(html).not.toContain('href="/faq"');
+  });
+});

--- a/app/routes/($lang)+/_layout.tsx
+++ b/app/routes/($lang)+/_layout.tsx
@@ -14,9 +14,11 @@ import { match } from "ts-pattern";
 
 import { Breakpoint, useBreakpoint } from "~/lib/client-hints";
 import { Content } from "~/lib/content.server";
+import type { PageId } from "~/lib/content/pages/registry";
 import { ReactRouterContext } from "~/lib/effect/router-context";
 import { routeHandler } from "~/lib/effect/route";
 import { useTranslate } from "~/lib/localization/context";
+import type { TranslationKey } from "~/lib/localization/translations";
 import { getLocale, Locale } from "~/lib/localization/localization";
 import { LocalizationProvider } from "~/lib/localization/provider";
 import { useRootLoader } from "~/lib/root-loader";
@@ -38,6 +40,43 @@ export const loader = routeHandler(function* () {
   const enabled = yield* content.getEnabledPages();
   return { lang, translation, currentConference, enabled };
 });
+
+/**
+ * One nav-link model entry: the evergreen `PageId` whose `enabled` flag gates the
+ * link, the route it points to, and the translation key for its label. EVERY nav
+ * consumer (desktop TopNav, mobile PopupNav, footer) derives its links from these
+ * single lists filtered by `enabled[page]` — there is no second hardcoded
+ * page-visibility list (`derive-dont-sync`, Feature C / Codex R6). Adding or hiding
+ * a page link is a data/flag change, never a per-consumer edit.
+ */
+interface NavLink {
+  readonly page: PageId;
+  readonly to: string;
+  readonly labelKey: TranslationKey;
+}
+
+/** The primary nav links (TopNav + PopupNav), in render order. */
+const PRIMARY_NAV: readonly NavLink[] = [
+  { page: "about", to: "/about", labelKey: "nav.about" },
+  { page: "team", to: "/team", labelKey: "nav.team" },
+  { page: "contact", to: "/contact", labelKey: "nav.contact" },
+  { page: "give", to: "/give", labelKey: "nav.give" },
+  { page: "volunteer", to: "/volunteer", labelKey: "nav.volunteer" },
+];
+
+/** The footer links (a subset that historically surfaces FAQ instead of team). */
+const FOOTER_NAV: readonly NavLink[] = [
+  { page: "about", to: "/about", labelKey: "nav.about" },
+  { page: "contact", to: "/contact", labelKey: "nav.contact" },
+  { page: "give", to: "/give", labelKey: "nav.give" },
+  { page: "faq", to: "/faq", labelKey: "nav.faq" },
+];
+
+/** The links from a nav list whose page is enabled, in declaration order. */
+const visibleLinks = (
+  links: readonly NavLink[],
+  enabled: Record<PageId, boolean>,
+): readonly NavLink[] => links.filter((link) => enabled[link.page]);
 
 export default function Layout() {
   const { translation } = useLoaderData<typeof loader>();
@@ -81,7 +120,7 @@ function Nav() {
     .otherwise(() => <TopNav />);
 }
 
-function TopNav() {
+export function TopNav() {
   const translate = useTranslate();
   const { enabled } = useLoaderData<typeof loader>();
 
@@ -100,19 +139,11 @@ function TopNav() {
             year: new Date().getFullYear(),
           })}
         </NavItem>
-        {enabled.about && (
-          <NavItem to="/about">{translate("nav.about")}</NavItem>
-        )}
-        {enabled.team && (
-          <NavItem to="/team">{translate("nav.team")}</NavItem>
-        )}
-        {enabled.contact && (
-          <NavItem to="/contact">{translate("nav.contact")}</NavItem>
-        )}
-        {enabled.give && <NavItem to="/give">{translate("nav.give")}</NavItem>}
-        {enabled.volunteer && (
-          <NavItem to="/volunteer">{translate("nav.volunteer")}</NavItem>
-        )}
+        {visibleLinks(PRIMARY_NAV, enabled).map((link) => (
+          <NavItem key={link.to} to={link.to}>
+            {translate(link.labelKey)}
+          </NavItem>
+        ))}
         <Language />
       </nav>
     </header>
@@ -174,36 +205,12 @@ function PopupNav() {
                         label: translate("nav.home", {
                           year: new Date().getFullYear(),
                         }),
-                        show: true,
                       },
-                      {
-                        to: "/about",
-                        label: translate("nav.about"),
-                        show: enabled.about,
-                      },
-                      {
-                        to: "/team",
-                        label: translate("nav.team"),
-                        show: enabled.team,
-                      },
-                      {
-                        to: "/contact",
-                        label: translate("nav.contact"),
-                        show: enabled.contact,
-                      },
-                      {
-                        to: "/give",
-                        label: translate("nav.give"),
-                        show: enabled.give,
-                      },
-                      {
-                        to: "/volunteer",
-                        label: translate("nav.volunteer"),
-                        show: enabled.volunteer,
-                      },
-                    ]
-                      .filter((item) => item.show)
-                      .map((item, index) => (
+                      ...visibleLinks(PRIMARY_NAV, enabled).map((link) => ({
+                        to: link.to,
+                        label: translate(link.labelKey),
+                      })),
+                    ].map((item, index) => (
                       <NavItem
                         key={item.to}
                         to={item.to}
@@ -330,7 +337,7 @@ function NavItem({
   );
 }
 
-function Footer() {
+export function Footer() {
   const translate = useTranslate();
   const { currentConference, enabled } = useLoaderData<typeof loader>();
   return (
@@ -372,26 +379,11 @@ function Footer() {
               {currentConference.title}{" "}
               {dayjs(currentConference.dates[0]).format("YYYY")}
             </Link>
-            {enabled.about && (
-              <Link to="/about" className={linkStyle}>
-                {translate("nav.about")}
+            {visibleLinks(FOOTER_NAV, enabled).map((link) => (
+              <Link key={link.to} to={link.to} className={linkStyle}>
+                {translate(link.labelKey)}
               </Link>
-            )}
-            {enabled.contact && (
-              <Link to="/contact" className={linkStyle}>
-                {translate("nav.contact")}
-              </Link>
-            )}
-            {enabled.give && (
-              <Link to="/give" className={linkStyle}>
-                {translate("nav.give")}
-              </Link>
-            )}
-            {enabled.faq && (
-              <Link to="/faq" className={linkStyle}>
-                {translate("nav.faq")}
-              </Link>
-            )}
+            ))}
           </div>
         </div>
 

--- a/app/routes/($lang)+/_layout.tsx
+++ b/app/routes/($lang)+/_layout.tsx
@@ -32,7 +32,11 @@ export const loader = routeHandler(function* () {
   const content = yield* Content.Service;
   const translation = yield* content.getTranslations(lang);
   const currentConference = yield* content.getCurrentConference(lang);
-  return { lang, translation, currentConference };
+  // Drive the nav (and footer) links off the per-page `enabled` flags — a page's
+  // link renders iff its page is enabled. This replaces the hardcoded team-hide
+  // comments with DATA (`derive-dont-sync`, Feature C): no second page list.
+  const enabled = yield* content.getEnabledPages();
+  return { lang, translation, currentConference, enabled };
 });
 
 export default function Layout() {
@@ -79,6 +83,7 @@ function Nav() {
 
 function TopNav() {
   const translate = useTranslate();
+  const { enabled } = useLoaderData<typeof loader>();
 
   return (
     <header className="bg-background text-foreground w-full">
@@ -95,11 +100,19 @@ function TopNav() {
             year: new Date().getFullYear(),
           })}
         </NavItem>
-        <NavItem to="/about">{translate("nav.about")}</NavItem>
-        {/* <NavItem to="/team">{translate('nav.team')}</NavItem> */}
-        <NavItem to="/contact">{translate("nav.contact")}</NavItem>
-        <NavItem to="/give">{translate("nav.give")}</NavItem>
-        <NavItem to="/volunteer">{translate("nav.volunteer")}</NavItem>
+        {enabled.about && (
+          <NavItem to="/about">{translate("nav.about")}</NavItem>
+        )}
+        {enabled.team && (
+          <NavItem to="/team">{translate("nav.team")}</NavItem>
+        )}
+        {enabled.contact && (
+          <NavItem to="/contact">{translate("nav.contact")}</NavItem>
+        )}
+        {enabled.give && <NavItem to="/give">{translate("nav.give")}</NavItem>}
+        {enabled.volunteer && (
+          <NavItem to="/volunteer">{translate("nav.volunteer")}</NavItem>
+        )}
         <Language />
       </nav>
     </header>
@@ -110,6 +123,7 @@ function PopupNav() {
   const [open, setOpen] = React.useState(false);
   const toggle = () => setOpen((prev) => !prev);
   const translate = useTranslate();
+  const { enabled } = useLoaderData<typeof loader>();
 
   const location = useLocation();
 
@@ -160,13 +174,36 @@ function PopupNav() {
                         label: translate("nav.home", {
                           year: new Date().getFullYear(),
                         }),
+                        show: true,
                       },
-                      { to: "/about", label: translate("nav.about") },
-                      // { to: "/team", label: translate("nav.team") },
-                      { to: "/contact", label: translate("nav.contact") },
-                      { to: "/give", label: translate("nav.give") },
-                      { to: "/volunteer", label: translate("nav.volunteer") },
-                    ].map((item, index) => (
+                      {
+                        to: "/about",
+                        label: translate("nav.about"),
+                        show: enabled.about,
+                      },
+                      {
+                        to: "/team",
+                        label: translate("nav.team"),
+                        show: enabled.team,
+                      },
+                      {
+                        to: "/contact",
+                        label: translate("nav.contact"),
+                        show: enabled.contact,
+                      },
+                      {
+                        to: "/give",
+                        label: translate("nav.give"),
+                        show: enabled.give,
+                      },
+                      {
+                        to: "/volunteer",
+                        label: translate("nav.volunteer"),
+                        show: enabled.volunteer,
+                      },
+                    ]
+                      .filter((item) => item.show)
+                      .map((item, index) => (
                       <NavItem
                         key={item.to}
                         to={item.to}
@@ -295,7 +332,7 @@ function NavItem({
 
 function Footer() {
   const translate = useTranslate();
-  const { currentConference } = useLoaderData<typeof loader>();
+  const { currentConference, enabled } = useLoaderData<typeof loader>();
   return (
     <footer className="bg-background text-foreground">
       <div className="mx-auto flex w-(--width) flex-col gap-12 px-4 py-10">
@@ -335,18 +372,26 @@ function Footer() {
               {currentConference.title}{" "}
               {dayjs(currentConference.dates[0]).format("YYYY")}
             </Link>
-            <Link to="/about" className={linkStyle}>
-              {translate("nav.about")}
-            </Link>
-            <Link to="/contact" className={linkStyle}>
-              {translate("nav.contact")}
-            </Link>
-            <Link to="/give" className={linkStyle}>
-              {translate("nav.give")}
-            </Link>
-            <Link to="/faq" className={linkStyle}>
-              {translate("nav.faq")}
-            </Link>
+            {enabled.about && (
+              <Link to="/about" className={linkStyle}>
+                {translate("nav.about")}
+              </Link>
+            )}
+            {enabled.contact && (
+              <Link to="/contact" className={linkStyle}>
+                {translate("nav.contact")}
+              </Link>
+            )}
+            {enabled.give && (
+              <Link to="/give" className={linkStyle}>
+                {translate("nav.give")}
+              </Link>
+            )}
+            {enabled.faq && (
+              <Link to="/faq" className={linkStyle}>
+                {translate("nav.faq")}
+              </Link>
+            )}
           </div>
         </div>
 

--- a/app/routes/($lang)+/about.tsx
+++ b/app/routes/($lang)+/about.tsx
@@ -1,6 +1,6 @@
 import { type MetaFunction, useLoaderData } from 'react-router';
 
-import { Content } from '~/lib/content.server';
+import { getEnabledPageOr404 } from '~/lib/content/page-guard.server';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeHandler } from '~/lib/effect/route';
 import { getLocale } from '~/lib/localization/localization';
@@ -25,8 +25,8 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content.Service;
-  return { page: toAboutView(yield* content.getPage('about'), locale) };
+  // 404 when the page is disabled (Feature C); else project the decoded page.
+  return { page: toAboutView(yield* getEnabledPageOr404('about'), locale) };
 });
 
 export default function Index() {

--- a/app/routes/($lang)+/archive+/_index.tsx
+++ b/app/routes/($lang)+/archive+/_index.tsx
@@ -1,6 +1,6 @@
 import { type MetaFunction, useLoaderData } from 'react-router';
 
-import { Content } from '~/lib/content.server';
+import { getEnabledPageOr404 } from '~/lib/content/page-guard.server';
 import { toArchiveView } from '~/lib/content/pages/project';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeHandler } from '~/lib/effect/route';
@@ -27,8 +27,8 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content.Service;
-  return { page: toArchiveView(yield* content.getPage('archive'), locale) };
+  // 404 when the page is disabled (Feature C); else project the decoded page.
+  return { page: toArchiveView(yield* getEnabledPageOr404('archive'), locale) };
 });
 
 export default function Index() {

--- a/app/routes/($lang)+/contact.tsx
+++ b/app/routes/($lang)+/contact.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 
 import { Content } from "~/lib/content.server";
+import { getEnabledPageOr404 } from "~/lib/content/page-guard.server";
 import { FormProvider, useForm } from "~/lib/conform";
 import { definitionToSchema, type DecodedForm } from "~/lib/forms/decode";
 import { FormDefinition } from "~/lib/forms/definition";
@@ -48,8 +49,10 @@ export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
   const content = yield* Content.Service;
+  // 404 when the contact page is disabled (Feature C); else project + load the form.
+  const page = toContactView(yield* getEnabledPageOr404("contact"), locale);
   return {
-    page: toContactView(yield* content.getPage("contact"), locale),
+    page,
     definition: yield* content.getForm("contact"),
   };
 });
@@ -85,6 +88,7 @@ const contactLine = (decoded: DecodedForm): string => {
 // when `notify` runs, so a mailer failure cannot lose the record).
 export const action = formAction({
   form: "contact",
+  page: "contact",
   notify: (submission) =>
     Effect.gen(function* () {
       const decoded = submission.payload;

--- a/app/routes/($lang)+/faq.tsx
+++ b/app/routes/($lang)+/faq.tsx
@@ -1,6 +1,6 @@
 import { type MetaFunction, useLoaderData } from 'react-router';
 
-import { Content } from '~/lib/content.server';
+import { getEnabledPageOr404 } from '~/lib/content/page-guard.server';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeHandler } from '~/lib/effect/route';
 import { getLocale } from '~/lib/localization/localization';
@@ -25,8 +25,8 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content.Service;
-  return { page: toFaqView(yield* content.getPage('faq'), locale) };
+  // 404 when the page is disabled (Feature C); else project the decoded page.
+  return { page: toFaqView(yield* getEnabledPageOr404('faq'), locale) };
 });
 
 export default function FaqPage() {

--- a/app/routes/($lang)+/give.tsx
+++ b/app/routes/($lang)+/give.tsx
@@ -1,6 +1,6 @@
 import { type MetaFunction, useLoaderData } from "react-router";
 
-import { Content } from "~/lib/content.server";
+import { getEnabledPageOr404 } from "~/lib/content/page-guard.server";
 import { ReactRouterContext } from "~/lib/effect/router-context";
 import { routeHandler } from "~/lib/effect/route";
 import { useTranslate } from "~/lib/localization/context";
@@ -26,8 +26,8 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
-  const content = yield* Content.Service;
-  return { page: toGiveView(yield* content.getPage("give"), locale) };
+  // 404 when the page is disabled (Feature C); else project the decoded page.
+  return { page: toGiveView(yield* getEnabledPageOr404("give"), locale) };
 });
 
 export default function Index() {

--- a/app/routes/($lang)+/team/_index.tsx
+++ b/app/routes/($lang)+/team/_index.tsx
@@ -1,6 +1,7 @@
 import { type MetaFunction, useLoaderData } from 'react-router';
 
 import { Content } from '~/lib/content.server';
+import { getEnabledPageOr404 } from '~/lib/content/page-guard.server';
 import { toTeamView } from '~/lib/content/pages/project';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeHandler } from '~/lib/effect/route';
@@ -30,7 +31,9 @@ export const loader = routeHandler(function* () {
   // Page CHROME (title / subtitle / board heading / images) comes from the CMS
   // `TeamPage` object; the per-member executive roster stays on `site.json` via
   // `getTeam()` (conference-executive data, not page copy — not migrated here).
-  const page = toTeamView(yield* content.getPage('team'), locale);
+  // 404 when the team page is disabled (Feature C — today's default-hidden team is
+  // this flag now, not a nav comment).
+  const page = toTeamView(yield* getEnabledPageOr404('team'), locale);
   const { team, board } = yield* content.getTeam();
   return { page, team, board };
 });

--- a/app/routes/($lang)+/volunteer.tsx
+++ b/app/routes/($lang)+/volunteer.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 
 import { Content } from "~/lib/content.server";
+import { getEnabledPageOr404 } from "~/lib/content/page-guard.server";
 import { FormProvider, useForm } from "~/lib/conform";
 import { definitionToSchema, type DecodedForm } from "~/lib/forms/decode";
 import { FormDefinition } from "~/lib/forms/definition";
@@ -45,8 +46,10 @@ export const loader = routeHandler(function* () {
   const { params } = yield* ReactRouterContext;
   const locale = getLocale(params);
   const content = yield* Content.Service;
+  // 404 when the volunteer page is disabled (Feature C); else project + load form.
+  const page = toVolunteerView(yield* getEnabledPageOr404("volunteer"), locale);
   return {
-    page: toVolunteerView(yield* content.getPage("volunteer"), locale),
+    page,
     definition: yield* content.getForm("volunteer"),
   };
 });
@@ -96,6 +99,7 @@ const positionsLine = (decoded: DecodedForm): string => {
 // when `notify` runs, so a mailer failure cannot lose the record).
 export const action = formAction({
   form: "volunteer",
+  page: "volunteer",
   notify: (submission) =>
     Effect.gen(function* () {
       const decoded = submission.payload;

--- a/app/routes/admin/controls.tsx
+++ b/app/routes/admin/controls.tsx
@@ -101,6 +101,36 @@ export function Bilingual({
   );
 }
 
+/**
+ * A boolean checkbox bound to a dotted form-field `name` (Feature C: the per-page
+ * `enabled` flag). An unchecked HTML checkbox is ABSENT from FormData, which would
+ * make "uncheck + save" a no-op (the override would omit the key and `deepMerge`
+ * keeps the base value). So a hidden `<input value="false">` companion is rendered
+ * BEFORE the checkbox: FormData then ALWAYS carries the field — `"false"` when
+ * unchecked, and the checkbox's `"true"` overriding it (last-wins in
+ * `form.entries()` order) when checked. The action's `assembleOverrides` coerces the
+ * resulting `"true"`/`"false"` string to a real boolean before the `Schema.Boolean`
+ * decode (Codex #5/#12), so the save always carries a deterministic boolean override.
+ */
+export function Checkbox({
+  label,
+  name,
+  defaultChecked,
+}: {
+  readonly label: string;
+  readonly name: string;
+  readonly defaultChecked: boolean;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm font-medium text-neutral-800">
+      {/* Hidden companion FIRST so an unchecked box still posts `false`. */}
+      <input type="hidden" name={name} value="false" />
+      <input type="checkbox" name={name} value="true" defaultChecked={defaultChecked} />
+      {label}
+    </label>
+  );
+}
+
 /** A collapsible titled section wrapping a group of fields. */
 export function Section({
   title,

--- a/app/routes/admin/pages.$page.action.test.ts
+++ b/app/routes/admin/pages.$page.action.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from 'bun:test';
 import { ConfigProvider, Effect, Layer, ManagedRuntime } from 'effect';
 import { RouterContextProvider } from 'react-router';
 
+import { Schema } from 'effect';
+
 import { Auth } from '~/lib/auth.server';
+import { Content } from '~/lib/content.server';
+import { getEnabledPageOr404 } from '~/lib/content/page-guard.server';
+import { pageDraftKey } from '~/lib/content/pages/registry';
+import { DraftTeamPage } from '~/lib/content/pages/schema';
 import { makeAppLayer, makeRequestRuntimeFromLayer } from '~/lib/effect/runtime';
 import type { RouteArgs } from '~/lib/effect/router-context';
+import { NotFoundError } from '~/lib/effect/errors';
 import { Storage } from '~/lib/storage.server';
 import { layerTest } from '~/lib/storage.test-helper';
 
@@ -170,6 +177,119 @@ describe('team page editor action — image-upload resize-to-webp (B.2)', () => 
     expect(head._tag).toBe('Some');
     if (head._tag === 'Some') {
       expect(head.value.contentType).toBe('image/webp');
+    }
+  });
+});
+
+/**
+ * POST urlencoded fields to the team page editor action through the REAL action
+ * (past the auth gate), returning the response + the request `args` so the test
+ * can read the draft/published object back through the SAME in-memory bucket.
+ */
+const postTeamFields = async (
+  fields: ReadonlyArray<readonly [string, string]>,
+): Promise<{ res: Response; args: RouteArgs }> => {
+  const { layer, context } = makeContext();
+  const cookie = await mintCookie(layer);
+
+  // URLSearchParams keeps duplicate keys in INSERTION order — exactly how the
+  // browser submits the `Checkbox`'s hidden companion + checkbox pair.
+  const body = new URLSearchParams();
+  for (const [name, value] of fields) body.append(name, value);
+  const url = 'http://localhost/admin/pages/team';
+  const request = new Request(url, {
+    method: 'POST',
+    body,
+    headers: { cookie, 'content-type': 'application/x-www-form-urlencoded' },
+  });
+  const args: RouteArgs = {
+    request,
+    url: new URL(url),
+    pattern: '/admin/pages/:page',
+    params: { page: 'team' },
+    context,
+  };
+  const res = (await action(args)) as Response;
+  return { res, args };
+};
+
+/**
+ * The per-page editor's `enabled`-flag edit (Feature C, C.5). The `Checkbox`
+ * posts a deterministic `enabled` value (hidden companion `false` + checkbox
+ * `true`), `assembleOverrides` coerces it to a real boolean, and the value rides
+ * the normal save/publish path. These drive the REAL action and read the result
+ * back through the same in-memory bucket:
+ *   - a CHECKED box (companion false + checkbox true) lands enabled:true;
+ *   - an UNCHECKED box (companion false only) lands enabled:false;
+ *   - publish enabled=false makes the published team page DISABLED, so the
+ *     public route guard 404s (the page genuinely no longer exists).
+ */
+describe('team page editor action — enabled flag edit (C.5)', () => {
+  /** Read + decode the stored team DRAFT through the action's own bucket. */
+  const readTeamDraft = async (args: RouteArgs): Promise<DraftTeamPage> => {
+    const draftJson = await args.context.runtime.run(
+      args,
+      Effect.gen(function* () {
+        const storage = yield* Storage.Service;
+        const object = yield* storage.get(pageDraftKey('team'));
+        return yield* Effect.promise(() => new Response(object.stream).text());
+      }),
+    );
+    return Schema.decodeUnknownSync(DraftTeamPage)(JSON.parse(draftJson));
+  };
+
+  it('a CHECKED box (companion false + checkbox true) lands enabled:true on the draft', async () => {
+    // The real Checkbox posts the hidden enabled=false FIRST, then the checkbox
+    // enabled=true; last-wins gives true after the assembleOverrides coercion.
+    const { res, args } = await postTeamFields([
+      ['intent', 'save-draft'],
+      ['enabled', 'false'],
+      ['enabled', 'true'],
+    ]);
+    expect(res.status).toBe(302);
+    const draft = await readTeamDraft(args);
+    expect(draft.enabled).toBe(true);
+  });
+
+  it('an UNCHECKED box (companion false only) lands enabled:false on the draft', async () => {
+    // "Uncheck + save" must be effective, not a no-op: the hidden companion makes
+    // the override always carry a deterministic boolean.
+    const { res, args } = await postTeamFields([
+      ['intent', 'save-draft'],
+      ['enabled', 'false'],
+    ]);
+    expect(res.status).toBe(302);
+    const draft = await readTeamDraft(args);
+    expect(draft.enabled).toBe(false);
+  });
+
+  it('publishing enabled=false disables the team page so the public route 404s', async () => {
+    const { res, args } = await postTeamFields([
+      ['intent', 'publish'],
+      ['enabled', 'false'],
+    ]);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('Published');
+
+    // Read the now-published team page through the public guard: a disabled page
+    // 404s (NotFoundError), and getPage reports enabled:false.
+    const outcome = await args.context.runtime.run(
+      args,
+      Effect.gen(function* () {
+        const content = yield* Content.Service;
+        yield* content.bust({ kind: 'page', page: 'team' });
+        const page = yield* content.getPage('team');
+        const guardExit = yield* Effect.exit(getEnabledPageOr404('team'));
+        return { enabled: page.enabled, guardExit };
+      }),
+    );
+    expect(outcome.enabled).toBe(false);
+    expect(outcome.guardExit._tag).toBe('Failure');
+    if (outcome.guardExit._tag === 'Failure') {
+      const failed = outcome.guardExit.cause.reasons.some(
+        (reason) => reason._tag === 'Fail' && NotFoundError.is(reason.error),
+      );
+      expect(failed).toBe(true);
     }
   });
 });

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -34,6 +34,7 @@ import {
   AddItemButton,
   Bilingual,
   type ActionResult,
+  Checkbox,
   ImageUpload,
   ItemControls,
   Section,
@@ -708,6 +709,19 @@ export default function AdminPageEditor() {
       )}
 
       <Form method="post" className="space-y-4">
+        <Section title="Visibility" open>
+          {/* The per-page `enabled` flag (Feature C): when off, the page 404s its
+              public route + action and its nav link is absent — all data-driven.
+              Rendered once for EVERY page (incl. team). The hidden companion in
+              `Checkbox` guarantees a deterministic boolean override every save. */}
+          <Checkbox
+            label="Page enabled (visible in nav + routable)"
+            name="enabled"
+            defaultChecked={Boolean(
+              (encoded as Record<string, unknown>)['enabled'] ?? true,
+            )}
+          />
+        </Section>
         <Section title={`${PAGE_LABELS[page]} content`} open>
           <PageEditor page={page} encoded={encoded as Record<string, unknown>} />
         </Section>

--- a/scripts/runtime-proof-c.ts
+++ b/scripts/runtime-proof-c.ts
@@ -1,0 +1,119 @@
+/**
+ * Runtime proof (Feature C) — drives the REAL route loaders + layout loader over
+ * an in-memory `Storage` seeded with published page docs, exercising the same
+ * give-toggle + team-flip scenario the plan describes (docs/cms-images-enable-plan.md
+ * "Runtime proof (C)") WITHOUT requiring a live R2 bucket. This is end-to-end
+ * through the actual exported `loader`s (not mocks): the nav links come from the
+ * `_layout` loader's `getEnabledPages()`, and a disabled page's loader genuinely
+ * throws a 404 `data(...)` response.
+ *
+ * Run: `bun scripts/runtime-proof-c.ts`
+ */
+import { Effect, Schema } from 'effect';
+import { RouterContextProvider } from 'react-router';
+
+import {
+  defaultGivePage,
+  defaultTeamPage,
+} from '../app/lib/content/pages/defaults';
+import { pageObjectKey } from '../app/lib/content/pages/registry';
+import { GivePage, TeamPage } from '../app/lib/content/pages/schema';
+import {
+  makeAppLayer,
+  makeRequestRuntimeFromLayer,
+} from '../app/lib/effect/runtime';
+import { layerTest } from '../app/lib/storage.test-helper';
+
+import { loader as layoutLoader } from '../app/routes/($lang)+/_layout';
+import { loader as giveLoader } from '../app/routes/($lang)+/give';
+
+type Seed = { give: boolean; team: boolean };
+
+const encodeGive = Schema.encodeUnknownEffect(Schema.fromJsonString(GivePage));
+const encodeTeam = Schema.encodeUnknownEffect(Schema.fromJsonString(TeamPage));
+
+/** Seed an in-memory bucket with give + team published docs at the given flags. */
+const seed = async ({ give, team }: Seed) => {
+  const giveJson = await Effect.runPromise(
+    encodeGive(GivePage.make({ ...defaultGivePage, enabled: give })),
+  );
+  const teamJson = await Effect.runPromise(
+    encodeTeam(TeamPage.make({ ...defaultTeamPage, enabled: team })),
+  );
+  const context = new RouterContextProvider();
+  context.runtime = makeRequestRuntimeFromLayer(
+    makeAppLayer(
+      layerTest({
+        [pageObjectKey('give')]: { body: giveJson },
+        [pageObjectKey('team')]: { body: teamJson },
+      }),
+    ),
+  );
+  return context;
+};
+
+const argsFor = (context: RouterContextProvider, path: string) => {
+  const url = `http://localhost${path}`;
+  return {
+    request: new Request(url),
+    url: new URL(url),
+    pattern: path === '/' ? '/' : '/:page',
+    params: {},
+    context,
+  };
+};
+
+/** Run the layout loader and return the enabled-flag map it exposes to the nav. */
+const navEnabled = async (
+  context: RouterContextProvider,
+): Promise<Record<string, boolean>> => {
+  const result = (await layoutLoader(argsFor(context, '/'))) as {
+    enabled: Record<string, boolean>;
+  };
+  return result.enabled;
+};
+
+/** Run the give loader; return 'ok' if it renders, '404' if it throws a 404. */
+const giveStatus = async (context: RouterContextProvider): Promise<'ok' | '404'> => {
+  try {
+    await giveLoader(argsFor(context, '/give'));
+    return 'ok';
+  } catch (thrown) {
+    const status = (thrown as { init?: { status?: number } })?.init?.status;
+    if (status === 404) return '404';
+    throw thrown;
+  }
+};
+
+const line = (text: string): void => {
+  process.stdout.write(`${text}\n`);
+};
+
+const assert = (label: string, ok: boolean): void => {
+  line(`${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) process.exitCode = 1;
+};
+
+const main = async (): Promise<void> => {
+  // 1. give DISABLED, team DISABLED (today's shipped default).
+  const off = await seed({ give: false, team: false });
+  const offNav = await navEnabled(off);
+  assert('give disabled -> give absent from nav', offNav['give'] === false);
+  assert('give disabled -> /give loader 404s', (await giveStatus(off)) === '404');
+  assert('team disabled (default) -> team absent from nav', offNav['team'] === false);
+
+  // 2. give ENABLED -> nav link returns + /give renders.
+  const giveOn = await seed({ give: true, team: false });
+  const giveOnNav = await navEnabled(giveOn);
+  assert('give enabled -> give present in nav', giveOnNav['give'] === true);
+  assert('give enabled -> /give loader renders', (await giveStatus(giveOn)) === 'ok');
+
+  // 3. team FLIPPED on -> team nav link returns (the CMS-team visibility flip).
+  const teamOn = await seed({ give: true, team: true });
+  const teamOnNav = await navEnabled(teamOn);
+  assert('team enabled -> team present in nav', teamOnNav['team'] === true);
+
+  line(process.exitCode === 1 ? '\nRUNTIME PROOF FAILED' : '\nRUNTIME PROOF PASSED');
+};
+
+await main();


### PR DESCRIPTION
## Feature C — Per-page `enabled` flag

Stacks on `cms/image-resize-on-upload` (Feature B). Implements plan sections **C.0–C.5** of `docs/cms-images-enable-plan.md`.

### What this delivers

A decode-safe per-page `enabled` boolean — data-driven nav, route AND action 404s, an admin checkbox — and the deletion of every hardcoded team hide. Team visibility is now `TeamPage.enabled` data, not a code comment.

- **C.0 — decode-safe flag on every Page (incl. team).** A single `EnabledFlag = Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true)))` added to every strict Page struct AND its `Draft*` variant. An already-published `<page>.json` that predates the field still decodes to `enabled: true`. The seed `team.json` ships `enabled: false` — today's hidden-team behavior as data (`derive-dont-sync`), no separate `teamEnabled` on `SiteContent`.
- **C.1/C.2 — read + project.** `Content.getEnabledPages(): Effect<Record<PageId, boolean>>` (thin read over the cached page objects); every `*View` carries `enabled` projected verbatim by each converter.
- **C.3 — data-driven nav, hardcoded hides deleted.** `_layout.tsx` loader fetches `getEnabledPages()`; `PRIMARY_NAV`/`FOOTER_NAV` single lists filtered by `enabled[page]` across TopNav/PopupNav/footer. Real `/team` `NavItem` gated on `enabled.team`. Deleted: both `_layout.tsx` team-hide comments AND the commented `/team` CTA in `_index.tsx` (Codex R1).
- **C.4 — route AND action 404.** Shared `getEnabledPageOr404(page)` guard on every `($lang)+` page loader. Form-bearing routes (contact, volunteer, newsletter) 404 via a route-level `guard` that runs BEFORE form-data parse + honeypot, and `NotFoundError` now re-fails to a real 404 (not a 200 form-error) (Codex #6). The newsletter gate runs the enabled check before the SendGrid check.
- **C.5 — admin editor.** A `Checkbox` control with a hidden `value="false"` companion rendered first (so an unchecked box still posts `false`), plus `enabled`-leaf boolean coercion in `assembleOverrides` (Codex #5/#12). Rendered in a "Visibility" section for every page incl. team.

### Counsel verdicts

- **Per-commit (standard counsel):** each of the 10 sub-commits was Codex-counseled with blocking feedback applied as it was built (first tier of the two-tier cadence).
- **Whole-PR `--deep` counsel:** **Approve / no blocking issues found.** The reviewer confirmed the branch delivers C.0–C.5 as one integrated change — `enabled` contract present, route/action 404 data-driven, image upload still on the existing `ImageUpload`/`upload:`/`applyImageUpload` path, resize centralized behind `prepareImage`. One **non-blocking** deploy caveat: confirm the live bucket has no pre-existing A/B-era `team.json` lacking `enabled` (which would decode to `true` and surface Team until republished) — matches the plan's seed-false assumption.

### Gate (all green locally)

`bun run typecheck && bun run lint && bun run build && bun test` → typecheck clean, lint clean (one pre-existing unrelated test warning), build OK, **472 tests pass / 0 fail**. (Counsel itself ran read-only and hit an EPERM on Vite's typegen temp dir; the full gate was run here to cover that.)

### Runtime proof

`bun scripts/runtime-proof-c.ts` drives the REAL route + layout loaders over an in-memory seeded `Storage` (no live bucket):

```
PASS  give disabled -> give absent from nav
PASS  give disabled -> /give loader 404s
PASS  team disabled (default) -> team absent from nav
PASS  give enabled -> give present in nav
PASS  give enabled -> /give loader renders
PASS  team enabled -> team present in nav
RUNTIME PROOF PASSED
```

A human merges. Draft until reviewed.

---

<!-- stacked -->
**Stack: `cms/team-cms-image-upload`** (3 of 3)

| # | Branch | PR |
|---|--------|----|
| 1 | `cms/team-cms-image-upload` | [#29](https://github.com/GYCCanada/Web/pull/29) ✅ |
| 2 | `cms/image-resize-on-upload` | [#30](https://github.com/GYCCanada/Web/pull/30) |
| **3** | **`cms/page-enabled-flag`** | **#31 ← you are here** |
<!-- /stacked -->