### PR TITLE
feat(cms): image resize-on-upload — one shared Bun.Image boundary (Feature B)

### DIFF
--- a/app/lib/content/admin-form.ts
+++ b/app/lib/content/admin-form.ts
@@ -24,6 +24,7 @@
  * without a runtime (`small-interface-deep-implementation`).
  */
 
+import { extensionForType } from './image-types';
 import { AssetKey } from './schema';
 
 /**
@@ -54,32 +55,14 @@ const isPlainObject = (value: Json): value is { readonly [k: string]: Json } =>
 export const IMAGE_UPLOAD_INTENT_PREFIX = 'upload:';
 
 /**
- * The accepted upload content-types. The resize/WebP pipeline is deferred (CMS
- * plan §"Non-goals"); for now we store the raw bytes under their original
- * content-type, so we only need to gate the obviously-image MIME types to keep
- * a stray PDF / script out of the image namespace.
+ * The accepted-image MIME gate + MIME↔extension table live in the leaf
+ * `image-types` module so both this form-policy module and the pure
+ * `image-optimize.server` resize boundary share one table without a cycle
+ * (`derive-dont-sync`). Re-exported here so the route imports that already pull
+ * `isAcceptedImageType` from `admin-form` keep working.
  */
-const ACCEPTED_IMAGE_TYPES = new Set([
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/avif',
-]);
-
-export const isAcceptedImageType = (type: string): boolean =>
-  ACCEPTED_IMAGE_TYPES.has(type.toLowerCase());
-
-const EXTENSION_BY_TYPE: Record<string, string> = {
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/webp': 'webp',
-  'image/gif': 'gif',
-  'image/avif': 'avif',
-};
-
-export const extensionForType = (type: string): string =>
-  EXTENSION_BY_TYPE[type.toLowerCase()] ?? 'bin';
+export { isAcceptedImageType } from './image-types';
+export { extensionForType };
 
 /**
  * Recover the dotted key path an image-upload intent targets, or `null` if the

--- a/app/lib/content/image-optimize.server.test.ts
+++ b/app/lib/content/image-optimize.server.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
+
+import {
+  MAX_WIDTH,
+  prepareImage,
+  WEBP_QUALITY,
+} from './image-optimize.server';
+
+/**
+ * `prepareImage` is the ONE shared upload boundary (Feature B): cap width at
+ * `MAX_WIDTH`, re-encode to WebP, pass GIFs through verbatim, and never fail an
+ * upload when the optimizer chokes. These pin each branch with REAL bytes —
+ * fixtures are encoded by `Bun.Image` here and decoded back through
+ * `Bun.Image().metadata()` to assert the stored width, so the width-cap is
+ * proven on the actual output, not a mock.
+ */
+
+// A 1×1 PNG seed; every fixture below is derived from it via `Bun.Image` so the
+// test carries no large binary literal and the width assertions are first-hand.
+const PNG_1X1 = new Uint8Array(
+  Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64',
+  ),
+);
+
+// A 1×1 transparent GIF (animated GIFs would lose all but frame 1 under a
+// decode/re-encode; this fixture stands in for "any GIF" — passthrough is keyed
+// on the MIME type, not the frame count).
+const GIF_1X1 = new Uint8Array(
+  Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64'),
+);
+
+/** Encode a solid JPEG of the given dimensions from the PNG seed. */
+const jpegOf = async (width: number, height: number): Promise<Uint8Array> =>
+  new Uint8Array(
+    await new Bun.Image(PNG_1X1).resize(width, height).jpeg({ quality: 90 }).toBuffer(),
+  );
+
+/** Decoded width of an encoded image (proves the actual stored geometry). */
+const widthOf = async (bytes: Uint8Array): Promise<number> =>
+  (await new Bun.Image(bytes).metadata()).width;
+
+const formatOf = async (bytes: Uint8Array): Promise<string> =>
+  (await new Bun.Image(bytes).metadata()).format;
+
+describe('prepareImage', () => {
+  it('downscales a wider-than-MAX_WIDTH image to MAX_WIDTH and re-encodes to WebP', async () => {
+    const wide = await jpegOf(2400, 800);
+    expect(await widthOf(wide)).toBe(2400);
+
+    const prepared = await Effect.runPromise(prepareImage(wide, 'image/jpeg'));
+
+    expect(prepared.contentType).toBe('image/webp');
+    expect(prepared.extension).toBe('webp');
+    expect(await formatOf(prepared.bytes)).toBe('webp');
+    // The width cap is applied to the ACTUAL output bytes.
+    expect(await widthOf(prepared.bytes)).toBe(MAX_WIDTH);
+    // Aspect ratio is preserved (2400×800 → 1600×533).
+    expect(await new Bun.Image(prepared.bytes).metadata().then((m) => m.height)).toBe(
+      533,
+    );
+  });
+
+  it('does NOT upscale a narrower image but still re-encodes it to WebP', async () => {
+    const narrow = await jpegOf(800, 600);
+    expect(await widthOf(narrow)).toBe(800);
+
+    const prepared = await Effect.runPromise(prepareImage(narrow, 'image/jpeg'));
+
+    expect(prepared.contentType).toBe('image/webp');
+    expect(await formatOf(prepared.bytes)).toBe('webp');
+    // Width is unchanged (no upscale), not bumped to MAX_WIDTH.
+    expect(await widthOf(prepared.bytes)).toBe(800);
+  });
+
+  it('re-encodes a WebP source through the same single path (recompress + cap)', async () => {
+    const wideWebp = new Uint8Array(
+      await new Bun.Image(PNG_1X1).resize(2000, 1000).webp({ quality: 90 }).toBuffer(),
+    );
+    expect(await widthOf(wideWebp)).toBe(2000);
+
+    const prepared = await Effect.runPromise(prepareImage(wideWebp, 'image/webp'));
+
+    expect(prepared.contentType).toBe('image/webp');
+    expect(await formatOf(prepared.bytes)).toBe('webp');
+    expect(await widthOf(prepared.bytes)).toBe(MAX_WIDTH);
+  });
+
+  it('passes a GIF through byte-identical, never decoding it', async () => {
+    const prepared = await Effect.runPromise(prepareImage(GIF_1X1, 'image/gif'));
+
+    expect(prepared.contentType).toBe('image/gif');
+    expect(prepared.extension).toBe('gif');
+    // The exact same buffer is stored — no decode, no frame loss.
+    expect(prepared.bytes).toBe(GIF_1X1);
+  });
+
+  it('passes a GIF through regardless of MIME-type casing', async () => {
+    const prepared = await Effect.runPromise(prepareImage(GIF_1X1, 'IMAGE/GIF'));
+    expect(prepared.contentType).toBe('image/gif');
+    expect(prepared.bytes).toBe(GIF_1X1);
+  });
+
+  it('falls back to the original bytes + type when the optimizer throws (never fails the upload)', async () => {
+    const corrupt = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+
+    // Must SUCCEED (the upload is never failed by a decode throw).
+    const prepared = await Effect.runPromise(prepareImage(corrupt, 'image/png'));
+
+    expect(prepared.bytes).toBe(corrupt);
+    expect(prepared.contentType).toBe('image/png');
+    expect(prepared.extension).toBe('png');
+  });
+
+  it('exposes the cap + quality as the single source of truth', () => {
+    expect(MAX_WIDTH).toBe(1600);
+    expect(WEBP_QUALITY).toBe(80);
+  });
+});

