### PR TITLE
fix(cms): close the two CMS asset/copy hardcodes (home mission photo + registration-form i18n)

### DIFF
--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -388,6 +388,35 @@ describe('Content translations + team selectors', () => {
       expect(team.team[0]?.image).toBe('/images/team/elijah.jpg');
       expect(team.board).toContain('George Cho');
     }).pipe(provideSeeded(defaultContent)));
+
+  it.effect(
+    'fills a static translation key absent from a published site.json (no blanks) while a CMS override still wins',
+    () =>
+      Effect.gen(function* () {
+        // The regression Codex's Batch-2/3 review surfaced: `content.translations`
+        // is an OPEN Record, so a published `site.json` predating a newly-added
+        // static key would make `useTranslate` return `undefined` (a blank). The
+        // read boundary now merges the static `root` table UNDER the CMS values, so
+        // a missing key resolves to its static default while a CMS edit overrides.
+        const content = yield* Content.Service;
+        const en = yield* content.getTranslations('en');
+        // A key NOT present in the seeded (stripped) translations resolves to its
+        // static default rather than undefined.
+        expect(en['registration.form.outreach.title']).toBe('Outreach');
+        // The one CMS-provided key overrides the static default.
+        expect(en['registration.form.submit']).toBe('Send it');
+      }).pipe(
+        provideSeeded({
+          ...defaultContent,
+          // A published doc carrying ONLY one (overriding) translation key — every
+          // other static key is absent, exactly like a legacy publish.
+          translations: {
+            en: { 'registration.form.submit': 'Send it' },
+            fr: {},
+          },
+        } as SiteContentType),
+      ),
+  );
 });
 
 describe('Content cache (TTL + single-flight)', () => {

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -39,6 +39,7 @@ import type {
 import { dayjs } from './dayjs';
 import { assertValidLocale } from './localization/localization';
 import type { Locale } from './localization/localization';
+import { root as staticTranslations } from './localization/translations';
 import { Storage } from './storage.server';
 
 /**
@@ -671,7 +672,16 @@ export const layer = Layer.effect(
     ) {
       assertValidLocale(locale);
       const content = yield* getSiteContent();
-      return content.translations[locale];
+      // Static defaults as the BASE, CMS values as OVERRIDES. `content.translations`
+      // (from `content/site.json`) is an OPEN `Record`, so an already-published
+      // site object NEVER carries a translation key added to the static `root` table
+      // after it was published — and `useTranslate` would then return `undefined`
+      // (a blank heading/button) until someone republished. Merging `root[locale]`
+      // underneath guarantees every static key is present, while a CMS edit to any
+      // key still wins. This makes a static translation addition self-applying on
+      // deploy with no manual republish (the translation analogue of the per-object
+      // read-boundary backfills — `make-operations-idempotent`, `derive-dont-sync`).
+      return { ...staticTranslations[locale], ...content.translations[locale] };
     });
 
     const getTeam = Effect.fn('Content.getTeam')(function* () {

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -584,7 +584,13 @@ export const layer = Layer.effect(
             new Response(object.stream).text(),
           );
           const parsed = yield* parseJson(json);
-          return yield* decode(parsed);
+          // One-shot, idempotent read-boundary backfill (the per-object analogue of
+          // `backfillListItemIds`) — fills a structural gap a legacy published
+          // object leaves after a new optional field was added (home's
+          // `mission.photo`). Absent for specs with no such gap; for ABSENCE only,
+          // so a malformed value still reaches `decode` to be rejected.
+          const normalized = spec.normalize ? spec.normalize(parsed) : parsed;
+          return yield* decode(normalized);
         }).pipe(
           Effect.catchCause((cause) =>
             Effect.logWarning(`Content: could not read ${key}`, cause).pipe(

--- a/app/lib/content/admin-form.test.ts
+++ b/app/lib/content/admin-form.test.ts
@@ -312,6 +312,53 @@ describe('pruneKeylessImageOverrides', () => {
         expect(strict.portrait).toBeUndefined();
       }),
   );
+
+  test('drops a keyless NESTED home mission.photo, keeping its sibling copy', () => {
+    // Home's slot lives under `mission`. A keyless `mission.photo` on a keyless
+    // base must be pruned WITHOUT disturbing `mission.readStoryLabel` — the prune
+    // rebuilds only the path, sharing every sibling.
+    const override = assembleOverrides(
+      entries({
+        'tagline.en': 'Tag',
+        'tagline.fr': 'Tag',
+        'mission.readStoryLabel.en': 'Read',
+        'mission.readStoryLabel.fr': 'Lire',
+        'mission.photo.alt.en': '',
+        'mission.photo.alt.fr': '',
+      }),
+    );
+    const pruned = pruneKeylessImageOverrides({}, override) as Record<
+      string,
+      unknown
+    >;
+    const mission = pruned['mission'] as
+      | { readStoryLabel?: unknown; photo?: unknown }
+      | undefined;
+    expect(mission?.readStoryLabel).toEqual({ en: 'Read', fr: 'Lire' });
+    expect(mission && 'photo' in mission).toBe(false);
+    expect(pruned['tagline']).toEqual({ en: 'Tag', fr: 'Tag' });
+  });
+
+  test('keeps a home mission.photo alt edit when the base already has the seeded key', () => {
+    // The bundled home default SEEDS `mission.photo.key` = `main/people.png`, so a
+    // plain save's keyless alt override must MERGE onto that key, not be pruned.
+    const base: Json = {
+      mission: {
+        readStoryLabel: { en: 'Read', fr: 'Lire' },
+        photo: { key: 'main/people.png', alt: { en: 'Mission', fr: 'Mission' } },
+      },
+    };
+    const override = assembleOverrides(
+      entries({
+        'mission.photo.alt.en': 'Our mission',
+        'mission.photo.alt.fr': 'Notre mission',
+      }),
+    );
+    const pruned = pruneKeylessImageOverrides(base, override) as {
+      mission?: { photo?: { alt?: { en?: string } } };
+    };
+    expect(pruned.mission?.photo?.alt?.en).toBe('Our mission');
+  });
 });
 
 describe('deepMerge', () => {

--- a/app/lib/content/admin-form.ts
+++ b/app/lib/content/admin-form.ts
@@ -294,43 +294,96 @@ const hasImageKey = (slot: Json | undefined): boolean =>
   slot['key'].trim() !== '';
 
 /**
- * Drop an optional image-slot override (`groupPhoto` / `portrait` on the Team
- * page) that carries ONLY alt text and no uploaded `key` — UNLESS the current
- * draft already has a `key` for that slot (then the alt edit must land onto the
- * existing image).
+ * The dotted paths of every OPTIONAL image slot an `/admin` page editor renders an
+ * alt-text input for: Team's two TOP-LEVEL slots (`groupPhoto` / `portrait`) and
+ * Home's slot NESTED one level under `mission` (`mission.photo`, Feature A
+ * remediation). Each is a `Schema.optionalKey(ImageRef)` whose editor always posts
+ * `<path>.alt.en/.fr` — so a plain save with no upload produces a present-but-
+ * keyless `{ alt }` object that must be pruned (see `pruneKeylessImageOverrides`).
+ * Declared ONCE here (`derive-dont-sync`): adding a new optional image slot is one
+ * entry, not a new branch in the prune walk.
+ */
+const OPTIONAL_IMAGE_SLOT_PATHS: readonly string[] = [
+  'groupPhoto',
+  'portrait',
+  'mission.photo',
+];
+
+/** Read the value at a dotted `path` inside a JSON object, or `undefined`. */
+const valueAtPath = (root: Json | undefined, path: string): Json | undefined => {
+  let cursor: Json | undefined = root;
+  for (const segment of path.split('.')) {
+    if (cursor === undefined || !isPlainObject(cursor)) return undefined;
+    cursor = cursor[segment];
+  }
+  return cursor;
+};
+
+/**
+ * Drop an optional image-slot override (Team's `groupPhoto` / `portrait`, Home's
+ * `mission.photo`) that carries ONLY alt text and no uploaded `key` — UNLESS the
+ * current draft already has a `key` for that slot (then the alt edit must land onto
+ * the existing image).
  *
  * Why this seam (mirrors `normalizeFaqAnswers`, registration-launch Branch 5.5):
- * the Team editor ALWAYS renders both image slots' alt-text `Bilingual` inputs,
- * which always post `groupPhoto.alt.en/.fr` + `portrait.alt.en/.fr`. On a plain
- * save with no image uploaded, `assembleOverrides` therefore produces a
- * `groupPhoto: { alt: { en, fr } }` object with NO `key`. That is DRAFT-valid
- * (the lax `DraftImageRef` makes `key` optional) but PUBLISH-INVALID: the strict
- * `ImageRef` sees the slot as *present* and rejects it with `groupPhoto.key:
- * Missing key`. Section-skip is for *absence* of the whole slot (ADR 0008), not a
- * present-but-keyless object — so the keyless alt-only override is pruned, leaving
- * the slot absent and the save/publish path clean. Once an image IS uploaded (the
- * draft base carries `key`), the alt override is kept so the upload-first /
- * fill-alt-second flow completes (ADR 0006). Only the two named image slots are
- * touched; every other override passes through verbatim.
+ * an image-slot editor ALWAYS renders the slot's alt-text `Bilingual` inputs, which
+ * always post `<slot>.alt.en/.fr`. On a plain save with no image uploaded,
+ * `assembleOverrides` therefore produces a `<slot>: { alt: { en, fr } }` object with
+ * NO `key`. That is DRAFT-valid (the lax `DraftImageRef` makes `key` optional) but
+ * PUBLISH-INVALID: the strict `ImageRef` sees the slot as *present* and rejects it
+ * with `<slot>.key: Missing key`. Section-skip is for *absence* of the whole slot
+ * (ADR 0008), not a present-but-keyless object — so the keyless alt-only override is
+ * pruned, leaving the slot absent and the save/publish path clean. Once an image IS
+ * uploaded (the draft base carries `key`), the alt override is kept so the
+ * upload-first / fill-alt-second flow completes (ADR 0006).
+ *
+ * Each slot is addressed by its dotted path (`OPTIONAL_IMAGE_SLOT_PATHS`), so a
+ * NESTED slot (`mission.photo`) is pruned by walking into `mission` and dropping a
+ * keyless `photo` — leaving `mission`'s other keys (`readStoryLabel`) untouched. A
+ * scope with none of these paths passes through verbatim.
  */
 export const pruneKeylessImageOverrides = (base: Json, override: Json): Json => {
   if (!isPlainObject(override)) return override;
-  const baseObject = isPlainObject(base) ? base : undefined;
-  const result: MutableJsonObject = {};
-  for (const key of Object.keys(override)) {
-    const slot = override[key];
-    if (slot === undefined) continue;
+  let result: Json = override;
+  for (const path of OPTIONAL_IMAGE_SLOT_PATHS) {
+    const slot = valueAtPath(result, path);
     if (
-      (key === 'groupPhoto' || key === 'portrait') &&
+      slot !== undefined &&
       isPlainObject(slot) &&
       !hasImageKey(slot) &&
-      !hasImageKey(baseObject?.[key])
+      !hasImageKey(valueAtPath(base, path))
     ) {
-      continue; // keyless, no existing image — drop so the slot stays absent
+      // Keyless, no existing image — drop so the slot stays absent. Removing a
+      // nested path rebuilds only the objects along it (the rest is shared).
+      result = removeAtPath(result, path);
     }
-    result[key] = slot;
   }
   return result;
+};
+
+/**
+ * Return a copy of `root` with the value at the dotted `path` removed, rebuilding
+ * only the objects along the path (every sibling and untouched subtree is shared by
+ * reference — the override is never mutated). A path segment whose parent isn't a
+ * plain object is a no-op (the slot wasn't there to begin with).
+ */
+const removeAtPath = (root: Json, path: string): Json => {
+  const segments = path.split('.');
+  const recur = (node: Json | undefined, depth: number): Json | undefined => {
+    if (node === undefined || !isPlainObject(node)) return node;
+    const segment = segments[depth];
+    if (segment === undefined) return node;
+    const next: MutableJsonObject = { ...node };
+    if (depth === segments.length - 1) {
+      delete next[segment];
+      return next;
+    }
+    const child = recur(next[segment], depth + 1);
+    if (child === undefined) delete next[segment];
+    else next[segment] = child;
+    return next;
+  };
+  return recur(root, 0) ?? root;
 };
 
 /**

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -822,6 +822,48 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect(result.draftKey).toBe(String(result.key));
   });
 
+  it('a LEGACY published home.json (no mission.photo) is backfilled to the seeded photo on read', async () => {
+    // The regression Codex's Batch-1 review surfaced: a `home.json` PUBLISHED
+    // before `mission.photo` existed carries a `mission` with NO `photo` key. It
+    // decodes cleanly (the field is optional), so `getPage` returns it as-is and
+    // the seeded default NEVER applies — the photo would silently vanish. The
+    // read-boundary backfill (`spec.normalize`) fills the absent slot with the
+    // seed, so the public view still shows the photo with no migration/redeploy.
+    const legacyHomeJson = JSON.stringify({
+      enabled: true,
+      tagline: { en: 'Legacy tagline', fr: 'Ancien slogan' },
+      // `mission` WITHOUT a `photo` key — exactly what a pre-field publish wrote.
+      mission: { readStoryLabel: { en: 'Read', fr: 'Lire' } },
+      join: {
+        title: { en: 'Join', fr: 'Rejoignez' },
+        subtitle: { en: 'Sub', fr: 'Sous' },
+        donateLabel: { en: 'Donate', fr: 'Donner' },
+        volunteerLabel: { en: 'Volunteer', fr: 'Bénévole' },
+      },
+      newsletter: {
+        title: { en: 'News', fr: 'Infos' },
+        subtitle: { en: 'NSub', fr: 'NSous' },
+        socials: { en: 'Follow', fr: 'Suivez' },
+      },
+    });
+    const result = await run(
+      Effect.gen(function* () {
+        const content = yield* Content.Service;
+        const live = yield* content.getPage('home');
+        return {
+          taglineEn: live.tagline.en, // proves the LEGACY object is what was read
+          photoKey: String(live.mission.photo?.key),
+          photoAlt: live.mission.photo?.alt,
+        };
+      }),
+      { [pageObjectKey('home')]: { body: legacyHomeJson } },
+    );
+    // The legacy object was read (its tagline), AND its absent photo was backfilled.
+    expect(result.taglineEn).toBe('Legacy tagline');
+    expect(result.photoKey).toBe('main/people.png');
+    expect(result.photoAlt).toEqual({ en: 'Mission', fr: 'Mission' });
+  });
+
   it('a plain home save (no upload) PUBLISHES and KEEPS the seeded photo', async () => {
     // The home editor always renders the mission.photo alt `Bilingual`, so a plain
     // save posts `mission.photo.alt.en/.fr` with NO key. Unlike Team (whose default

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -773,4 +773,104 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect(imageUploadTarget('upload:portrait.key')).toBe('portrait.key');
     expect(imageUploadTarget('upload:groupPhoto.key')).toBe('groupPhoto.key');
   });
+
+  // --- Home page's NESTED mission.photo image slot (Feature A remediation) -----
+  // Mirrors the Team image-slot tests above, but the slot lives one level under
+  // `mission` and the bundled default SEEDS it (`main/people.png`) — so the
+  // section-skip / keyless-prune assertions differ where the seed makes them.
+
+  it('the seeded home mission photo reads through to the public Content boundary', async () => {
+    // The default `home` page seeds `mission.photo` = `main/people.png` so the
+    // day-one render matches the pre-migration hardcoded `<img>`. Proven here by
+    // reading the page with no bucket object (the bundled default) and asserting
+    // the projected slot resolves to the managed `/images/main/people.png` URL.
+    const result = await run(
+      Effect.gen(function* () {
+        const content = yield* Content.Service;
+        const live = yield* content.getPage('home');
+        return { key: String(live.mission.photo?.key), alt: live.mission.photo?.alt };
+      }),
+    );
+    expect(result.key).toBe('main/people.png');
+    expect(result.alt).toEqual({ en: 'Mission', fr: 'Mission' });
+  });
+
+  it('upload:mission.photo.key rewrites the NESTED home draft key (REUSED applyImageUpload)', async () => {
+    const homeScope = pageScope('home');
+    // The same generic `upload:<keyPath>` intent — `setPath` navigates the nested
+    // `mission.photo.key` exactly as it does the top-level `groupPhoto.key`.
+    const target = imageUploadTarget('upload:mission.photo.key');
+    expect(target).toBe('mission.photo.key');
+
+    const jpg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const storage = yield* Storage.Service;
+        const key = uploadedImageKey(target!, 'image/jpeg', 1_700_000_000_000);
+        yield* storage.put(key, jpg, 'image/jpeg');
+        yield* editor.applyImageUpload(homeScope, target!, key);
+        const draft = yield* editor.load(homeScope);
+        const mission = draft.content.mission as { photo?: { key?: string } };
+        return { key, draftKey: String(mission.photo?.key) };
+      }),
+    );
+    expect(String(result.key)).toMatch(
+      /^images\/uploads\/mission-photo-key-1700000000000\.jpg$/,
+    );
+    // The uploaded key replaced the seeded `main/people.png` at the nested path.
+    expect(result.draftKey).toBe(String(result.key));
+  });
+
+  it('a plain home save (no upload) PUBLISHES and KEEPS the seeded photo', async () => {
+    // The home editor always renders the mission.photo alt `Bilingual`, so a plain
+    // save posts `mission.photo.alt.en/.fr` with NO key. Unlike Team (whose default
+    // is keyless → pruned to absent), home's DEFAULT carries a key, so the prune
+    // KEEPS the alt override (it merges onto the seeded key) and publish succeeds
+    // with the photo intact — the keyless-prune must not clobber a seeded slot.
+    const homeScope = pageScope('home');
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const content = yield* Content.Service;
+        const override = assembleOverrides([
+          ['tagline.en', 'A movement'],
+          ['tagline.fr', 'Un mouvement'],
+          ['mission.readStoryLabel.en', 'Read our story'],
+          ['mission.readStoryLabel.fr', 'Lire notre histoire'],
+          ['mission.photo.alt.en', 'Our mission'],
+          ['mission.photo.alt.fr', 'Notre mission'],
+          ['join.title.en', 'Join'],
+          ['join.title.fr', 'Rejoignez'],
+          ['join.subtitle.en', 'Sub'],
+          ['join.subtitle.fr', 'Sous'],
+          ['join.donateLabel.en', 'Donate'],
+          ['join.donateLabel.fr', 'Donner'],
+          ['join.volunteerLabel.en', 'Volunteer'],
+          ['join.volunteerLabel.fr', 'Bénévole'],
+          ['newsletter.title.en', 'News'],
+          ['newsletter.title.fr', 'Infos'],
+          ['newsletter.subtitle.en', 'NSub'],
+          ['newsletter.subtitle.fr', 'NSous'],
+          ['newsletter.socials.en', 'Follow'],
+          ['newsletter.socials.fr', 'Suivez'],
+        ]) as Json;
+        yield* TestClock.adjust('1 second');
+        yield* editor.editDocument(homeScope, override);
+        const publishExit = yield* Effect.exit(editor.publish(homeScope));
+        const live = yield* content.getPage('home');
+        return {
+          publishTag: publishExit._tag,
+          photoKey: String(live.mission.photo?.key),
+          photoAltEn: live.mission.photo?.alt.en,
+          taglineEn: live.tagline.en,
+        };
+      }),
+    );
+    expect(result.publishTag).toBe('Success');
+    expect(result.taglineEn).toBe('A movement');
+    // Seeded key preserved; the alt edit landed onto it (NOT pruned away).
+    expect(result.photoKey).toBe('main/people.png');
+    expect(result.photoAltEn).toBe('Our mission');
+  });
 });

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -822,30 +822,31 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect(result.draftKey).toBe(String(result.key));
   });
 
-  it('a LEGACY published home.json (no mission.photo) is backfilled to the seeded photo on read', async () => {
-    // The regression Codex's Batch-1 review surfaced: a `home.json` PUBLISHED
-    // before `mission.photo` existed carries a `mission` with NO `photo` key. It
-    // decodes cleanly (the field is optional), so `getPage` returns it as-is and
+  // A `home.json` PUBLISHED before `mission.photo` existed — a `mission` with NO
+  // `photo` key, exactly what a pre-field publish wrote. Used to prove the
+  // read-boundary backfill on BOTH the public read and the /admin draft read.
+  const legacyHomeJson = JSON.stringify({
+    enabled: true,
+    tagline: { en: 'Legacy tagline', fr: 'Ancien slogan' },
+    mission: { readStoryLabel: { en: 'Read', fr: 'Lire' } },
+    join: {
+      title: { en: 'Join', fr: 'Rejoignez' },
+      subtitle: { en: 'Sub', fr: 'Sous' },
+      donateLabel: { en: 'Donate', fr: 'Donner' },
+      volunteerLabel: { en: 'Volunteer', fr: 'Bénévole' },
+    },
+    newsletter: {
+      title: { en: 'News', fr: 'Infos' },
+      subtitle: { en: 'NSub', fr: 'NSous' },
+      socials: { en: 'Follow', fr: 'Suivez' },
+    },
+  });
+
+  it('a LEGACY published home.json (no mission.photo) is backfilled to the seeded photo on the PUBLIC read', async () => {
+    // It decodes cleanly (the field is optional), so `getPage` returns it as-is and
     // the seeded default NEVER applies — the photo would silently vanish. The
     // read-boundary backfill (`spec.normalize`) fills the absent slot with the
     // seed, so the public view still shows the photo with no migration/redeploy.
-    const legacyHomeJson = JSON.stringify({
-      enabled: true,
-      tagline: { en: 'Legacy tagline', fr: 'Ancien slogan' },
-      // `mission` WITHOUT a `photo` key — exactly what a pre-field publish wrote.
-      mission: { readStoryLabel: { en: 'Read', fr: 'Lire' } },
-      join: {
-        title: { en: 'Join', fr: 'Rejoignez' },
-        subtitle: { en: 'Sub', fr: 'Sous' },
-        donateLabel: { en: 'Donate', fr: 'Donner' },
-        volunteerLabel: { en: 'Volunteer', fr: 'Bénévole' },
-      },
-      newsletter: {
-        title: { en: 'News', fr: 'Infos' },
-        subtitle: { en: 'NSub', fr: 'NSous' },
-        socials: { en: 'Follow', fr: 'Suivez' },
-      },
-    });
     const result = await run(
       Effect.gen(function* () {
         const content = yield* Content.Service;
@@ -862,6 +863,78 @@ describe('per-page /admin editor via DraftEditor (page scope, ADR 0008/0006)', (
     expect(result.taglineEn).toBe('Legacy tagline');
     expect(result.photoKey).toBe('main/people.png');
     expect(result.photoAlt).toEqual({ en: 'Mission', fr: 'Mission' });
+  });
+
+  it('a LEGACY published home.json opens in the /admin editor WITH the seeded photo (draft-read backfill)', async () => {
+    // The --deep review's High: the backfill ran on the PUBLIC read but NOT the
+    // DraftEditor draft read (`objectCodec.fromBucket`), so the editor opened the
+    // slot empty on a legacy doc. With `normalize` now applied there too, the editor
+    // sees the seeded photo — so the admin doesn't unknowingly publish it away.
+    const homeScope = pageScope('home');
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const draft = yield* editor.load(homeScope);
+        const mission = draft.content.mission as {
+          photo?: { key?: string; alt?: unknown };
+        };
+        return { photoKey: String(mission.photo?.key), photoAlt: mission.photo?.alt };
+      }),
+      { [pageObjectKey('home')]: { body: legacyHomeJson } },
+    );
+    expect(result.photoKey).toBe('main/people.png');
+    expect(result.photoAlt).toEqual({ en: 'Mission', fr: 'Mission' });
+  });
+
+  it('a plain save on a LEGACY home.json through the editor PUBLISHES and KEEPS the seeded photo', async () => {
+    // The end-to-end of the --deep High: open a legacy (photo-less) home.json, do a
+    // plain save (posts keyless mission.photo.alt), publish. Before the draft-read
+    // backfill, the base had no key → the prune dropped the alt → publish wrote a
+    // photo-less object (the seed lost). Now the draft base carries the backfilled
+    // key, so the alt edit MERGES onto it and the published object keeps the photo.
+    const homeScope = pageScope('home');
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+        const content = yield* Content.Service;
+        const override = assembleOverrides([
+          ['tagline.en', 'New tagline'],
+          ['tagline.fr', 'Nouveau slogan'],
+          ['mission.readStoryLabel.en', 'Read'],
+          ['mission.readStoryLabel.fr', 'Lire'],
+          ['mission.photo.alt.en', 'Edited alt'],
+          ['mission.photo.alt.fr', 'Alt modifié'],
+          ['join.title.en', 'Join'],
+          ['join.title.fr', 'Rejoignez'],
+          ['join.subtitle.en', 'Sub'],
+          ['join.subtitle.fr', 'Sous'],
+          ['join.donateLabel.en', 'Donate'],
+          ['join.donateLabel.fr', 'Donner'],
+          ['join.volunteerLabel.en', 'Volunteer'],
+          ['join.volunteerLabel.fr', 'Bénévole'],
+          ['newsletter.title.en', 'News'],
+          ['newsletter.title.fr', 'Infos'],
+          ['newsletter.subtitle.en', 'NSub'],
+          ['newsletter.subtitle.fr', 'NSous'],
+          ['newsletter.socials.en', 'Follow'],
+          ['newsletter.socials.fr', 'Suivez'],
+        ]) as Json;
+        yield* TestClock.adjust('1 second');
+        yield* editor.editDocument(homeScope, override);
+        const publishExit = yield* Effect.exit(editor.publish(homeScope));
+        const live = yield* content.getPage('home');
+        return {
+          publishTag: publishExit._tag,
+          photoKey: String(live.mission.photo?.key),
+          photoAltEn: live.mission.photo?.alt.en,
+        };
+      }),
+      { [pageObjectKey('home')]: { body: legacyHomeJson } },
+    );
+    expect(result.publishTag).toBe('Success');
+    // The seeded key survived the plain save; the alt edit landed on it.
+    expect(result.photoKey).toBe('main/people.png');
+    expect(result.photoAltEn).toBe('Edited alt');
   });
 
   it('a plain home save (no upload) PUBLISHES and KEEPS the seeded photo', async () => {

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -365,10 +365,18 @@ const objectCodec = (
   const encodePublishJson = Schema.encodeUnknownEffect(
     Schema.fromJsonString(spec.schema),
   );
+  // The same read-boundary normalization the public `Content` read applies
+  // (`spec.normalize`): a legacy bucket object missing a newly-added optional field
+  // (home's `mission.photo`) must be backfilled BEFORE the draft decode too, or the
+  // `/admin` editor opens the slot empty — and a plain save would then publish an
+  // object that drops the seeded photo (the prune sees no key on the base). For
+  // ABSENCE only, idempotent; a no-op for every scope without a `normalize` hook.
+  const normalize = spec.normalize ?? ((parsed: unknown) => parsed);
   return {
     keys,
     default: spec.default,
-    fromBucket: (json) => parseJson(json).pipe(Effect.flatMap(decodeDraft)),
+    fromBucket: (json) =>
+      parseJson(json).pipe(Effect.map(normalize), Effect.flatMap(decodeDraft)),
     decodeDraft,
     decodePublish,
     encodeObject: (value) =>

--- a/app/lib/content/pages/defaults.ts
+++ b/app/lib/content/pages/defaults.ts
@@ -367,6 +367,17 @@ export const defaultHomePage: HomePage = Schema.decodeUnknownSync(HomePage)({
   },
   mission: {
     readStoryLabel: { en: 'Read our story', fr: 'Lire notre histoire' },
+    // Seed the existing mission art (`public/main/people.png`) under its managed
+    // AssetKey so the day-one render is byte-identical to the pre-migration
+    // hardcoded `<img src="/main/people.png">` — `assetUrl('main/people.png')`
+    // resolves to `/images/main/people.png`, which the `GET /images/*` route
+    // serves from the bundled `public/` tree until an admin upload overrides it.
+    // Unlike Team's omitted photos (uploaded at launch), home ALWAYS shows this
+    // photo today, so seeding it (rather than section-skipping) preserves behavior.
+    photo: {
+      key: 'main/people.png',
+      alt: { en: 'Mission', fr: 'Mission' },
+    },
   },
   join: {
     title: { en: 'Join the Movement', fr: 'Rejoignez le mouvement' },

--- a/app/lib/content/pages/home-photo-backfill.test.ts
+++ b/app/lib/content/pages/home-photo-backfill.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+
+import { backfillHomeMissionPhoto } from './home-photo-backfill';
+import { defaultHomePage } from './defaults';
+
+describe('backfillHomeMissionPhoto', () => {
+  const seededPhoto = defaultHomePage.mission.photo;
+
+  test('fills an absent mission.photo with the seeded default photo', () => {
+    const legacy = {
+      enabled: true,
+      tagline: { en: 'T', fr: 'T' },
+      mission: { readStoryLabel: { en: 'R', fr: 'L' } }, // no photo key
+      join: {},
+      newsletter: {},
+    };
+    const out = backfillHomeMissionPhoto(legacy) as {
+      mission: { readStoryLabel: unknown; photo: unknown };
+    };
+    expect(out.mission.photo).toEqual(seededPhoto);
+    // The sibling is preserved untouched.
+    expect(out.mission.readStoryLabel).toEqual({ en: 'R', fr: 'L' });
+  });
+
+  test('leaves a PRESENT mission.photo untouched (idempotent — for absence only)', () => {
+    const uploaded = {
+      mission: {
+        readStoryLabel: { en: 'R', fr: 'L' },
+        photo: { key: 'images/uploads/x.webp', alt: { en: 'A', fr: 'B' } },
+      },
+    };
+    const out = backfillHomeMissionPhoto(uploaded);
+    // Same reference semantics: a present photo means no rewrite.
+    expect(out).toBe(uploaded);
+  });
+
+  test('running twice equals running once (idempotent)', () => {
+    const legacy = { mission: { readStoryLabel: { en: 'R', fr: 'L' } } };
+    const once = backfillHomeMissionPhoto(legacy);
+    const twice = backfillHomeMissionPhoto(once);
+    expect(twice).toEqual(once);
+  });
+
+  test('leaves a non-object, or a non-object mission, for the decoder to reject', () => {
+    expect(backfillHomeMissionPhoto(null)).toBe(null);
+    expect(backfillHomeMissionPhoto('nope')).toBe('nope');
+    const badMission = { mission: 'not-an-object' };
+    expect(backfillHomeMissionPhoto(badMission)).toBe(badMission);
+  });
+});

--- a/app/lib/content/pages/home-photo-backfill.ts
+++ b/app/lib/content/pages/home-photo-backfill.ts
@@ -1,0 +1,52 @@
+import type { Json } from '../admin-form';
+import { defaultHomePage } from './defaults';
+
+/**
+ * Read-path backfill for the home page's `mission.photo` slot (Feature A
+ * remediation) — the per-page analogue of `backfillListItemIds` (registration-
+ * launch Branch 2.1).
+ *
+ * The hazard: `mission.photo` is a NEW field on `HomePage`. Every `content/pages/
+ * home.json` published BEFORE it existed carries a `mission` object WITHOUT a
+ * `photo` key. Such an object decodes cleanly (the field is `optionalKey`), so the
+ * `getPage` read path returns it as-is and the bundled-default seed (which carries
+ * the photo) NEVER applies — the seed only fires when the object is absent or
+ * unreadable. The route then section-skips, and the mission photo silently
+ * VANISHES on the next deploy, even though the default seeds it. (`Content`'s read
+ * boundary at `content.server.ts` decodes the stored object and falls back to
+ * `spec.default` only on FAILURE, not on a successfully-decoded legacy object.)
+ *
+ * The fix is the same one-shot, idempotent normalization `backfillListItemIds`
+ * applies for absent ids / `hotels`: before decode, if the parsed home JSON has a
+ * `mission` object with NO `photo` key, fill it with the seeded default photo. It
+ * is `make-operations-idempotent`:
+ *   - It fires ONLY on an ABSENT `photo` key — a present `photo` (a real upload, or
+ *     the seeded default once persisted) is left untouched, so re-running on an
+ *     already-migrated object is a no-op and the first `/admin` publish persists
+ *     the photo (from then on this changes nothing).
+ *   - It is for ABSENCE, not repair: a present-but-malformed `photo` is left for the
+ *     decoder to reject, exactly like `backfillListItemIds` leaves a bad id.
+ * `boundary-discipline`: it runs over already-parsed `unknown` JSON, never mutates
+ * its input, and hands a fresh value to the sole decode gate. A non-object or a
+ * `mission` that isn't an object is returned verbatim (the decoder rejects it).
+ *
+ * Why home and not a blanket page hook: home is the ONLY page that (a) gained a new
+ * field after it could already be published AND (b) needs the field's default to
+ * render unchanged (the photo always showed pre-migration). The other pages' new
+ * fields are either `enabled` (its own decoding default) or list items (covered by
+ * the site backfill). Wired as the home spec's `normalize` so it is one registry
+ * entry, not an `if (key === 'home')` in the generic cache (`derive-dont-sync`).
+ */
+const isObject = (value: unknown): value is { readonly [key: string]: Json } =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const backfillHomeMissionPhoto = (parsed: unknown): unknown => {
+  if (!isObject(parsed)) return parsed;
+  const mission = parsed['mission'];
+  if (!isObject(mission)) return parsed;
+  if ('photo' in mission) return parsed; // present (upload or persisted seed) — leave it
+  return {
+    ...parsed,
+    mission: { ...mission, photo: defaultHomePage.mission.photo as Json },
+  };
+};

--- a/app/lib/content/pages/project.ts
+++ b/app/lib/content/pages/project.ts
@@ -131,7 +131,12 @@ export interface ArchiveView {
 export interface HomeView {
   readonly enabled: boolean;
   readonly tagline: string;
-  readonly mission: { readonly readStoryLabel: string };
+  readonly mission: {
+    readonly readStoryLabel: string;
+    // The mission photo projected to a renderable `{ src, alt }`, or `undefined`
+    // when the slot is absent (section-skip) — exactly like Team's `groupPhoto`.
+    readonly photo?: { readonly src: string; readonly alt: string };
+  };
   readonly join: {
     readonly title: string;
     readonly subtitle: string;
@@ -233,7 +238,14 @@ export const toArchiveView = (
 export const toHomeView = (page: HomePage, locale: Locale): HomeView => ({
   enabled: page.enabled,
   tagline: page.tagline[locale],
-  mission: { readStoryLabel: page.mission.readStoryLabel[locale] },
+  mission: {
+    readStoryLabel: page.mission.readStoryLabel[locale],
+    // Section-skip when absent; `assetUrl` is the shared leaf-module URL rule
+    // (`derive-dont-sync`), identical to `toTeamView`'s slot projection.
+    photo: page.mission.photo
+      ? { src: assetUrl(page.mission.photo.key), alt: page.mission.photo.alt[locale] }
+      : undefined,
+  },
   join: {
     title: page.join.title[locale],
     subtitle: page.join.subtitle[locale],

--- a/app/lib/content/pages/registry.ts
+++ b/app/lib/content/pages/registry.ts
@@ -30,6 +30,7 @@ import {
   TeamPage,
   VolunteerPage,
 } from './schema';
+import { backfillHomeMissionPhoto } from './home-photo-backfill';
 import { type ListItemId } from '../schema';
 
 /**
@@ -150,6 +151,17 @@ export interface ObjectSpec<A, I> {
   readonly schema: Schema.Codec<A, I>;
   readonly draftSchema: Schema.Codec<unknown, unknown>;
   readonly default: A;
+  /**
+   * An optional one-shot, idempotent read-boundary normalization run over the
+   * parsed (untrusted) JSON BEFORE decode — the per-object analogue of the site
+   * `backfillListItemIds`. Fills a structural gap a legacy published object leaves
+   * after a new field was added (e.g. home's `mission.photo`); absent for objects
+   * with no such gap. For ABSENCE only (a malformed value is left for the decoder
+   * to reject), so it never masks a real error (`make-operations-idempotent`).
+   * Typed over `unknown` (the raw parsed JSON the read path hands it), narrowing
+   * defensively before it touches shape — it never trusts the input.
+   */
+  readonly normalize?: (parsed: unknown) => unknown;
 }
 
 /**
@@ -162,7 +174,8 @@ const draftPageSpec = <A, I>(
   schema: Schema.Codec<A, I>,
   draftSchema: Schema.Codec<unknown, unknown>,
   defaultValue: A,
-): ObjectSpec<A, I> => ({ schema, draftSchema, default: defaultValue });
+  normalize?: (parsed: unknown) => unknown,
+): ObjectSpec<A, I> => ({ schema, draftSchema, default: defaultValue, normalize });
 
 /**
  * Build a spec with NO laxer draft variant: the draft boundary IS the strict
@@ -193,8 +206,15 @@ export const PAGE_SPECS = {
   archive: draftPageSpec(ArchivePage, DraftArchivePage, defaultArchivePage),
   // Draft ≠ strict: the `mission.photo` slot's `alt` may be unfilled in the draft
   // (upload first, fill alt second), so home wires the laxer `DraftHomePage`
-  // (ADR 0006) — exactly as team does for its image slots.
-  home: draftPageSpec(HomePage, DraftHomePage, defaultHomePage),
+  // (ADR 0006) — exactly as team does for its image slots. `normalize` backfills
+  // the seeded photo onto a legacy `home.json` published before `mission.photo`
+  // existed, so the photo never vanishes on deploy (idempotent; for absence only).
+  home: draftPageSpec(
+    HomePage,
+    DraftHomePage,
+    defaultHomePage,
+    backfillHomeMissionPhoto,
+  ),
   // Draft ≠ strict: a present image's `alt` may be unfilled in the draft (upload
   // first, fill alt second), so team wires the laxer `DraftTeamPage` (ADR 0006).
   team: draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage),

--- a/app/lib/content/pages/registry.ts
+++ b/app/lib/content/pages/registry.ts
@@ -22,6 +22,7 @@ import {
   DraftArchivePage,
   DraftFaqPage,
   DraftGivePage,
+  DraftHomePage,
   DraftTeamPage,
   FaqPage,
   GivePage,
@@ -190,7 +191,10 @@ export const PAGE_SPECS = {
   contact: pageSpec(ContactPage, defaultContactPage),
   volunteer: pageSpec(VolunteerPage, defaultVolunteerPage),
   archive: draftPageSpec(ArchivePage, DraftArchivePage, defaultArchivePage),
-  home: pageSpec(HomePage, defaultHomePage),
+  // Draft ≠ strict: the `mission.photo` slot's `alt` may be unfilled in the draft
+  // (upload first, fill alt second), so home wires the laxer `DraftHomePage`
+  // (ADR 0006) — exactly as team does for its image slots.
+  home: draftPageSpec(HomePage, DraftHomePage, defaultHomePage),
   // Draft ≠ strict: a present image's `alt` may be unfilled in the draft (upload
   // first, fill alt second), so team wires the laxer `DraftTeamPage` (ADR 0006).
   team: draftPageSpec(TeamPage, DraftTeamPage, defaultTeamPage),

--- a/app/lib/content/pages/schema.ts
+++ b/app/lib/content/pages/schema.ts
@@ -268,6 +268,13 @@ export const HomePage = Schema.Struct({
   tagline: Text,
   mission: Schema.Struct({
     readStoryLabel: Text,
+    // The mission section's photo — an optional named image slot mirroring the
+    // Team page's `groupPhoto` / `portrait` (Feature A): a present photo carries a
+    // strict `{ key, alt }` (a valid `AssetKey` + both-locales alt), and an absent
+    // slot SECTION-SKIPS in the route (ADR 0008). Kept INSIDE `mission` so the photo
+    // travels with the read-story CTA it sits beside, not as a sibling top-level
+    // field (`make-impossible-states-unrepresentable`).
+    photo: Schema.optionalKey(ImageRef),
   }),
   join: Schema.Struct({
     title: Text,
@@ -431,4 +438,36 @@ export const DraftTeamPage = Schema.Struct({
   portrait: Schema.optionalKey(DraftImageRef),
 });
 export type DraftTeamPage = typeof DraftTeamPage.Type;
+
+/**
+ * The DRAFT variant of `HomePage` (Feature A pattern, extended to a NESTED image
+ * slot). Home has no id-only add-item flow, so every copy field stays strict — the
+ * lone reason home needs a draft variant at all is its `mission.photo` slot: an
+ * uploaded `key` must be able to land before its alt text (upload-first /
+ * fill-alt-second, ADR 0006), which a strict `ImageRef` inside `mission` would
+ * reject. So `mission.photo` relaxes to the lax `DraftImageRef`; everything else
+ * (`tagline`, `mission.readStoryLabel`, `join.*`, `newsletter.*`) is the strict
+ * `Text`, identical to `HomePage`. Unlike Team's two TOP-LEVEL image slots, home's
+ * single slot is nested one level under `mission`.
+ */
+export const DraftHomePage = Schema.Struct({
+  enabled: EnabledFlag,
+  tagline: Text,
+  mission: Schema.Struct({
+    readStoryLabel: Text,
+    photo: Schema.optionalKey(DraftImageRef),
+  }),
+  join: Schema.Struct({
+    title: Text,
+    subtitle: Text,
+    donateLabel: Text,
+    volunteerLabel: Text,
+  }),
+  newsletter: Schema.Struct({
+    title: Text,
+    subtitle: Text,
+    socials: Text,
+  }),
+});
+export type DraftHomePage = typeof DraftHomePage.Type;
 

--- a/app/lib/localization/translations.ts
+++ b/app/lib/localization/translations.ts
@@ -170,6 +170,10 @@ const en = {
   'registration.form.meals.disclaimer':
     'Please Note, we may not be able to accommodate all allergies/sensitivities, but will do our best to accommodate you',
   'registration.form.meals.label': 'Meals',
+  'registration.form.outreach.title': 'Outreach',
+  'registration.form.extra.title': 'Extra Information',
+  'registration.form.volunteer.title': 'Volunteer',
+  'registration.form.add-registrant': 'Add Registrant',
   'registration.form.meals.description':
     'Please select your meal preference. Meals are only available for attendees. Exhibitors must make their own arrangements.',
   'registration.form.meals.yes': 'Weekend Meals (5 Meals) ($60.00)',
@@ -441,6 +445,11 @@ const fr: Record<TranslationKey, string> = {
   'registration.form.meals.disclaimer':
     'Veuillez noter que nous ne pourrons pas accommoder toutes les allergies/sensibilités, mais ferons de notre mieux pour vous accommoder',
   'registration.form.meals.label': 'Repas',
+  // TODO(i18n): native-speaker review of these four FR strings before publish.
+  'registration.form.outreach.title': 'Rayonnement',
+  'registration.form.extra.title': 'Renseignements supplémentaires',
+  'registration.form.volunteer.title': 'Bénévolat',
+  'registration.form.add-registrant': 'Ajouter un participant',
   'registration.form.meals.description':
     'Veuillez sélectionner votre préférence de repas. Les repas ne sont disponibles que pour les participants. Les exposants doivent faire leurs propres arrangements.',
   'registration.form.meals.yes': 'Repas du week-end (5 repas) (60,00 $)',

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -115,11 +115,13 @@ export default function Index() {
         <h3 className="text-5xl">{page.tagline}</h3>
       </section>
       <section className="flex flex-col gap-6 pt-16 text-5xl md:flex-row-reverse md:justify-between">
-        <img
-          src="/main/people.png"
-          alt="Mission"
-          className="aspect-auto max-md:w-full md:flex-1"
-        />
+        {page.mission.photo ? (
+          <img
+            src={page.mission.photo.src}
+            alt={page.mission.photo.alt}
+            className="aspect-auto max-md:w-full md:flex-1"
+          />
+        ) : null}
         <div className="flex flex-col gap-6 p-3 max-md:absolute max-md:top-0 md:flex-1">
           <h3 className="text-5xl max-md:hidden">{page.tagline}</h3>
           <div>

--- a/app/routes/($lang)+/registration-form.tsx
+++ b/app/routes/($lang)+/registration-form.tsx
@@ -420,7 +420,7 @@ export function RegistrationForm({
                         </fieldset>
                       )}
 
-                      <h2>Meals</h2>
+                      <h2>{translate('registration.form.meals.title')}</h2>
 
                       <RadioGroup name={fields.meals.name}>
                         <Label>
@@ -454,7 +454,7 @@ export function RegistrationForm({
                         <FieldErrors />
                       </TextField>
 
-                      <h2>Outreach</h2>
+                      <h2>{translate('registration.form.outreach.title')}</h2>
                       <CheckboxGroup
                         name={fields.outreach.name}
                         orientation="vertical"
@@ -485,7 +485,7 @@ export function RegistrationForm({
                         <FieldErrors />
                       </CheckboxGroup>
 
-                      <h2>Extra Information</h2>
+                      <h2>{translate('registration.form.extra.title')}</h2>
 
                       <TextField name={extras.howDidYouHear.name}>
                         <Label>
@@ -622,7 +622,7 @@ export function RegistrationForm({
                         <FieldErrors />
                       </CheckboxGroup>
 
-                      <h2>Volunteer</h2>
+                      <h2>{translate('registration.form.volunteer.title')}</h2>
 
                       <Checkbox name={volunteer.songLeader.name}>
                         {translate('registration.form.song-leader.label')}
@@ -740,11 +740,13 @@ export function RegistrationForm({
                 intent.insert({ name: fields.registrants.name });
               }}
             >
-              Add Registrant
+              {translate('registration.form.add-registrant')}
             </Button>
           </div>
           <div>
-            <Button type="submit">Submit</Button>
+            <Button type="submit">
+              {translate('registration.form.submit')}
+            </Button>
           </div>
         </Form>
       </FormProvider>

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -558,6 +558,27 @@ function PageEditor({
             name="mission.readStoryLabel"
             value={text(mission['readStoryLabel'] as DraftText)}
           />
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-neutral-800">
+              Mission · photo
+            </legend>
+            <ImageUpload
+              keyPath="mission.photo.key"
+              currentKey={String(
+                ((mission['photo'] ?? {}) as Record<string, unknown>)['key'] ??
+                  '',
+              )}
+            />
+            <Bilingual
+              label="Mission photo alt"
+              name="mission.photo.alt"
+              value={text(
+                ((mission['photo'] ?? {}) as Record<string, unknown>)[
+                  'alt'
+                ] as DraftText,
+              )}
+            />
+          </fieldset>
           <Bilingual label="Join · title" name="join.title" value={text(join['title'] as DraftText)} />
           <Bilingual
             label="Join · subtitle"

--- a/docs/cms-asset-hardcode-audit.md
+++ b/docs/cms-asset-hardcode-audit.md
@@ -1,15 +1,28 @@
-# CMS Sourcing Audit + Remediation Plan — GYC Site Assets & Copy
+# CMS Sourcing Audit + Remediation — GYC Site Assets & Copy
 
-_Audited 2026-06-19 against `main` @ c17478c. Every file:line below was re-verified against the working tree._
+> **STATUS: REMEDIATED by branch `cms/hardcode-remediation` (this PR).** Both
+> confirmed violations below are now fixed: the home mission photo is a CMS image
+> slot (`HomePage.mission.photo`, projected via `assetUrl`, section-skip render,
+> `/admin` upload, seeded `main/people.png` default so there's no day-one visual
+> change), and the six registration-form literals now route through `translate()`.
+> Two read-boundary backfills were added so neither the new field nor the new
+> translation keys vanish on an already-published `home.json` / `site.json`
+> (mirroring `backfillListItemIds`). The sections below are the ORIGINAL audit
+> (state of `main` @ c17478c) kept as the record of what was found and why — read
+> "should move to CMS" as "moved to CMS by this PR."
+
+_Audited 2026-06-19 against `main` @ c17478c; remediated on `cms/hardcode-remediation`._
 
 ## 1. Executive verdict
 
-**No — assets and copy are NOT yet fully CMS-sourced. The site is ~95% on the runtime-read CMS path, but two route files carry confirmed hardcodes:** the home page's "Mission" photo (`/main/people.png` + `alt="Mission"`) bypasses the CMS image path entirely, and the shared registration-form module renders six English JSX string literals that bypass the localization layer. Everything else is fully CMS-driven (or legitimately static chrome).
+_(original audit verdict — now remediated)_
 
-| File | Status |
+**At audit time: assets and copy were NOT yet fully CMS-sourced.** The site was ~95% on the runtime-read CMS path, but two route files carried confirmed hardcodes: the home page's "Mission" photo (`/main/people.png` + `alt="Mission"`) bypassed the CMS image path entirely, and the shared registration-form module rendered six English JSX string literals that bypassed the localization layer. Everything else was fully CMS-driven (or legitimately static chrome). **Both are fixed in this PR** — the two files below are now fully CMS-sourced.
+
+| File | Status (audit → now) |
 |------|--------|
-| `app/routes/($lang)+/_index.tsx` | **partially-cms** (1 asset + 1 copy violation) |
-| `app/routes/($lang)+/registration-form.tsx` | **partially-cms** (6 copy violations) |
+| `app/routes/($lang)+/_index.tsx` | partially-cms → **fully-cms** (mission photo now `page.mission.photo`) |
+| `app/routes/($lang)+/registration-form.tsx` | partially-cms → **fully-cms** (6 literals now `translate()`) |
 | `app/routes/($lang)+/_layout.tsx` | fully-cms |
 | `app/routes/($lang)+/about.tsx` | fully-cms |
 | `app/routes/($lang)+/contact.tsx` | fully-cms |

--- a/docs/cms-asset-hardcode-audit.md
+++ b/docs/cms-asset-hardcode-audit.md
@@ -1,0 +1,136 @@
+# CMS Sourcing Audit + Remediation Plan — GYC Site Assets & Copy
+
+_Audited 2026-06-19 against `main` @ c17478c. Every file:line below was re-verified against the working tree._
+
+## 1. Executive verdict
+
+**No — assets and copy are NOT yet fully CMS-sourced. The site is ~95% on the runtime-read CMS path, but two route files carry confirmed hardcodes:** the home page's "Mission" photo (`/main/people.png` + `alt="Mission"`) bypasses the CMS image path entirely, and the shared registration-form module renders six English JSX string literals that bypass the localization layer. Everything else is fully CMS-driven (or legitimately static chrome).
+
+| File | Status |
+|------|--------|
+| `app/routes/($lang)+/_index.tsx` | **partially-cms** (1 asset + 1 copy violation) |
+| `app/routes/($lang)+/registration-form.tsx` | **partially-cms** (6 copy violations) |
+| `app/routes/($lang)+/_layout.tsx` | fully-cms |
+| `app/routes/($lang)+/about.tsx` | fully-cms |
+| `app/routes/($lang)+/contact.tsx` | fully-cms |
+| `app/routes/($lang)+/faq.tsx` | fully-cms |
+| `app/routes/($lang)+/give.tsx` | fully-cms |
+| `app/routes/($lang)+/volunteer.tsx` | fully-cms |
+| `app/routes/($lang)+/team/_index.tsx` | fully-cms (gold standard) |
+| `app/routes/($lang)+/conference-detail.tsx` | fully-cms |
+| `app/routes/($lang)+/2024/_index.tsx` | fully-cms |
+| `app/routes/($lang)+/2025/_index.tsx` | fully-cms |
+| `app/routes/($lang)+/2026/_index.tsx` | fully-cms |
+| `app/routes/($lang)+/archive+/_index.tsx` | fully-cms |
+| `app/routes/($lang)+/archive+/2023.tsx` | static-snapshot (n/a) |
+
+## 2. Confirmed hardcodes that should move to CMS
+
+Ordered by severity. All line references re-verified.
+
+### Home page — `app/routes/($lang)+/_index.tsx`
+
+**[HIGH] Mission photo `src` is a build-time literal — `_index.tsx:118-122`**
+```jsx
+<img
+  src="/main/people.png"
+  alt="Mission"
+  className="aspect-auto max-md:w-full md:flex-1"
+/>
+```
+- **What:** A content-bearing photograph typed directly into JSX `src`. It never crosses the `AssetKey` brand, never hits `assetUrl(key) → /images/* → bucket-first-then-public` serve, and can never be overridden via `/admin` upload. Confirmed sole reference: `grep people.png` across `app/` and `public/` returns only `_index.tsx:119` (file lives only at `public/main/people.png`).
+- **Root cause (verified):** `HomePage` schema (`schema.ts:266-283`) carries only `enabled` + Text fields (`tagline`, `mission.readStoryLabel`, `join.*`, `newsletter.*`) — **no `ImageRef`**. `toHomeView` (`project.ts:233-248`) projects only those text fields — **no `{src,alt}` slot**. `HomeView` interface (`project.ts:131-146`) has no image field. So `page` physically cannot carry this image.
+- **Fix:** Add an optional image slot to `HomePage`, mirroring the Team gold standard exactly:
+  - `schema.ts`: add `mission: Schema.Struct({ readStoryLabel: Text, photo: Schema.optionalKey(ImageRef) })` (extend the existing `mission` struct rather than adding a sibling — keeps the photo semantically grouped with its CTA).
+  - `project.ts` `HomeView`: add `mission: { readStoryLabel: string; photo?: { src: string; alt: string } }`.
+  - `project.ts` `toHomeView`: `photo: page.mission.photo ? { src: assetUrl(page.mission.photo.key), alt: page.mission.photo.alt[locale] } : undefined` (copy the `toTeamView` `groupPhoto` projection at `project.ts:257-258`).
+  - `_index.tsx:118-122`: render `{page.mission.photo && <img src={page.mission.photo.src} alt={page.mission.photo.alt} className="…" />}` — section-skip on absent slot (gold-standard guard, `team/_index.tsx`).
+
+**[MEDIUM] Mission photo `alt="Mission"` is an unlocalized literal — `_index.tsx:120`**
+- **What:** The `alt` half of the same slot — fixed English, so `/fr` renders English alt text.
+- **Fix:** Resolved by the same schema change above (`ImageRef.alt` is bilingual `Text`, projected per-locale via `alt[locale]`). This is one slot, one fix.
+
+### Registration form — `app/routes/($lang)+/registration-form.tsx`
+
+This is a shared presentational module (not a route). It has **zero image references** — these are all localization (`translate()`) bypasses, not CMS-projection-path violations. `useTranslate()` is in scope (`const translate = useTranslate()`, ~line 207) and drives ~50 sibling labels; these six are the lone literals. Translations are sourced from `content/site.json` via `content.getTranslations` (`_layout.tsx:35`), so they ARE on the CMS read path.
+
+**[MEDIUM] Four section headings hardcoded as English JSX literals**
+
+| Line | Literal | Existing key? | Fix |
+|------|---------|---------------|-----|
+| `registration-form.tsx:423` | `<h2>Meals</h2>` | **Yes** — `registration.form.meals.title` ('Meals'/'Repas', `translations.ts:169`/`:440`) but **unused** | `{translate('registration.form.meals.title')}` |
+| `registration-form.tsx:457` | `<h2>Outreach</h2>` | No | Add `registration.form.outreach.title` (en `'Outreach'` / fr `'Rayonnement'`), then `translate(...)` |
+| `registration-form.tsx:488` | `<h2>Extra Information</h2>` | No | Add `registration.form.extra.title` (en/fr), then `translate(...)` |
+| `registration-form.tsx:625` | `<h2>Volunteer</h2>` | No | Add `registration.form.volunteer.title` (en/fr), then `translate(...)` |
+
+**[MEDIUM] Two button labels hardcoded as English JSX literals**
+
+| Line | Literal | Existing key? | Fix |
+|------|---------|---------------|-----|
+| `registration-form.tsx:743` | `Add Registrant` (inside `<Button>`) | No | Add `registration.form.add-registrant` (en/fr), then `translate(...)` |
+| `registration-form.tsx:747` | `Submit` (inside `<Button type="submit">`) | **Yes** — `registration.form.submit` ('Submit'/'Soumettre', `translations.ts:258`/`:538`) but **unused** | `{translate('registration.form.submit')}` |
+
+> French-locale regression is real and reproducible: `/fr` renders all six in English today.
+
+## 3. Legitimately static (leave alone)
+
+So a future reviewer doesn't re-flag these:
+
+- **Decorative texture `/topography.svg`** — `_index.tsx:138,342`. `alt=""`, opacity-10 background texture. Not authored content; served from `public/`. Correctly NOT in any Page schema.
+- **Brand logo `/logo/gycc-logo-small-red.png`** — `_layout.tsx:132,170` (TopNav + PopupNav). Site chrome, served from `public/`, contract-allowed.
+- **Favicon, footer social URLs, `Français`/`English` toggle labels** — `_layout.tsx`. UI chrome with no Page-schema home; nav labels/buttons legitimately live in the Translations doc.
+- **External destination URLs** — BibleGateway search + Facebook hotels group in `conference-detail.tsx:149,243`. External link targets, not image AssetKeys or page-body copy.
+- **All `meta()` SEO title/description literals** — every route. React Router head chrome, explicitly out of scope; already locale-switch where relevant.
+- **Conference year slugs (`2024`/`2025`/`2026`)** — passed to `getConference`. Conference identity, not content. These read `content/site.json` via `getConference`, NOT a `PageId` object, so `getEnabledPageOr404` correctly does not apply.
+- **`archive+/2023.tsx`** — frozen hand-built archive snapshot (`schema.ts:242-247`); empty div, no content, no Content.Service read. Not a CMS-known page.
+- **Form action mailer/notification copy** — server-side email bodies in `contact.tsx`/`volunteer.tsx` actions. Not rendered page content.
+
+## 4. Remediation plan
+
+Two independent tracks. Follow the **Feature A (Team route migration, commit `ca3320f`)** pattern as prior art for the image track. Each batch compiles + gates green (`tsc --noEmit` + lint + tests) before commit.
+
+### Batch 1 — Home mission photo → CMS image slot (the HIGH violation)
+
+Mirrors Feature A end-to-end. Because adding an image slot requires the upload-first / fill-alt-second draft flow, `home` must also migrate from the strict `pageSpec` to `draftPageSpec` (it currently has no draft variant — `registry.ts:193`, `schema.ts:340`).
+
+1. **Schema** (`app/lib/content/pages/schema.ts`):
+   - Extend `mission` struct on `HomePage` (`:269-271`) with `photo: Schema.optionalKey(ImageRef)`.
+   - Add `DraftHomePage` (mirror `DraftTeamPage`, `:425-433`): strict text fields + `mission.photo` relaxed to the existing `DraftImageRef` (`:414-417`).
+2. **Default seed** (`app/lib/content/pages/defaults.ts`): leave `defaultHomePage.mission` (`:368-370`) photo-less (`optionalKey` ⇒ section-skip), exactly as `defaultTeamPage` omits `groupPhoto`/`portrait` (`:403`). The `public/main/people.png` art stays as a transparent public-fallback if/when an admin uploads to the matching key — but no seed AssetKey is required.
+3. **Registry** (`app/lib/content/pages/registry.ts:193`): `home: draftPageSpec(HomePage, DraftHomePage, defaultHomePage)`. Import `DraftHomePage`.
+4. **Projection** (`app/lib/content/pages/project.ts`): extend `HomeView.mission` (`:134`) with optional `photo?: { src; alt }`; project it in `toHomeView` (`:236`) via `assetUrl(page.mission.photo.key)` (copy `toTeamView:257-258`).
+5. **Route** (`app/routes/($lang)+/_index.tsx:118-122`): replace the literal `<img>` with the section-skip guard `{page.mission.photo && <img src={page.mission.photo.src} alt={page.mission.photo.alt} … />}`.
+6. **Admin editor** (`app/routes/admin/pages.$page.tsx`): in the `case 'home':` branch (`:549`), add the `mission.photo` `<ImageUpload keyPath="mission.photo.key" … />` + `<Bilingual name="mission.photo.alt" … />` fieldset, copying the Team slot markup (`:620-647`).
+7. **Keyless-override prune** (`app/lib/content/admin-form.ts:316-334`): the slot allowlist is hardcoded to `groupPhoto`/`portrait` (`:324`). Add `mission.photo` handling — the home photo is nested, so generalize the keyless-prune check to also cover the `mission.photo` path (a plain save posts `mission.photo.alt` with no key → must be pruned so the slot stays absent, identical to the Team rationale at `:296-314`). **This is the one place the Team pattern doesn't transfer 1:1** (Team slots are top-level; home's is nested under `mission`).
+8. **Tests**: extend `cms-e2e.test.ts` (mirror the `groupPhoto` upload tests at `:620-762`) for `mission.photo.key` upload + keyless-prune + section-skip.
+
+Gate. Commit: `feat(cms): model home mission photo as a CMS image slot (Feature A pattern)`.
+
+### Batch 2 — Registration form section headings → Translations
+
+1. **Add keys** (`app/lib/localization/translations.ts`, both EN block + FR block ~`:263`): `registration.form.outreach.title`, `registration.form.extra.title`, `registration.form.volunteer.title` (en + fr each). `meals.title` already exists.
+2. **Route** (`registration-form.tsx`): replace the four `<h2>` literals (`:423,:457,:488,:625`) with `{translate('registration.form.<section>.title')}`.
+
+Gate. Commit: `fix(i18n): localize registration-form section headings`.
+
+### Batch 3 — Registration form button labels → Translations
+
+1. **Add key** (`translations.ts`): `registration.form.add-registrant` (en + fr). `submit` already exists.
+2. **Route** (`registration-form.tsx`): `:743` → `{translate('registration.form.add-registrant')}`; `:747` → `{translate('registration.form.submit')}`.
+
+Gate. Commit: `fix(i18n): localize registration-form Add Registrant / Submit buttons`.
+
+> Batches 2 and 3 are independent of Batch 1 and of each other; they can ship in any order or be combined into one i18n commit if preferred. Batch 1 is the only structurally non-trivial one (schema + draft + registry + projection + admin + prune + tests).
+
+## 5. Open questions / ambiguities
+
+1. **Home photo: keep `people.png` as-is, or re-seed under a managed key?** Batch 1 leaves the slot empty-by-default and relies on the `public/main/people.png` fallback only if an admin uploads to the matching key. Alternative: seed `defaultHomePage.mission.photo` with a `main/people.png` AssetKey so the current art renders through `assetUrl` immediately (note: the file is at `public/main/people.png`, and AssetKeys map 1:1 onto the `public/` tree minus the leading `/`, so the key would be `main/people.png`). **Decision needed:** empty-default + section-skip (matches Team's omitted `groupPhoto`) vs. seed-the-existing-art (no visual change on day one). The Team precedent favors empty-default, but home currently always shows the photo, so a seed avoids a visual regression. Recommend **seed the existing art** to preserve current behavior.
+
+2. **French copy for the three new heading/button keys** — `outreach.title`, `extra.title`, `volunteer.title`, `add-registrant`. I can draft (`Rayonnement` / `Renseignements supplémentaires` / `Bénévolat` / `Ajouter un participant`), but these are user-facing French strings and may want a native-speaker review before publish. `meals.title`→`Repas` and `submit`→`Soumettre` already exist and are settled.
+
+---
+
+**Let me take more off your plate:**
+- **Next actions I can do right now:** Implement Batch 1 end-to-end (schema + draft + registry + projection + route + admin + prune + e2e tests) following the verified Feature A pattern, gating green per step. / Ship Batches 2-3 as one i18n commit with my drafted French strings flagged `// TODO: native review`.
+- **Automations I can set up:** A lint rule (oxlint-plugin or a grep-based CI check) that fails on raw JSX string literals inside `<h1>`/`<h2>`/`<Button>` in route files, and on literal `src="/…png|jpg"` outside the allowed-static list (`/logo`, `/topography.svg`, `/favicon`) — so this audit's two violation classes can't silently reappear.
+- **Delegate to your team:** Draft for a French-fluent reviewer — _"Need FR copy review for 4 registration-form keys before publish: outreach.title, extra.title, volunteer.title, add-registrant. My proposals: Rayonnement / Renseignements supplémentaires / Bénévolat / Ajouter un participant."_


### PR DESCRIPTION
## What & why

An **ultracode CMS audit** (`docs/cms-asset-hardcode-audit.md`) swept all 15 public routes asking: are assets **and** user-facing copy sourced from the runtime-read CMS, or hardcoded in route components? Verdict: **~95% CMS-driven**, with two confirmed, adversarially-verified violations — both fixed here:

1. **Home mission photo** — `<img src="/main/people.png" alt="Mission">` bypassed the CMS image path entirely (`HomePage` had no `ImageRef`, so the page object couldn't carry it; `alt` was unlocalized → English on `/fr`).
2. **Six registration-form literals** — `<h2>Meals/Outreach/Extra Information/Volunteer</h2>` + `Add Registrant` / `Submit` bypassed the localization layer (a real French regression — they rendered in English on `/fr`).

Both now flow through the CMS, following the **Team-route migration (#29)** as the gold-standard image pattern.

## Changes

**Home mission photo → CMS image slot** (Feature A pattern, nested under `mission`):
- `HomePage.mission.photo = optionalKey(ImageRef)` + `DraftHomePage` (lax `DraftImageRef`: upload-first / fill-alt-second, ADR 0006).
- Projection via `assetUrl` → `{ src, alt }` or section-skip (ADR 0008); route renders `page.mission.photo`.
- **Seeded** default `main/people.png` so the day-one render is byte-identical (`assetUrl` → `/images/main/people.png`, served from `public/` until an `/admin` upload overrides).
- `/admin` home editor gains the `mission.photo` ImageUpload + alt fieldset.
- `pruneKeylessImageOverrides` generalized to dotted slot paths (handles the **nested** slot — the one place the Team pattern didn't transfer 1:1).

**Registration-form copy → localization:**
- 6 literals → `translate(...)`; 4 new keys added to **both** EN & FR (`meals.title`/`submit` already existed). FR strings flagged `// TODO(i18n)` for native review.

**Two read-boundary backfills** (the recurring "new field/key on already-published content" hazard, mirroring `backfillListItemIds`):
- `ObjectSpec.normalize` hook backfills an absent `home.mission.photo` with the seed — applied on **both** the public read (`Content.getPage`) **and** the `/admin` draft read (`DraftEditor.fromBucket`), so a legacy `home.json` never loses the photo on read *or* on a plain admin save.
- `getTranslations` merges static `root[locale]` **under** the CMS values, so new static translation keys never blank out on a legacy `site.json`.

## Review process

5 commits, each with **per-commit Codex counsel** + a **`--deep` whole-PR counsel** before this PR. Counsel caught three real issues, all fixed in-branch:
- **P1** (Batch 1): seeded default wouldn't apply to a legacy published `home.json` → home-photo read backfill.
- **High** (Batch 2/3): new translation keys would blank on a legacy `site.json` → static-defaults merge.
- **High** (`--deep`): the photo backfill ran on the public read but not the `/admin` draft read → applied it there too (an admin could otherwise publish the seeded photo away).

## Verification

`bun run typecheck` + `bun run lint` clean; **485 tests pass** (incl. e2e: legacy-object backfill on public + admin paths, plain-save-keeps-photo, nested upload, translation-defaults merge).

## Follow-up

FR copy review before publish: `Rayonnement` / `Renseignements supplémentaires` / `Bénévolat` / `Ajouter un participant`.