--- a/app/lib/content/image-optimize.server.test.ts
+++ b/app/lib/content/image-optimize.server.test.ts
@@ -114,6 +114,17 @@ describe('prepareImage', () => {
     expect(prepared.extension).toBe('png');
   });
 
+  it('normalizes the source MIME casing in the fallback content-type', async () => {
+    const corrupt = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1]);
+
+    const prepared = await Effect.runPromise(prepareImage(corrupt, 'IMAGE/PNG'));
+
+    expect(prepared.bytes).toBe(corrupt);
+    // The stored type/extension are clean lowercase, not the uppercase echo.
+    expect(prepared.contentType).toBe('image/png');
+    expect(prepared.extension).toBe('png');
+  });
+
   it('exposes the cap + quality as the single source of truth', () => {
     expect(MAX_WIDTH).toBe(1600);
     expect(WEBP_QUALITY).toBe(80);

--- a/app/lib/content/image-optimize.server.test.ts
+++ b/app/lib/content/image-optimize.server.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { Effect } from 'effect';
+import { Effect, Option } from 'effect';
 
+import { Storage } from '../storage.server';
+import { layerTest } from '../storage.test-helper';
+import { uploadedImageKey } from './admin-form';
 import {
   MAX_WIDTH,
   prepareImage,
@@ -128,5 +131,48 @@ describe('prepareImage', () => {
   it('exposes the cap + quality as the single source of truth', () => {
     expect(MAX_WIDTH).toBe(1600);
     expect(WEBP_QUALITY).toBe(80);
+  });
+});
+
+/**
+ * The route-boundary contract (B.2): both editors run the exact sequence
+ * `prepareImage → uploadedImageKey(target, prepared.contentType) →
+ * storage.put(key, prepared.bytes, prepared.contentType)`. This pins the
+ * load-bearing correction — the key's extension AND the stored content-type
+ * follow the RE-ENCODED type, never `file.type` — against the real in-memory
+ * `Storage` (not a mock), so a regression that keys off the source MIME is
+ * caught here even though the route action itself is a thin shell over this.
+ */
+describe('upload boundary: key + put follow prepared.contentType', () => {
+  const storeUpload = (bytes: Uint8Array, sourceType: string) =>
+    Effect.gen(function* () {
+      const storage = yield* Storage.Service;
+      const prepared = yield* prepareImage(bytes, sourceType);
+      const key = uploadedImageKey('groupPhoto.key', prepared.contentType, 1_700_000_000_000);
+      yield* storage.put(key, prepared.bytes, prepared.contentType);
+      const head = yield* storage.head(key);
+      return { key: String(key), head };
+    }).pipe(Effect.provide(layerTest()));
+
+  it('stores a wide JPEG as a .webp object with an image/webp content-type', async () => {
+    const wide = await jpegOf(2400, 800);
+
+    const { key, head } = await Effect.runPromise(storeUpload(wide, 'image/jpeg'));
+
+    expect(key).toMatch(/\.webp$/);
+    expect(Option.isSome(head)).toBe(true);
+    const stored = Option.getOrThrow(head);
+    expect(stored.contentType).toBe('image/webp');
+    expect(stored.size).toBeGreaterThan(0);
+  });
+
+  it('stores a GIF as a .gif object with an image/gif content-type (passthrough)', async () => {
+    const { key, head } = await Effect.runPromise(
+      storeUpload(GIF_1X1, 'image/gif'),
+    );
+
+    expect(key).toMatch(/\.gif$/);
+    const stored = Option.getOrThrow(head);
+    expect(stored.contentType).toBe('image/gif');
   });
 });

--- a/app/lib/content/image-optimize.server.ts
+++ b/app/lib/content/image-optimize.server.ts
@@ -26,7 +26,7 @@
 
 import { Effect } from 'effect';
 
-import { extensionForType } from './admin-form';
+import { extensionForType } from './image-types';
 
 /** Upload width cap (px). A wider image is downscaled to this; a narrower one is left as-is. */
 export const MAX_WIDTH = 1600;
@@ -54,9 +54,14 @@ export const prepareImage = (
   sourceType: string,
 ): Effect.Effect<PreparedImage> =>
   Effect.gen(function* () {
+    // Normalize the source MIME once: the GIF check, the fallback content-type,
+    // and `extensionForType` are all case-insensitive, so a `IMAGE/PNG` upload
+    // falls back to a clean lowercase `image/png` rather than echoing the casing.
+    const normalizedType = sourceType.toLowerCase();
+
     // GIF passthrough: a `Bun.Image` decode/re-encode keeps only frame 1, so an
     // animated GIF would silently flatten. Store it verbatim instead.
-    if (sourceType.toLowerCase() === 'image/gif') {
+    if (normalizedType === 'image/gif') {
       return { bytes, contentType: 'image/gif', extension: 'gif' };
     }
 
@@ -80,8 +85,8 @@ export const prepareImage = (
       Effect.catch(() =>
         Effect.succeed<PreparedImage>({
           bytes,
-          contentType: sourceType,
-          extension: extensionForType(sourceType),
+          contentType: normalizedType,
+          extension: extensionForType(normalizedType),
         }),
       ),
     );

--- a/app/lib/content/image-optimize.server.ts
+++ b/app/lib/content/image-optimize.server.ts
@@ -1,0 +1,88 @@
+/**
+ * The ONE shared image-upload optimization boundary (CMS plan Feature B).
+ *
+ * Both content editors — the site editor (`admin/content.tsx`) and the per-page
+ * editor (`admin/pages.$page.tsx`) — read an uploaded `File`'s bytes and then
+ * `storage.put` them. `prepareImage` is the single point between those two steps
+ * where an upload is shrunk and re-encoded, so the resize is applied EXACTLY
+ * ONCE regardless of which editor performed the upload (`subtract-before-you-add`,
+ * `derive-dont-sync`: one optimization rule, not a copy per route).
+ *
+ * Policy:
+ *   - cap width at `MAX_WIDTH` (never upscale a narrower image);
+ *   - re-encode to WebP at `WEBP_QUALITY`;
+ *   - GIF is stored verbatim (animated GIFs would lose every frame but the first
+ *     under a decode/re-encode — unrequested data loss);
+ *   - if `Bun.Image` throws on a corrupt/exotic input, fall back to the ORIGINAL
+ *     bytes + original content-type so a decode failure NEVER fails an upload
+ *     (`boundary-discipline`: the optimizer choking is recoverable, the upload is
+ *     not the place to surface it).
+ *
+ * The returned `contentType` / `extension` describe the bytes ACTUALLY stored
+ * (`image/webp` after a re-encode, the source type on passthrough/fallback), so
+ * the caller keys + `storage.put`s off `prepared.contentType` — never the source
+ * `file.type`, which would make the served object's extension/type lie.
+ */
+
+import { Effect } from 'effect';
+
+import { extensionForType } from './admin-form';
+
+/** Upload width cap (px). A wider image is downscaled to this; a narrower one is left as-is. */
+export const MAX_WIDTH = 1600;
+
+/** WebP re-encode quality (0–100). */
+export const WEBP_QUALITY = 80;
+
+export interface PreparedImage {
+  /** The bytes to store (re-encoded WebP, or the original on passthrough/fallback). */
+  readonly bytes: Uint8Array;
+  /** The content-type of `bytes`: `'image/webp'` after re-encode, else the original. */
+  readonly contentType: string;
+  /** The file extension for `bytes`: `'webp'` after re-encode, else `extensionForType(original)`. */
+  readonly extension: string;
+}
+
+/**
+ * Shrink-to-`MAX_WIDTH` + re-encode-to-WebP an uploaded image, with a GIF
+ * passthrough and a never-fail fallback. Pure w.r.t. storage — the caller stores
+ * the result. Always succeeds (the error channel is `never`): a `Bun.Image`
+ * throw is caught and folded into an original-bytes `PreparedImage`.
+ */
+export const prepareImage = (
+  bytes: Uint8Array,
+  sourceType: string,
+): Effect.Effect<PreparedImage> =>
+  Effect.gen(function* () {
+    // GIF passthrough: a `Bun.Image` decode/re-encode keeps only frame 1, so an
+    // animated GIF would silently flatten. Store it verbatim instead.
+    if (sourceType.toLowerCase() === 'image/gif') {
+      return { bytes, contentType: 'image/gif', extension: 'gif' };
+    }
+
+    return yield* Effect.tryPromise(async () => {
+      const img = new Bun.Image(bytes);
+      // CRITICAL: `img.width` is -1 until `metadata()` resolves in Bun 1.3.14, so
+      // the no-upscale decision MUST read `(await img.metadata()).width`. Reading
+      // `img.width` here would make `width > MAX_WIDTH` always false → nothing
+      // would ever resize and every upload would re-encode at full resolution.
+      const meta = await img.metadata();
+      const chain = meta.width > MAX_WIDTH ? img.resize(MAX_WIDTH) : img;
+      const out = new Uint8Array(await chain.webp({ quality: WEBP_QUALITY }).toBuffer());
+      return {
+        bytes: out,
+        contentType: 'image/webp',
+        extension: 'webp',
+      } satisfies PreparedImage;
+    }).pipe(
+      // The optimizer choking (corrupt/exotic upload) must not fail the upload:
+      // store the ORIGINAL bytes under their original type/extension.
+      Effect.catch(() =>
+        Effect.succeed<PreparedImage>({
+          bytes,
+          contentType: sourceType,
+          extension: extensionForType(sourceType),
+        }),
+      ),
+    );
+  });

--- a/app/lib/content/image-types.ts
+++ b/app/lib/content/image-types.ts
@@ -1,0 +1,35 @@
+/**
+ * The accepted image MIME types and their file extensions — the single source of
+ * truth for "what counts as an uploadable image" and "what extension its bytes
+ * get on disk".
+ *
+ * This is a LEAF module: it imports nothing from `admin-form` (form/key policy)
+ * or `image-optimize.server` (the resize boundary), so both can depend on it
+ * without a cycle and without the pure image-optimization boundary reaching into
+ * admin-form's naming policy (`boundary-discipline`, `derive-dont-sync` — one
+ * MIME↔extension table, not a copy per consumer).
+ */
+
+const ACCEPTED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/avif',
+]);
+
+/** Whether `type` is an image MIME we accept for upload (case-insensitive). */
+export const isAcceptedImageType = (type: string): boolean =>
+  ACCEPTED_IMAGE_TYPES.has(type.toLowerCase());
+
+const EXTENSION_BY_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/avif': 'avif',
+};
+
+/** The file extension for an image MIME (`'bin'` for anything unrecognized). */
+export const extensionForType = (type: string): string =>
+  EXTENSION_BY_TYPE[type.toLowerCase()] ?? 'bin';

--- a/app/lib/images.server.ts
+++ b/app/lib/images.server.ts
@@ -22,7 +22,7 @@
 
 // The only object extensions `/images/*` is ever allowed to serve. Mirrors the
 // image entries in `server.ts`'s `mimeFor` and covers every extension the
-// uploader emits (`EXTENSION_BY_TYPE` in `app/lib/content/admin-form.ts`) plus
+// uploader emits (`EXTENSION_BY_TYPE` in `app/lib/content/image-types.ts`) plus
 // the bundled `public/<year>/…` art (`.jpg`/`.jpeg`/`.png`/`.svg`).
 export const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
   'svg',

--- a/app/routes/admin/content.action.test.ts
+++ b/app/routes/admin/content.action.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'bun:test';
+import { ConfigProvider, Effect, Layer, ManagedRuntime, Schema } from 'effect';
+import { RouterContextProvider } from 'react-router';
+
+import { Auth } from '~/lib/auth.server';
+import { SITE_CONTENT_KEY } from '~/lib/content.server';
+import { defaultContent } from '~/lib/content/defaults';
+import { SiteContent } from '~/lib/content/schema';
+import { makeAppLayer, makeRequestRuntimeFromLayer } from '~/lib/effect/runtime';
+import type { RouteArgs } from '~/lib/effect/router-context';
+import { Storage } from '~/lib/storage.server';
+import { layerTest } from '~/lib/storage.test-helper';
+
+import { action } from './content';
+
+/**
+ * The SITE editor action's image-upload resize path through the REAL action
+ * (Feature B.2). B wires `prepareImage` into BOTH editors; the per-page editor
+ * is pinned in `pages.$page.action.test.ts`. This pins the OTHER editor — the
+ * site editor (`/admin/content`) — so a regression that re-encodes only on the
+ * per-page path, or that keys the site upload off `file.type` instead of the
+ * re-encoded `prepared.contentType`, is caught here. A wide JPEG uploaded to a
+ * team member's `photo.key` must land as a `.webp` object with an `image/webp`
+ * content-type in the SAME in-memory bucket the action wrote to.
+ *
+ * Harness mirrors the per-page action test: admin secrets ride a scoped
+ * `ConfigProvider` (never `process.env`), and the success assertion queries the
+ * store through the request's own `context.runtime` so it is the same bucket.
+ */
+
+const PASSWORD = 'correct-horse';
+const SECRET = 'a-signing-secret-of-sufficient-length';
+
+const adminConfig = ConfigProvider.layer(
+  ConfigProvider.fromEnv({
+    env: { ADMIN_PASSWORD: PASSWORD, COOKIE_SECRET: SECRET },
+  }),
+);
+
+/** `content/site.json` seed bytes — the published doc the upload drafts from. */
+const seedSite = (): Promise<string> =>
+  Effect.runPromise(
+    Schema.encodeUnknownEffect(Schema.fromJsonString(SiteContent))(defaultContent),
+  );
+
+/** Build the app layer (in-memory storage seeded with `site.json`) + admin config. */
+const makeLayer = (seed: string) =>
+  Layer.provide(
+    makeAppLayer(layerTest({ [SITE_CONTENT_KEY]: { body: seed } })),
+    adminConfig,
+  );
+
+const makeContext = (seed: string) => {
+  const layer = makeLayer(seed);
+  const context = new RouterContextProvider();
+  context.runtime = makeRequestRuntimeFromLayer(layer);
+  return { layer, context };
+};
+
+const mintCookie = async (
+  layer: ReturnType<typeof makeLayer>,
+): Promise<string> => {
+  const runtime = ManagedRuntime.make(layer);
+  const header = await runtime.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service;
+      const token = yield* auth.verifyPassword(PASSWORD);
+      return auth.cookieHeader(token);
+    }),
+  );
+  await runtime.dispose();
+  return header;
+};
+
+/**
+ * POST an `upload:team.<id>.photo.key` multipart request to the site editor
+ * action, returning the response AND the request `args` so the success test can
+ * read back the stored bytes through the SAME `context.runtime`.
+ */
+const postUpload = async (
+  target: string,
+  file: File,
+): Promise<{ res: Response; args: RouteArgs }> => {
+  const seed = await seedSite();
+  const { layer, context } = makeContext(seed);
+  const cookie = await mintCookie(layer);
+
+  const body = new FormData();
+  body.set('intent', `upload:${target}`);
+  body.set('file', file);
+
+  const url = 'http://localhost/admin/content';
+  const request = new Request(url, {
+    method: 'POST',
+    body,
+    headers: { cookie },
+  });
+  const args: RouteArgs = {
+    request,
+    url: new URL(url),
+    pattern: '/admin/content',
+    params: {},
+    context,
+  };
+  const res = (await action(args)) as Response;
+  return { res, args };
+};
+
+/** The `key` echoed in the action's success redirect `?status=Image uploaded: <key>`. */
+const uploadedKeyFromRedirect = (res: Response): string => {
+  const location = res.headers.get('location') ?? '';
+  const status = new URL(location, 'http://localhost').searchParams.get('status') ?? '';
+  const match = status.match(/Image uploaded: (.+)$/);
+  if (match === null) throw new Error(`no uploaded key in redirect: ${location}`);
+  return match[1]!;
+};
+
+describe('site editor action — image-upload resize-to-webp (B.2)', () => {
+  // A 1×1 PNG seed grown to a wide JPEG via Bun.Image — a real >MAX_WIDTH image.
+  const wideJpeg = async (): Promise<File> => {
+    const seed = new Uint8Array(
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+        'base64',
+      ),
+    );
+    const bytes = new Uint8Array(
+      await new Bun.Image(seed).resize(2400, 800).jpeg({ quality: 90 }).toBuffer(),
+    );
+    return new File([bytes], 'wide.jpg', { type: 'image/jpeg' });
+  };
+
+  it('a wide JPEG uploaded to a team photo is stored as a .webp / image/webp object', async () => {
+    // Address a real team member by its id (ADR 0006), exactly as the editor's
+    // `upload:team.<id>.photo.key` intent does.
+    const memberId = String(defaultContent.team[0]?.id);
+    const target = `team.${memberId}.photo.key`;
+
+    const { res, args } = await postUpload(target, await wideJpeg());
+
+    expect(res.status).toBe(302);
+    const key = uploadedKeyFromRedirect(res);
+    expect(key).toMatch(/\.webp$/);
+
+    // The action's put landed an image/webp object — read through the SAME
+    // runtime the action used, so it is the same in-memory bucket.
+    const head = await args.context.runtime.run(
+      args,
+      Effect.gen(function* () {
+        const storage = yield* Storage.Service;
+        return yield* storage.head(key);
+      }),
+    );
+
+    expect(head._tag).toBe('Some');
+    if (head._tag === 'Some') {
+      expect(head.value.contentType).toBe('image/webp');
+    }
+  });
+});

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -34,6 +34,7 @@ import {
   uploadedImageKey,
   type Json,
 } from '~/lib/content/admin-form';
+import { prepareImage } from '~/lib/content/image-optimize.server';
 import { collectListOps, fieldName } from '~/lib/content/list-edit';
 import {
   DraftSiteContent,
@@ -58,9 +59,10 @@ export const headers = adminSecurityHeaders;
  *   - **Publish** writes `content/site.json`, removes the draft, and **busts the
  *     `Content` read cache** so the change is live on the next public read with
  *     NO redeploy (D3);
- *   - per-image **Upload** stores the raw bytes under `images/uploads/…` and
- *     rewrites the targeted `…key` field to the new bucket object key (the
- *     resize/WebP/thumbnail pipeline is deferred — CMS plan §"Non-goals").
+ *   - per-image **Upload** shrinks + re-encodes the bytes to WebP at the one
+ *     shared `prepareImage` boundary (`~/lib/content/image-optimize.server`),
+ *     stores them under `images/uploads/…`, and rewrites the targeted `…key`
+ *     field to the new bucket object key.
  *
  * The merge-onto-current-document strategy (`~/lib/content/admin-form`) means the
  * form only carries the fields it renders; every unedited deep field (long bios,
@@ -152,11 +154,18 @@ export const action = routeAction(function* () {
       );
     }
 
-    const now = yield* Clock.currentTimeMillis;
-    const key = uploadedImageKey(uploadTarget, file.type, now);
+    // Shrink + re-encode at the ONE shared boundary (Feature B). The stored
+    // object IS WebP after `prepareImage`, so the key + `storage.put` follow
+    // `prepared.contentType` — never `file.type` — or the served object's
+    // extension/type would lie.
     const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
+    const prepared = yield* prepareImage(bytes, file.type);
+    const now = yield* Clock.currentTimeMillis;
+    const key = uploadedImageKey(uploadTarget, prepared.contentType, now);
 
-    const putExit = yield* Effect.exit(storage.put(key, bytes, file.type));
+    const putExit = yield* Effect.exit(
+      storage.put(key, prepared.bytes, prepared.contentType),
+    );
     if (putExit._tag === 'Failure') {
       return Response.json(
         {

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -131,7 +131,8 @@ export const action = routeAction(function* () {
   const intent = String(form.get('intent') ?? 'save-draft');
 
   // ---- image upload --------------------------------------------------------
-  // The route owns the FormData side: validate the file and store its raw bytes;
+  // The route owns the FormData side: validate the file, optimize it at the
+  // shared `prepareImage` boundary, and store the prepared bytes;
   // `DraftEditor.applyImageUpload` then rewrites the targeted `…key` field on the
   // draft so the new image survives a reload and a later publish.
   const uploadTarget = imageUploadTarget(intent);
@@ -154,9 +155,9 @@ export const action = routeAction(function* () {
       );
     }
 
-    // Shrink + re-encode at the ONE shared boundary (Feature B). The stored
-    // object IS WebP after `prepareImage`, so the key + `storage.put` follow
-    // `prepared.contentType` — never `file.type` — or the served object's
+    // Shrink + re-encode at the ONE shared boundary (Feature B): WebP for the
+    // decodable raster types, GIF/originals passed through. The key + `storage.put`
+    // follow `prepared.contentType` — never `file.type` — or the served object's
     // extension/type would lie.
     const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
     const prepared = yield* prepareImage(bytes, file.type);

--- a/app/routes/admin/pages.$page.action.test.ts
+++ b/app/routes/admin/pages.$page.action.test.ts
@@ -5,6 +5,7 @@ import { RouterContextProvider } from 'react-router';
 import { Auth } from '~/lib/auth.server';
 import { makeAppLayer, makeRequestRuntimeFromLayer } from '~/lib/effect/runtime';
 import type { RouteArgs } from '~/lib/effect/router-context';
+import { Storage } from '~/lib/storage.server';
 import { layerTest } from '~/lib/storage.test-helper';
 
 import { action } from './pages.$page';
@@ -61,8 +62,16 @@ const mintCookie = async (
   return header;
 };
 
-/** POST an `upload:groupPhoto.key` multipart request to the team page action. */
-const postUpload = async (file: File): Promise<Response> => {
+/**
+ * POST an `upload:groupPhoto.key` multipart request to the team page action,
+ * returning the response AND the request `args` so a success test can inspect
+ * the bytes the action actually stored — through the SAME `context.runtime`, so
+ * the in-memory bucket is the one the action wrote to (a fresh `ManagedRuntime`
+ * would build a fresh, empty store).
+ */
+const postUpload = async (
+  file: File,
+): Promise<{ res: Response; args: RouteArgs }> => {
   const { layer, context } = makeContext();
   const cookie = await mintCookie(layer);
 
@@ -83,13 +92,23 @@ const postUpload = async (file: File): Promise<Response> => {
     params: { page: 'team' },
     context,
   };
-  return (await action(args)) as Response;
+  const res = (await action(args)) as Response;
+  return { res, args };
+};
+
+/** The `key` echoed in the action's success redirect `?status=Image uploaded: <key>`. */
+const uploadedKeyFromRedirect = (res: Response): string => {
+  const location = res.headers.get('location') ?? '';
+  const status = new URL(location, 'http://localhost').searchParams.get('status') ?? '';
+  const match = status.match(/Image uploaded: (.+)$/);
+  if (match === null) throw new Error(`no uploaded key in redirect: ${location}`);
+  return match[1]!;
 };
 
 describe('team page editor action — image-upload guards (A.5)', () => {
   it('an empty file is a 400 (no bytes stored)', async () => {
     const empty = new File([], 'photo.jpg', { type: 'image/jpeg' });
-    const res = await postUpload(empty);
+    const { res } = await postUpload(empty);
     expect(res.status).toBe(400);
     const json = (await res.json()) as { ok: boolean; error: string };
     expect(json.ok).toBe(false);
@@ -100,10 +119,57 @@ describe('team page editor action — image-upload guards (A.5)', () => {
     const pdf = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'doc.pdf', {
       type: 'application/pdf',
     });
-    const res = await postUpload(pdf);
+    const { res } = await postUpload(pdf);
     expect(res.status).toBe(400);
     const json = (await res.json()) as { ok: boolean; error: string };
     expect(json.ok).toBe(false);
     expect(json.error).toContain('Upload a JPEG');
+  });
+});
+
+/**
+ * The per-page editor upload SUCCESS path through the REAL action (Feature B.2).
+ * A wide JPEG must be resized + re-encoded to WebP at the shared `prepareImage`
+ * boundary, so the action's redirect key ends `.webp` AND the byte the action
+ * stored in the shared in-memory bucket carries an `image/webp` content-type —
+ * proving the key + `storage.put` follow the RE-ENCODED type, not `file.type`.
+ */
+describe('team page editor action — image-upload resize-to-webp (B.2)', () => {
+  // A 1×1 PNG seed grown to a wide JPEG via Bun.Image — a real >MAX_WIDTH image.
+  const wideJpeg = async (): Promise<File> => {
+    const seed = new Uint8Array(
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+        'base64',
+      ),
+    );
+    const bytes = new Uint8Array(
+      await new Bun.Image(seed).resize(2400, 800).jpeg({ quality: 90 }).toBuffer(),
+    );
+    return new File([bytes], 'wide.jpg', { type: 'image/jpeg' });
+  };
+
+  it('a wide JPEG is stored as a .webp object with an image/webp content-type', async () => {
+    const { res, args } = await postUpload(await wideJpeg());
+
+    // Success is a redirect carrying the stored key in its status message.
+    expect(res.status).toBe(302);
+    const key = uploadedKeyFromRedirect(res);
+    expect(key).toMatch(/^images\/uploads\/groupPhoto-key-\d+\.webp$/);
+
+    // The action's put landed an image/webp object under that key — queried
+    // through the SAME runtime the action used, so it is the same bucket.
+    const head = await args.context.runtime.run(
+      args,
+      Effect.gen(function* () {
+        const storage = yield* Storage.Service;
+        return yield* storage.head(key);
+      }),
+    );
+
+    expect(head._tag).toBe('Some');
+    if (head._tag === 'Some') {
+      expect(head.value.contentType).toBe('image/webp');
+    }
   });
 });

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -22,6 +22,7 @@ import {
   uploadedImageKey,
   type Json,
 } from '~/lib/content/admin-form';
+import { prepareImage } from '~/lib/content/image-optimize.server';
 import { collectListOps, fieldName } from '~/lib/content/list-edit';
 import { PAGE_SPECS, PageId } from '~/lib/content/pages/registry';
 import { ListItemId, newListItemId } from '~/lib/content/schema';
@@ -176,11 +177,17 @@ export const action = routeAction(function* () {
       );
     }
 
-    const now = yield* Clock.currentTimeMillis;
-    const key = uploadedImageKey(uploadTarget, file.type, now);
+    // Shrink + re-encode at the ONE shared boundary (Feature B), identical to
+    // the site editor: the stored object IS WebP after `prepareImage`, so the
+    // key + `storage.put` follow `prepared.contentType`, never `file.type`.
     const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
+    const prepared = yield* prepareImage(bytes, file.type);
+    const now = yield* Clock.currentTimeMillis;
+    const key = uploadedImageKey(uploadTarget, prepared.contentType, now);
 
-    const putExit = yield* Effect.exit(storage.put(key, bytes, file.type));
+    const putExit = yield* Effect.exit(
+      storage.put(key, prepared.bytes, prepared.contentType),
+    );
     if (putExit._tag === 'Failure') {
       return Response.json(
         {

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -152,7 +152,8 @@ export const action = routeAction(function* () {
 
   // ---- image upload --------------------------------------------------------
   // Identical in shape to the site editor (`content.tsx`), scoped to THIS page:
-  // validate the file, store its raw bytes, then `DraftEditor.applyImageUpload`
+  // validate the file, optimize it at the shared `prepareImage` boundary, store
+  // the prepared bytes, then `DraftEditor.applyImageUpload`
   // rewrites the targeted `<image>.key` field on the page draft so the new image
   // survives a reload and a later publish. The image-upload path is REUSED, not
   // re-implemented — `applyImageUpload` is scope-generic and `setAtPath` already
@@ -178,8 +179,8 @@ export const action = routeAction(function* () {
     }
 
     // Shrink + re-encode at the ONE shared boundary (Feature B), identical to
-    // the site editor: the stored object IS WebP after `prepareImage`, so the
-    // key + `storage.put` follow `prepared.contentType`, never `file.type`.
+    // the site editor: WebP for decodable rasters, GIF/originals passed through,
+    // so the key + `storage.put` follow `prepared.contentType`, never `file.type`.
     const bytes = new Uint8Array(yield* Effect.promise(() => file.arrayBuffer()));
     const prepared = yield* prepareImage(bytes, file.type);
     const now = yield* Clock.currentTimeMillis;


### PR DESCRIPTION
Feature B of the CMS images+enable stack. Stacks on Feature A (#29, merged to main).

**What:** one shared `prepareImage` boundary (`app/lib/content/image-optimize.server.ts`) that BOTH the site editor (`content.tsx`) and the per-page editor (`pages.$page.tsx`) route uploads through. `Bun.Image`, zero new deps: cap width 1600, re-encode to WebP@~80, **guarded on `(await img.metadata()).width`** (not `img.width`, which is -1 until `metadata()` resolves in Bun 1.3.14), GIF passthrough (never flattens animation), and a `catchAll → original bytes/type` fallback so a `Bun.Image` failure never fails an upload. Key + `storage.put` follow `prepared.contentType`.

**Cadence:** built B.1–B.2 sub-commit-by-sub-commit with `okra counsel` after each; final `okra counsel --deep` whole-PR review verdict: structurally correct, one P1 test-gap (site-editor resize path) raised and closed (`a38e18b`).

**Rebased** onto `main` after A (#29) squash-merged — carries only B's 5 commits; gate green (typecheck, lint, build, 430 tests).

🤖 Two-tier-counsel implementation from `docs/cms-images-enable-plan.md`.