### PR TITLE
feat(order): durable Order workflow — process/cancel/refund/expire on encore SQL storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,16 @@ BUCKET_SECRET_KEY=
 BUCKET_NAME=
 BUCKET_REGION=auto
 
+# Durable Order workflow database (encore SQL MessageStorage). OPTIONAL
+# everywhere — when DATABASE_URL is unset the durable Order entity is disabled
+# and the app falls back to the existing bucket-only registration/webhook path.
+# In production this MUST be a sqlite FILE path on a persistent volume (e.g.
+# /data/order.db on a Railway volume), NEVER ':memory:': the long-lived runner
+# (ServerLive) and the request/webhook senders (AppRuntime) are two separate
+# layer graphs that coordinate ONLY through the shared sqlite file, so an
+# in-memory DB would give them two disjoint databases and break the loop.
+DATABASE_URL=
+
 # /admin CMS editor session. OPTIONAL everywhere — when ADMIN_PASSWORD is unset
 # the admin area is DISABLED (every /admin route 404s), so dev and a
 # prod-without-admin both behave as if the admin does not exist. Set both to

--- a/app/lib/content/pages/registry.ts
+++ b/app/lib/content/pages/registry.ts
@@ -142,6 +142,18 @@ export const submissionKey = (form: FormId, id: ListItemId): string =>
 export const orderKey = (form: FormId, orderId: string): string =>
   `submissions/${form}/orders/${orderId}.json`;
 
+/**
+ * The bucket-key PREFIX every `RegistrationOrder` of a form lives under
+ * (`submissions/<form>/orders/`). The deadline sweep (order-workflow G9) lists
+ * this prefix to enumerate the form's orders without touching the registrant
+ * submissions, which sit one level UP at `submissions/<form>/<id>.json` (NOT
+ * under `orders/`) — so listing this prefix returns orders ONLY, never a
+ * registrant record. Derived from the same closed `FormId` as `orderKey` so the
+ * listing root and the per-order key can never drift apart.
+ */
+export const ordersPrefix = (form: FormId): string =>
+  `submissions/${form}/orders/`;
+
 // ---------------------------------------------------------------------------
 // Object specs (schema + default per id)
 // ---------------------------------------------------------------------------

--- a/app/lib/effect/form-schema.ts
+++ b/app/lib/effect/form-schema.ts
@@ -1,5 +1,5 @@
 import { formatPath } from '@conform-to/dom/future';
-import { Result, Schema, SchemaIssue } from 'effect';
+import { Result, Schema, SchemaIssue, SchemaParser } from 'effect';
 import type { Issue } from 'effect/SchemaIssue';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
@@ -53,7 +53,7 @@ function issuePathToName(
 export const parseSchema = <A, I>(
   schema: Schema.Codec<A, I, never, never>,
   payload: unknown,
-): Result.Result<A, Issue> => Schema.decodeUnknownResult(schema)(payload);
+): Result.Result<A, Issue> => SchemaParser.decodeUnknownResult(schema)(payload);
 
 /**
  * Convert an Effect Schema parse {@link Result} into conform's

--- a/app/lib/effect/form.ts
+++ b/app/lib/effect/form.ts
@@ -135,7 +135,7 @@ const handleFormError = (
  *    errors become form/field error reports; redirects propagate via C1.
  */
 export const routeFormAction =
-  <Eff extends Effect.Yieldable<any, any, any, FormServices>>(
+  <Eff extends Effect.Effect<any, any, FormServices>>(
     body: () => Generator<Eff, FormSuccess, never>,
     options?: {
       /**

--- a/app/lib/effect/route.ts
+++ b/app/lib/effect/route.ts
@@ -6,7 +6,7 @@ import type { AppError, AppServices } from './runtime';
 type RouteServices = AppServices | ReactRouterContext;
 
 export const routeHandler =
-  <Eff extends Effect.Yieldable<any, any, any, RouteServices>, AEff>(
+  <Eff extends Effect.Effect<any, any, RouteServices>, AEff>(
     body: () => Generator<Eff, AEff, never>,
   ) =>
   (args: RouteArgs): Promise<AEff> =>
@@ -16,7 +16,7 @@ export const routeHandler =
     );
 
 export const routeAction =
-  <Eff extends Effect.Yieldable<any, any, any, RouteServices>, AEff>(
+  <Eff extends Effect.Effect<any, any, RouteServices>, AEff>(
     body: () => Generator<Eff, AEff, never>,
   ) =>
   (args: RouteArgs): Promise<AEff> =>

--- a/app/lib/effect/runtime.ts
+++ b/app/lib/effect/runtime.ts
@@ -16,6 +16,7 @@ import { Sendgrid, SendgridDisabled, SendgridError } from '~/lib/sendgrid.server
 import { Mailer, MailError } from '~/lib/mailer.server';
 import { NotFound, Storage, StorageError } from '~/lib/storage.server';
 import { Toast } from '~/lib/toast.server';
+import { Order } from '~/lib/order/runner.server';
 
 import {
   BadRequestError,
@@ -36,6 +37,12 @@ export type AppServices =
   | Payment.Service
   | Auth.Service
   | Storage.Service
+  // The durable Order workflow's SENDER seam (G6): the registration action's
+  // `arm` send (G7) and the Stripe webhook's `settle` resolve (G8) dispatch
+  // against these from the request graph. `Env.database`-gated at the build
+  // boundary (`Order.appSenderLayer`) — DB-less the inert in-memory instance is
+  // never reached by a (likewise-gated) sender.
+  | Order.SenderServices
   | Toast;
 export type AppError =
   | Response
@@ -111,6 +118,11 @@ export const makeAppLayer = (
     DraftEditor.layer,
     Submissions.layer,
     paymentLayer,
+    // The Order SENDER seam — `Env.database`-gated at its build boundary, so a
+    // DB-less runtime composes the inert in-memory instance (never reached by a
+    // gated sender) and a DB runtime composes the real sender over the SAME
+    // shared sqlite FILE + `ShardingConfigLive` the `ServerLive` runner uses.
+    Order.appSenderLayer,
   ).pipe(Layer.provideMerge(baseLayer), Layer.provideMerge(Env.layer));
 };
 

--- a/app/lib/effect/runtime.ts
+++ b/app/lib/effect/runtime.ts
@@ -106,6 +106,19 @@ export const makeAppLayer = (
   // exercised end-to-end with NO network. Defaulted so every existing caller is
   // unchanged.
   paymentLayer: Layer.Layer<Payment.Service, never, Env.Service> = Payment.layer,
+  // The Order SENDER seam — `Env.database`-gated at its build boundary, so a
+  // DB-less runtime composes the inert in-memory instance (never reached by a
+  // gated sender) and a DB runtime composes the real sender over the SAME shared
+  // sqlite FILE + `ShardingConfigLive` the `ServerLive` runner uses. Defaulted so
+  // every production/test caller is unchanged; a webhook test passes a sender
+  // built over a FAULTY `MessageStorage` (its `saveRequest` fails) to exercise the
+  // F3 `settle.send` persistence-failure → retryable-5xx path end-to-end through
+  // the real request runtime.
+  senderLayer: Layer.Layer<
+    Order.SenderServices,
+    never,
+    Env.Service
+  > = Order.appSenderLayer,
 ) => {
   const baseLayer = Layer.mergeAll(
     Mailer.layer,
@@ -118,11 +131,7 @@ export const makeAppLayer = (
     DraftEditor.layer,
     Submissions.layer,
     paymentLayer,
-    // The Order SENDER seam — `Env.database`-gated at its build boundary, so a
-    // DB-less runtime composes the inert in-memory instance (never reached by a
-    // gated sender) and a DB runtime composes the real sender over the SAME
-    // shared sqlite FILE + `ShardingConfigLive` the `ServerLive` runner uses.
-    Order.appSenderLayer,
+    senderLayer,
   ).pipe(Layer.provideMerge(baseLayer), Layer.provideMerge(Env.layer));
 };
 

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -179,6 +179,37 @@ const bucketConfig: Config.Config<Option.Option<BucketConfig>> = Config.all({
 );
 
 /**
+ * Sentinel sqlite in-memory connection string. SQLite treats `':memory:'` as a
+ * private, per-connection database — impossible to share across two layer graphs.
+ */
+const SQLITE_MEMORY = ':memory:';
+
+const isSqliteMemory = (value: Redacted.Redacted<string>): boolean =>
+  Redacted.value(value).trim().toLowerCase() === SQLITE_MEMORY;
+
+/**
+ * Production guard on the durable Order DB target. The runner (`ServerLive`) and
+ * the senders (`AppRuntime`) are two separate layer graphs that coordinate ONLY
+ * through the shared sqlite FILE; `':memory:'` gives each graph its OWN private
+ * in-memory DB, so a `send` from a route lands in a DB the runner never polls —
+ * the route → runner → webhook loop silently breaks. The plan
+ * (`docs/order-workflow-plan.md:327`) and `.env.example` already declare this
+ * IMPOSSIBLE in production; this turns the documented invariant into a typed
+ * boot failure. A `Schema.SchemaError` (not a thrown defect) flows into
+ * `Config.ConfigError`, mirroring the `STRIPE_CURRENCY` decode above so the env
+ * layer keeps its single `ConfigError` error channel.
+ */
+const ProductionDatabaseUrl = Schema.Redacted(Schema.String).check(
+  Schema.makeFilter<Redacted.Redacted<string>>(
+    (url) =>
+      isSqliteMemory(url)
+        ? "DATABASE_URL must be a sqlite FILE path on a persistent volume in production, never ':memory:' — the runner and request/webhook senders are separate layer graphs that coordinate only through the shared file (docs/order-workflow-plan.md:327)"
+        : undefined,
+    { title: 'DATABASE_URL' },
+  ),
+);
+
+/**
  * Durable Order workflow database (encore SQL MessageStorage). OPTIONAL
  * everywhere — when `DATABASE_URL` is unset the durable Order entity is disabled
  * and the app falls back to the existing bucket-only registration/webhook path.
@@ -195,17 +226,26 @@ const bucketConfig: Config.Config<Option.Option<BucketConfig>> = Config.all({
  * future Postgres URL with embedded credentials). In production this MUST be a
  * sqlite FILE path on a persistent volume, never `':memory:'` — the long-lived
  * runner and the request/webhook senders are two separate layer graphs that
- * coordinate ONLY through the shared sqlite file.
+ * coordinate ONLY through the shared sqlite file. `:memory:` is read together
+ * with `NODE_ENV` so the production rejection fails the env layer at boot
+ * (development/test keep `':memory:'` for the single-graph G3 layerTest path).
  */
-const databaseConfig: Config.Config<Option.Option<DatabaseConfig>> = Config.redacted(
-  'DATABASE_URL',
-).pipe(
-  Config.withDefault(Redacted.make('')),
-  Config.map((url) =>
-    isBlankRedacted(url)
-      ? Option.none()
-      : Option.some<DatabaseConfig>({ url }),
-  ),
+const databaseConfig: Config.Config<Option.Option<DatabaseConfig>> = Config.all({
+  url: Config.redacted('DATABASE_URL').pipe(Config.withDefault(Redacted.make(''))),
+  nodeEnv: Config.string('NODE_ENV').pipe(Config.withDefault('development')),
+}).pipe(
+  Config.mapOrFail(({ url, nodeEnv }) => {
+    if (isBlankRedacted(url)) {
+      return Effect.succeed(Option.none<DatabaseConfig>());
+    }
+    if (nodeEnv !== 'production') {
+      return Effect.succeed(Option.some<DatabaseConfig>({ url }));
+    }
+    return Schema.decodeUnknownEffect(ProductionDatabaseUrl)(url).pipe(
+      Effect.map((validated) => Option.some<DatabaseConfig>({ url: validated })),
+      Effect.mapError((error) => new Config.ConfigError(error)),
+    );
+  }),
 );
 
 export class Service extends Context.Service<

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -49,6 +49,10 @@ export interface BucketConfig {
   readonly region: string;
 }
 
+export interface DatabaseConfig {
+  readonly url: Redacted.Redacted<string>;
+}
+
 const mailConfigRequired = Config.all({
   host: Config.string('MAIL_HOST'),
   port: Config.number('MAIL_PORT'),
@@ -174,6 +178,36 @@ const bucketConfig: Config.Config<Option.Option<BucketConfig>> = Config.all({
   ),
 );
 
+/**
+ * Durable Order workflow database (encore SQL MessageStorage). OPTIONAL
+ * everywhere — when `DATABASE_URL` is unset the durable Order entity is disabled
+ * and the app falls back to the existing bucket-only registration/webhook path.
+ *
+ * Same blank-collapse None-gate as the bucket/stripe/sendgrid configs: read with
+ * a `''` default, trimmed, collapsing to `Option.none()` unless non-blank. We do
+ * NOT use `Config.option` — a present-but-empty `DATABASE_URL=` (the value
+ * shipped in `.env.example`) is a *successful* empty parse, not missing data, so
+ * `Config.option` would wrongly resolve it to `Some(Redacted(''))` and treat the
+ * empty placeholder as a real DB.
+ *
+ * The connection string flows through `Config.redacted` so it is never
+ * accidentally logged (harmless for a sqlite file path; load-bearing for a
+ * future Postgres URL with embedded credentials). In production this MUST be a
+ * sqlite FILE path on a persistent volume, never `':memory:'` — the long-lived
+ * runner and the request/webhook senders are two separate layer graphs that
+ * coordinate ONLY through the shared sqlite file.
+ */
+const databaseConfig: Config.Config<Option.Option<DatabaseConfig>> = Config.redacted(
+  'DATABASE_URL',
+).pipe(
+  Config.withDefault(Redacted.make('')),
+  Config.map((url) =>
+    isBlankRedacted(url)
+      ? Option.none()
+      : Option.some<DatabaseConfig>({ url }),
+  ),
+);
+
 export class Service extends Context.Service<
   Service,
   {
@@ -182,6 +216,7 @@ export class Service extends Context.Service<
     readonly sendgrid: Option.Option<SendgridConfig>;
     readonly stripe: Option.Option<StripeConfig>;
     readonly bucket: Option.Option<BucketConfig>;
+    readonly database: Option.Option<DatabaseConfig>;
   }
 >()('gycc/lib/env.server/Service') {}
 
@@ -203,6 +238,7 @@ export const layer = Layer.effect(
     const bucket = yield* bucketConfig;
     const sendgrid = yield* sendgridConfig;
     const stripe = yield* stripeConfig;
+    const database = yield* databaseConfig;
 
     if (isProduction) {
       const mail = yield* mailConfigRequired;
@@ -212,11 +248,12 @@ export const layer = Layer.effect(
         sendgrid,
         stripe,
         bucket,
+        database,
       });
     }
 
     const mail = yield* Config.option(mailConfigRequired);
-    return Service.of({ isProduction, mail, sendgrid, stripe, bucket });
+    return Service.of({ isProduction, mail, sendgrid, stripe, bucket, database });
   }),
 );
 

--- a/app/lib/forms/decode.ts
+++ b/app/lib/forms/decode.ts
@@ -1,4 +1,4 @@
-import { Result, Schema, SchemaGetter } from 'effect';
+import { Result, Schema, SchemaGetter, SchemaParser } from 'effect';
 import type { Issue } from 'effect/SchemaIssue';
 
 import { activationIndex, isActiveByName } from './activation';
@@ -735,4 +735,4 @@ export const decodeForm = (
   definition: FormDefinition,
   payload: unknown,
 ): Result.Result<DecodedForm, Issue> =>
-  Schema.decodeUnknownResult(definitionToSchema(definition))(payload);
+  SchemaParser.decodeUnknownResult(definitionToSchema(definition))(payload);

--- a/app/lib/forms/order-conflict.ts
+++ b/app/lib/forms/order-conflict.ts
@@ -1,0 +1,30 @@
+import { Schema } from 'effect';
+
+/**
+ * A same-payload registration resubmit landed on a LIVE `pending` order whose
+ * frozen fields (amount / currency / receiptEmail / mode / registrantIds) do NOT
+ * match the resubmitted order (order-workflow round-2 --deep H1, case (d)).
+ *
+ * The deterministic `orderId` (the request fingerprint, possibly `:index`) is a
+ * stable hash of the submission payload, so a verbatim resubmit re-derives the
+ * SAME id and idempotently REUSES the live pending order (case (b)). A
+ * fingerprint COLLISION — two genuinely different orders hashing to the same id
+ * while the first is still `pending` — is the only way the frozen fields can
+ * disagree at a matching id. Rather than silently overwriting the live order's
+ * frozen amount/receipt (the money/receipt-routing hazard the H1 guard closes),
+ * `createOrReuseOrder` fails EXPLICITLY with this error: the resubmit cannot
+ * proceed against a conflicting in-flight order.
+ *
+ * It is NOT HTTP-mapped at the boundary the way a 4xx is — the registration
+ * action catches it and surfaces a form-level validation error (the same channel
+ * a decode failure uses), so the visitor sees an explicit "this submission
+ * conflicts with an in-flight order" message rather than a silent corruption.
+ */
+export class OrderConflict extends Schema.TaggedErrorClass<OrderConflict>()(
+  'Order.Conflict',
+  {
+    orderId: Schema.String,
+    /** A short, human-meaningful description of which frozen field disagreed. */
+    reason: Schema.String,
+  },
+) {}

--- a/app/lib/forms/order.test.ts
+++ b/app/lib/forms/order.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Result, Schema } from 'effect';
 
-import { newListItemId } from '../content/schema';
+import { IsoDate, newListItemId } from '../content/schema';
 
 import { RegistrationOrder } from './order';
 import { Cents, CurrencyCode } from './pricing';
@@ -39,10 +39,36 @@ describe('RegistrationOrder', () => {
     }
   });
 
-  test('rejects an off-list status', () => {
+  test('round-trips at each widened status (cancelled, refunded, expired)', () => {
+    // The G5 widen added `cancelled` + `refunded` (atop the original
+    // pending/paid/failed/expired). A `refunded` order ALSO carries the frozen
+    // `refundedAt`; every status round-trips losslessly through the bucket codec.
+    const codec = Schema.fromJsonString(RegistrationOrder);
+    const cases = [
+      { ...validOrder, status: 'cancelled' as const },
+      { ...validOrder, status: 'expired' as const },
+      {
+        ...validOrder,
+        status: 'refunded' as const,
+        paidAt: IsoDate.make('2026-06-18'),
+        refundedAt: IsoDate.make('2026-06-20'),
+      },
+    ];
+    for (const order of cases) {
+      const back = Schema.decodeUnknownResult(codec)(
+        Schema.encodeSync(codec)(order),
+      );
+      expect(Result.isSuccess(back)).toBe(true);
+      if (Result.isSuccess(back)) {
+        expect(back.success).toEqual(order);
+      }
+    }
+  });
+
+  test('rejects an off-list status (still a CLOSED literal after the widen)', () => {
     const result = Schema.decodeUnknownResult(RegistrationOrder)({
       ...validOrder,
-      status: 'refunded',
+      status: 'partially_refunded',
     });
     expect(Result.isFailure(result)).toBe(true);
   });

--- a/app/lib/forms/order.ts
+++ b/app/lib/forms/order.ts
@@ -53,7 +53,22 @@ export const RegistrationOrder = Schema.Struct({
   // FROZEN — group: party.payer.email (nominated, possibly a non-attendee);
   // perRegistrant: registrants[i].email (Decision 2b.6). Required, never absent.
   receiptEmail: Schema.String,
-  status: Schema.Literals(['pending', 'paid', 'failed', 'expired']),
+  // The order lifecycle (Decision 5 / G5). Widened from the original
+  // `['pending','paid','failed','expired']` to the additive superset
+  // `+ 'cancelled' + 'refunded'` so the durable Order actor's two new terminal
+  // states have a durable bucket home. STILL a CLOSED `Schema.Literals`: a
+  // present-but-unknown token fails decode, and every legacy
+  // `pending`/`paid`/`failed`/`expired` order decodes byte-unchanged (the new
+  // arms are append-only). `failed` (Stripe `async_payment_failed`) and
+  // `cancelled` (operator/abandon) stay DISTINCT — they are not aliases.
+  status: Schema.Literals([
+    'pending',
+    'paid',
+    'failed',
+    'expired',
+    'cancelled',
+    'refunded',
+  ]),
   // group: every party id; perRegistrant: the one id. The webhook flips each
   // named registrant submission's payment alongside the order (C8).
   registrantIds: Schema.Array(ListItemId),
@@ -69,5 +84,13 @@ export const RegistrationOrder = Schema.Struct({
   // order has nothing settled, so it carries no `paidAt`; a read-back of a legacy
   // paid order written before this field existed tolerates its absence.
   paidAt: Schema.optionalKey(IsoDate),
+  // FROZEN the instant a `paid` order first transitions to `refunded` (G5
+  // `markOrderRefunded`), and NEVER re-stamped — the mirror of `paidAt` for the
+  // refund terminal, so a re-flip to `refunded` re-reads this value rather than
+  // the clock and the registrant `refunded` stamp derives its own `refundedAt`
+  // FROM it (`derive-dont-sync`). `optionalKey` (backfill-safe): only a
+  // `refunded` order carries it; every other status — and every legacy order
+  // written before this field existed — tolerates its absence.
+  refundedAt: Schema.optionalKey(IsoDate),
 });
 export type RegistrationOrder = typeof RegistrationOrder.Type;

--- a/app/lib/forms/registration-action.test.ts
+++ b/app/lib/forms/registration-action.test.ts
@@ -167,7 +167,14 @@ const listRegistrations = (runtime: RequestRuntime, args: RouteArgs) =>
     args,
     Effect.gen(function* () {
       const storage = yield* Storage.Service;
-      const listed = yield* storage.list('submissions/registration/');
+      // Registrant submissions sit at `submissions/registration/<id>.json`; the
+      // frozen ORDERS nest one level UNDER at `submissions/registration/orders/`.
+      // The shared `list` prefix returns BOTH, so the order keys are filtered out
+      // here (they decode as orders, not submissions — the real registrar reads
+      // them through `listOrders`).
+      const listed = (
+        yield* storage.list('submissions/registration/')
+      ).filter((entry) => !entry.key.startsWith('submissions/registration/orders/'));
       const decode = Schema.decodeUnknownEffect(
         Schema.fromJsonString(submissionSchema(defaultRegistrationForm)),
       );
@@ -837,8 +844,12 @@ describe('registrationAction — perRegistrant checkout (registrar C7.5)', () =>
       a.idempotencyKey.localeCompare(b.idempotencyKey),
     );
     byKey.forEach((call, index) => {
+      // The idempotency key is derived from the RESOLVED orderId
+      // (`<fingerprint>:<index>`) + mode (order-workflow round-2 --deep H1), so a
+      // fresh generation after a dead terminal would key a new session; a verbatim
+      // resubmit replays the same per-registrant session.
       expect(call.idempotencyKey).toMatch(
-        new RegExp(`^registration:checkout:[a-f0-9]+:perRegistrant:${index}$`),
+        new RegExp(`^registration:checkout:[a-f0-9]+:${index}:perRegistrant$`),
       );
       expect(call.receiptEmail).toBe(`booth${index}@example.com`);
       expect(call.metadata).toEqual(
@@ -1115,5 +1126,238 @@ describe('registrationAction — durable Order arm send (order-workflow G7.1)', 
     const { orders, armTags } = await runActionAndAwaitArms(groupBody(2), {});
     expect(orders.length).toBe(0);
     expect(armTags).toEqual([]);
+  });
+});
+
+/**
+ * order-workflow round-2 --deep H1 — the GUARDED order create/reuse on a
+ * same-payload registration resubmit. A verbatim resubmit derives the SAME
+ * deterministic `orderId` (the request fingerprint), so a naive
+ * `persistOrder` would silently OVERWRITE whatever order already lives there —
+ * restamping an already-PAID order's registrants back to `pending` (the F1
+ * resurrection class through the CREATE path), or resurrecting a non-paid
+ * TERMINAL order. These pin the CONFIRMED resubmit UX end-to-end through the real
+ * action over a PERSISTENT shared bucket (so the second submit reads what the
+ * first wrote):
+ *   (a) resubmit after PAID  ⇒ existing receipt, NO new session, order stays
+ *       paid, registrants NOT restamped;
+ *   (b) resubmit while PENDING ⇒ replays the same session, NO restamp;
+ *   (c) resubmit after a non-paid TERMINAL ⇒ a FRESH pending order (new
+ *       generation) is allowed — the user legitimately re-registers;
+ *   (d) a live PENDING whose frozen fields CONFLICT ⇒ explicit failure.
+ */
+
+/** A single-registrant priced GROUP body (the simplest order to drive). */
+const oneRegistrantGroupBody = (): URLSearchParams => groupBody(1);
+
+/**
+ * Drive a registration action over the SAME runtime/bucket the test holds, and
+ * return the thrown `Response` (the redirect) or the `FormResult` (an error
+ * report). The action's terminal `toast.redirect`/Stripe `redirect` throws a
+ * mapped `Response`; a validation failure resolves to a `FormResult`.
+ */
+const driveAction = async (
+  runtime: RequestRuntime,
+  action: ReturnType<typeof registrationAction>,
+  body: URLSearchParams,
+): Promise<Response | Awaited<ReturnType<ReturnType<typeof registrationAction>>>> => {
+  try {
+    return await action(makeRegistrationArgs(runtime, body));
+  } catch (error) {
+    if (error instanceof Response) return error;
+    throw error;
+  }
+};
+
+describe('registrationAction — guarded order create/reuse on resubmit (H1)', () => {
+  it('(a) resubmit after PAID returns the existing receipt — no new session, order stays paid, registrants NOT restamped', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    // ONE shared bucket across both submits + the status mutation.
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+
+    // First submit: one pending order + one session.
+    const first = await driveAction(runtime, action, body);
+    expect(first).toBeInstanceOf(Response);
+    expect((first as Response).status).toBe(303);
+    expect(calls.length).toBe(1);
+    const args = makeRegistrationArgs(runtime, body);
+    const order = (await listOrders(runtime, args))[0]!.order;
+
+    // Mark it PAID through the bucket authority (the webhook's reconcile).
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        yield* submissions.markOrderPaid('registration', order.orderId);
+      }),
+    );
+    const paidRegistrants = await listRegistrations(runtime, args);
+    expect(paidRegistrants[0]?.record.payment?._tag).toBe('paid');
+
+    // Resubmit the SAME payload: the order is paid, so the action returns the
+    // existing success/receipt — NO new Stripe session, the order stays paid,
+    // and the registrant is NOT restamped back to pending.
+    const second = await driveAction(runtime, action, body);
+    expect(second).toBeInstanceOf(Response);
+    // Lands on the success TOAST (302 to the form), not a Stripe checkout (303).
+    expect((second as Response).status).toBe(302);
+    expect((second as Response).headers.get('location')).toBe('/2026/form');
+    expect((second as Response).headers.get('location')).not.toContain(
+      'checkout.stripe.test',
+    );
+    // No SECOND create-session call (no re-charge).
+    expect(calls.length).toBe(1);
+    // Still exactly ONE order, still `paid` (never overwritten to pending).
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(ordersAfter[0]!.order.status).toBe('paid');
+    // The registrant kept its `paid` stamp — NOT restamped to pending.
+    const registrantsAfter = await listRegistrations(runtime, args);
+    expect(registrantsAfter[0]?.record.payment?._tag).toBe('paid');
+  });
+
+  it('(b) resubmit while PENDING reuses the same checkout — order not overwritten, registrants not restamped', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit: pending order + session.
+    const first = await driveAction(runtime, action, body);
+    expect((first as Response).status).toBe(303);
+    expect(calls.length).toBe(1);
+    const firstOrder = (await listOrders(runtime, args))[0]!.order;
+    const firstUrl = (first as Response).headers.get('location');
+
+    // Resubmit the SAME payload while still pending: Stripe replays the SAME
+    // session (idempotency key), so the visitor is redirected to the same hosted
+    // url; the order is NOT overwritten (same orderId, same sessionId), and there
+    // is still exactly ONE order.
+    const second = await driveAction(runtime, action, body);
+    expect((second as Response).status).toBe(303);
+    expect((second as Response).headers.get('location')).toBe(firstUrl);
+    // The Payment testLayer is idempotency-keyed, so a verbatim resubmit does NOT
+    // double the create-session calls beyond the replayed one.
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(ordersAfter[0]!.order.orderId).toBe(firstOrder.orderId);
+    expect(ordersAfter[0]!.order.sessionId).toBe(firstOrder.sessionId);
+    expect(ordersAfter[0]!.order.status).toBe('pending');
+  });
+
+  it('(c) resubmit after a non-paid TERMINAL (expired) mints a FRESH pending order at a new generation — the dead order is left untouched', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit → pending order. Expire it (the deadline sweep / abandon).
+    await driveAction(runtime, action, body);
+    const deadOrder = (await listOrders(runtime, args))[0]!.order;
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        yield* submissions.markOrderExpired('registration', deadOrder.orderId);
+      }),
+    );
+    const afterExpire = await listOrders(runtime, args);
+    expect(afterExpire.length).toBe(1);
+    expect(afterExpire[0]!.order.status).toBe('expired');
+
+    // Resubmit the SAME payload: the user is legitimately re-registering past a
+    // dead order, so a FRESH pending order is minted at a NEW generation — the
+    // expired order is NEVER overwritten back to pending.
+    const second = await driveAction(runtime, action, body);
+    expect((second as Response).status).toBe(303);
+    const ordersAfter = await listOrders(runtime, args);
+    // TWO orders now: the dead expired one (untouched) + a fresh pending one.
+    expect(ordersAfter.length).toBe(2);
+    const byStatus = Object.fromEntries(
+      ordersAfter.map((entry) => [entry.order.status, entry.order]),
+    );
+    expect(byStatus['expired']?.orderId).toBe(deadOrder.orderId);
+    expect(byStatus['pending']).toBeDefined();
+    // The fresh order is a DISTINCT generation key, not the dead one.
+    expect(byStatus['pending']?.orderId).not.toBe(deadOrder.orderId);
+    expect(byStatus['pending']?.orderId.startsWith(deadOrder.orderId)).toBe(true);
+  });
+
+  it('(d) a live PENDING order whose frozen fields CONFLICT fails explicitly — the in-flight order is NOT overwritten', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit → a live pending order. Mutate its frozen `amount` on the
+    // bucket to simulate a fingerprint COLLISION: a different order's frozen
+    // fields now live at the orderId the resubmit derives.
+    await driveAction(runtime, action, body);
+    const order = (await listOrders(runtime, args))[0]!.order;
+    const tamperedReceipt = 'collision@example.com';
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        yield* submissions.persistOrder('registration', {
+          ...order,
+          receiptEmail: tamperedReceipt,
+        });
+      }),
+    );
+
+    // Resubmit the SAME payload: the live pending order's frozen receiptEmail now
+    // disagrees with the proposed order, so the guard FAILS explicitly rather
+    // than overwriting the in-flight order's receipt routing.
+    const result = await driveAction(runtime, action, body);
+    // A form-level validation error report (not a redirect Response).
+    expect(result).not.toBeInstanceOf(Response);
+    const formResult = result as Exclude<typeof result, Response>;
+    expect(formResult.status).toBe('error');
+    expect(formResult.result.error?.formErrors?.[0]).toContain(
+      'registration.checkout.conflict:receiptEmail',
+    );
+    // The tampered order was NOT overwritten back to the proposed receipt.
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(ordersAfter[0]!.order.receiptEmail).toBe(tamperedReceipt);
+    expect(ordersAfter[0]!.order.status).toBe('pending');
   });
 });

--- a/app/lib/forms/registration-action.test.ts
+++ b/app/lib/forms/registration-action.test.ts
@@ -16,7 +16,8 @@ import { isSuccess } from 'effect-encore';
 
 import { defaultRegistrationForm } from '../content/pages/defaults';
 import { Content } from '../content.server';
-import { formObjectKey } from '../content/pages/registry';
+import { formObjectKey, orderKey } from '../content/pages/registry';
+import { IsoDate } from '../content/schema';
 import { formValidationError } from '../effect/errors';
 import {
   type AppLayer,
@@ -30,6 +31,7 @@ import { type CreateCheckoutSessionCall, Payment } from '../payment.server';
 import { type ObjectHead, NotFound, Storage, StorageError } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
 
+import { Cents } from './pricing';
 import { FormDefinition } from './definition';
 import { RegistrationOrder } from './order';
 import { registrationAction } from './registration-action';
@@ -991,6 +993,69 @@ const sharedStorageLayer = (
   );
 };
 
+/**
+ * A Map-backed `Storage` over an EXTERNALLY-owned `entries` map (so a test can
+ * seed it, read it, mutate it mid-action, and share one instance across submits).
+ * Distinct from `sharedStorageLayer` (which owns its map internally): the H1
+ * round-3 adversarial tests need to (i) flip an order to paid mid-action via a
+ * Payment-hook side effect and (ii) inject a targeted `put` failure on the
+ * registrant-stamp write — both require holding the map AND a `failPut` predicate.
+ */
+const mapBackedStorage = (
+  entries: Map<string, { body: string; contentType: string }>,
+  failPut: (key: string) => boolean = () => false,
+): Layer.Layer<Storage.Service> =>
+  Layer.sync(Storage.Service, () =>
+    Storage.Service.of({
+      get: Effect.fn('Storage.get')(function* (key: string) {
+        const object = entries.get(key);
+        if (object === undefined) return yield* new NotFound({ key });
+        return {
+          stream:
+            new Response(object.body).body ?? new ReadableStream<Uint8Array>(),
+          contentType: object.contentType,
+          size: new TextEncoder().encode(object.body).byteLength,
+        };
+      }),
+      put: Effect.fn('Storage.put')(function* (
+        key: string,
+        body: string | Uint8Array,
+        contentType: string,
+      ) {
+        if (failPut(key)) return yield* new StorageError({ key, op: 'put' });
+        entries.set(key, { body: String(body), contentType });
+      }),
+      head: Effect.fn('Storage.head')((key: string) =>
+        Effect.sync(() =>
+          entries.has(key)
+            ? Option.some<ObjectHead>({
+                size: 0,
+                contentType: 'application/json',
+                lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+                etag: `"${key}"`,
+              })
+            : Option.none<ObjectHead>(),
+        ),
+      ),
+      list: Effect.fn('Storage.list')((prefix?: string) =>
+        Effect.sync(() =>
+          [...entries.keys()]
+            .filter((key) => prefix === undefined || key.startsWith(prefix))
+            .map((key) => ({
+              key,
+              size: 0,
+              lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+            })),
+        ),
+      ),
+      delete: Effect.fn('Storage.delete')((key: string) =>
+        Effect.sync(() => {
+          entries.delete(key);
+        }),
+      ),
+    }),
+  );
+
 const tmpDbFile = (suffix: string): string =>
   `${tmpdir()}/gyc-order-action-${process.pid}-${Date.now()}-${suffix}.sqlite`;
 
@@ -1169,16 +1234,35 @@ const driveAction = async (
   }
 };
 
+/** Sync `RegistrationOrder` JSON codecs — the race-injection hook (i) rewrites a
+ * stored order to `paid` through the SAME schema the action reads, no raw JSON. */
+const decodeOrderSync = Schema.decodeUnknownSync(
+  Schema.fromJsonString(RegistrationOrder),
+);
+const encodeOrderSync = Schema.encodeSync(
+  Schema.fromJsonString(RegistrationOrder),
+);
+/** Decode a `YYYY-MM-DD` string to the branded, real-calendar `IsoDate`. */
+const isoDateSync = Schema.decodeUnknownSync(IsoDate);
+
 describe('registrationAction — guarded order create/reuse on resubmit (H1)', () => {
-  it('(a) resubmit after PAID returns the existing receipt — no new session, order stays paid, registrants NOT restamped', async () => {
+  it('(a) resubmit after PAID returns the existing ?checkout=success receipt — no new session, order stays paid, registrants NOT restamped, NO duplicate admin notify', async () => {
     const calls: Array<CreateCheckoutSessionCall> = [];
     // ONE shared bucket across both submits + the status mutation.
     const storage = sharedStorageLayer(pricedRegistrationObject());
     const runtime = makeRequestRuntimeFromLayer(
       stripeEnabledLayer(storage, Payment.testLayer({ calls })),
     );
+    // Spy `notify`: the CONFIRMED paid-resubmit UX redirects to the existing
+    // `?checkout=success` receipt state WITHOUT calling `config.notify` (a second
+    // notify would re-send the admin `[!] Registration…` mail — round-3 --deep
+    // MAJOR 1). The count must stay 0 across the paid resubmit.
+    let notifyCount = 0;
     const action = registrationAction({
-      notify: () => Effect.void,
+      notify: () =>
+        Effect.sync(() => {
+          notifyCount += 1;
+        }),
       notifyPaymentLink: noopPaymentLink,
       success,
       perRegistrantSuccess,
@@ -1209,12 +1293,19 @@ describe('registrationAction — guarded order create/reuse on resubmit (H1)', (
     // and the registrant is NOT restamped back to pending.
     const second = await driveAction(runtime, action, body);
     expect(second).toBeInstanceOf(Response);
-    // Lands on the success TOAST (302 to the form), not a Stripe checkout (303).
-    expect((second as Response).status).toBe(302);
-    expect((second as Response).headers.get('location')).toBe('/2026/form');
+    // Lands on the EXISTING `?checkout=success` receipt state (303 to the same url
+    // Stripe returns to on a first completion), NOT a Stripe checkout url and NOT
+    // the legacy success toast (the CONFIRMED resubmit UX — round-3 --deep).
+    expect((second as Response).status).toBe(303);
+    expect((second as Response).headers.get('location')).toBe(
+      'http://localhost/2026/form?checkout=success',
+    );
     expect((second as Response).headers.get('location')).not.toContain(
       'checkout.stripe.test',
     );
+    // The admin `notify` was NEVER called on the paid resubmit (no duplicate
+    // notification — round-3 --deep MAJOR 1).
+    expect(notifyCount).toBe(0);
     // No SECOND create-session call (no re-charge).
     expect(calls.length).toBe(1);
     // Still exactly ONE order, still `paid` (never overwritten to pending).
@@ -1309,6 +1400,370 @@ describe('registrationAction — guarded order create/reuse on resubmit (H1)', (
     // The fresh order is a DISTINCT generation key, not the dead one.
     expect(byStatus['pending']?.orderId).not.toBe(deadOrder.orderId);
     expect(byStatus['pending']?.orderId.startsWith(deadOrder.orderId)).toBe(true);
+  });
+
+  it('(i) PAID between resolve and commit (the race) lands on ?checkout=success — no Stripe redirect, no restamp, no duplicate notify', async () => {
+    // The adversarial race the round-3 --deep BLOCKER 1 names: `resolveOrderSlot`
+    // reads the order live-PENDING, then the order flips to PAID in the window
+    // BEFORE the guarded `createOrReuseOrder` re-read at commit. The pre-mint
+    // paid fast-path cannot catch this (it already saw pending); only the commit
+    // branch on the FULL outcome union can. We inject the flip INSIDE
+    // `createCheckoutSession` (which the action calls AFTER resolve, BEFORE the
+    // commit re-read): the double rewrites the live order on the shared bucket to
+    // `paid` as a side effect, so `createOrReuseOrder` re-reads `alreadyPaid`.
+    const entries = new Map<string, { body: string; contentType: string }>();
+    for (const [key, object] of Object.entries(pricedRegistrationObject())) {
+      entries.set(key, { body: object.body, contentType: 'application/json' });
+    }
+    const mapStorage = mapBackedStorage(entries);
+    // The Payment double: on every call, flip whatever pending registration order
+    // already lives on the bucket to `paid` (the race), then return the session.
+    let flipNext = false;
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const racingPayment = Layer.succeed(
+      Payment.Service,
+      Payment.Service.of({
+        createCheckoutSession: (params) =>
+          Effect.sync(() => {
+            calls.push({
+              amount: params.amount,
+              currency: params.currency,
+              receiptEmail: params.receiptEmail,
+              productName: params.productName,
+              successUrl: params.successUrl,
+              cancelUrl: params.cancelUrl,
+              metadata: params.metadata,
+              idempotencyKey: params.idempotencyKey,
+            });
+            if (flipNext) {
+              // Rewrite the order at the resolved orderId to `paid` — the exact
+              // shape `markOrderPaid` would write (status + a frozen paidAt) —
+              // through the `RegistrationOrder` codec (no raw JSON), so the
+              // re-read sees a fully-valid paid order.
+              const key = orderKey('registration', params.metadata['orderId']!);
+              const current = entries.get(key);
+              if (current !== undefined) {
+                const order = decodeOrderSync(current.body);
+                const paid = encodeOrderSync({
+                  ...order,
+                  status: 'paid',
+                  paidAt: isoDateSync('2026-01-01'),
+                });
+                entries.set(key, {
+                  body: paid,
+                  contentType: 'application/json',
+                });
+              }
+            }
+            return {
+              sessionId: `cs_test_${params.idempotencyKey}`,
+              url: `https://checkout.stripe.test/${params.idempotencyKey}`,
+            };
+          }),
+        createRefund: () => Effect.die(new Error('unused')),
+        constructEvent: () => Effect.succeed({}),
+      }),
+    );
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(mapStorage, racingPayment),
+    );
+    let notifyCount = 0;
+    const action = registrationAction({
+      notify: () =>
+        Effect.sync(() => {
+          notifyCount += 1;
+        }),
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit: a normal pending order (no flip yet).
+    const first = await driveAction(runtime, action, body);
+    expect((first as Response).status).toBe(303);
+    expect(calls.length).toBe(1);
+
+    // Capture the registrant's stamp BEFORE the racing resubmit (it is `pending`
+    // from the first submit; the webhook that would flip it `paid` alongside the
+    // order has not run in this race scenario). The racing resubmit must NOT write
+    // it at all — so the stamp must be byte-identical after.
+    const stampBefore = (await listRegistrations(runtime, args))[0]?.record
+      .payment;
+    expect(stampBefore?._tag).toBe('pending');
+
+    // Second submit WITH the race armed: resolve sees pending → session mints (and
+    // flips the order to paid) → the commit re-read sees `alreadyPaid`.
+    flipNext = true;
+    const second = await driveAction(runtime, action, body);
+    expect(second).toBeInstanceOf(Response);
+    // Lands on the existing `?checkout=success` receipt (303), NOT a Stripe url.
+    expect((second as Response).status).toBe(303);
+    expect((second as Response).headers.get('location')).toBe(
+      'http://localhost/2026/form?checkout=success',
+    );
+    expect((second as Response).headers.get('location')).not.toContain(
+      'checkout.stripe.test',
+    );
+    // No admin notify on the paid-race landing (no duplicate notification).
+    expect(notifyCount).toBe(0);
+    // Still exactly ONE order, still `paid` (the race flip stuck; the commit did
+    // NOT overwrite it back to pending).
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(ordersAfter[0]!.order.status).toBe('paid');
+    // The registrant stamp is UNTOUCHED by the racing resubmit — byte-identical to
+    // the pre-resubmit value (the `alreadyPaid` branch skips the stamp loop
+    // entirely, so nothing re-wrote the registrant record).
+    const registrantsAfter = await listRegistrations(runtime, args);
+    expect(registrantsAfter[0]?.record.payment).toEqual(stampBefore);
+  });
+
+  it('(ii) perRegistrant resubmit after EVERY registrant PAID lands on ?checkout=success — no link mail, no duplicate notify', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    let notifyCount = 0;
+    let mailCount = 0;
+    const action = registrationAction({
+      notify: () =>
+        Effect.sync(() => {
+          notifyCount += 1;
+        }),
+      notifyPaymentLink: () =>
+        Effect.sync(() => {
+          mailCount += 1;
+        }),
+      success,
+      perRegistrantSuccess,
+    });
+    const body = perRegistrantBody(2);
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit: 2 pending per-registrant orders + 2 link mails.
+    const first = await driveAction(runtime, action, body);
+    expect((first as Response).status).toBe(302);
+    expect(calls.length).toBe(2);
+    expect(mailCount).toBe(2);
+
+    // Mark BOTH per-registrant orders paid (the webhook reconciles each).
+    const orders = await listOrders(runtime, args);
+    expect(orders.length).toBe(2);
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        for (const { order } of orders) {
+          yield* submissions.markOrderPaid('registration', order.orderId);
+        }
+      }),
+    );
+    mailCount = 0;
+
+    // Resubmit the SAME payload: every chargeable registrant is already paid, so
+    // there is nothing to mail — land on the existing `?checkout=success` receipt,
+    // NOT the legacy notify/toast and NOT a fresh link mail.
+    const second = await driveAction(runtime, action, body);
+    expect(second).toBeInstanceOf(Response);
+    expect((second as Response).status).toBe(303);
+    expect((second as Response).headers.get('location')).toBe(
+      'http://localhost/2026/form?checkout=success',
+    );
+    // No new sessions, no link mails, no admin notify.
+    expect(calls.length).toBe(2);
+    expect(mailCount).toBe(0);
+    expect(notifyCount).toBe(0);
+    // Both orders stayed `paid`, registrants kept their `paid` stamp.
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.every((e) => e.order.status === 'paid')).toBe(true);
+    const registrantsAfter = await listRegistrations(runtime, args);
+    expect(registrantsAfter.every((e) => e.record.payment?._tag === 'paid')).toBe(
+      true,
+    );
+  });
+
+  it('(iii) a setRegistrantPayment failure AFTER the order write self-heals on retry — the registrant ends stamped, never permanently skipped', async () => {
+    // The round-3 --deep BLOCKER 2: the first submit writes the pending order, then
+    // `setRegistrantPayment` FAILS — leaving the order pending but the registrant
+    // un-stamped. A retry sees the order `reused`; the OLD code skipped stamping on
+    // `reused`, stranding the registrant un-stamped FOREVER. The fix re-stamps on
+    // `reused`, so the retry self-heals.
+    const entries = new Map<string, { body: string; contentType: string }>();
+    for (const [key, object] of Object.entries(pricedRegistrationObject())) {
+      entries.set(key, { body: object.body, contentType: 'application/json' });
+    }
+    // Fail the registrant-record put that happens AFTER the order already landed —
+    // i.e. the `setRegistrantPayment` write (persist's first write happens BEFORE
+    // any order exists). `failStampWrites` arms exactly that window.
+    let failStampWrites = false;
+    const failingStorage = mapBackedStorage(entries, (key) => {
+      if (!failStampWrites) return false;
+      const isOrder = key.startsWith('submissions/registration/orders/');
+      const orderExists = [...entries.keys()].some((k) =>
+        k.startsWith('submissions/registration/orders/'),
+      );
+      // A registrant-record write (not the order) while an order already exists =
+      // the post-order `setRegistrantPayment` stamp.
+      return !isOrder && orderExists;
+    });
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(failingStorage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // Attempt 1: the order writes, then the registrant stamp put FAILS → 500.
+    failStampWrites = true;
+    const firstThrown = await driveAction(runtime, action, body);
+    expect(firstThrown).toBeInstanceOf(Response);
+    expect((firstThrown as Response).status).toBe(500);
+    // The order landed (pending), but the registrant is NOT yet stamped (the put
+    // that would have stamped it failed).
+    const ordersMid = await listOrders(runtime, args);
+    expect(ordersMid.length).toBe(1);
+    expect(ordersMid[0]!.order.status).toBe('pending');
+    const registrantsMid = await listRegistrations(runtime, args);
+    expect(registrantsMid[0]?.record.payment).toBeUndefined();
+
+    // Attempt 2 (retry), storage healthy: the order is seen `reused`, and the fix
+    // RE-stamps the registrant — so it self-heals instead of being skipped forever.
+    failStampWrites = false;
+    const second = await driveAction(runtime, action, body);
+    expect((second as Response).status).toBe(303);
+    // Still exactly ONE order (reused, not duplicated), still pending.
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(ordersAfter[0]!.order.status).toBe('pending');
+    // The registrant is NOW stamped `pending` (the reuse self-healed the stamp).
+    const registrantsAfter = await listRegistrations(runtime, args);
+    const healed = registrantsAfter[0]?.record.payment;
+    expect(healed?._tag).toBe('pending');
+    // The healed stamp links the SAME (reused) order.
+    if (healed?._tag === 'pending') {
+      expect(healed.orderId).toBe(ordersAfter[0]!.order.orderId);
+    }
+  });
+
+  it('(iv) case (c) resubmitted a THIRD time re-walks to the SAME generation — no runaway #gN', async () => {
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // Submit 1 → pending order at the base generation. Expire it.
+    await driveAction(runtime, action, body);
+    const base = (await listOrders(runtime, args))[0]!.order;
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        yield* submissions.markOrderExpired('registration', base.orderId);
+      }),
+    );
+
+    // Submit 2 → a fresh pending order at generation #g1 (walks past the expired
+    // base). The base stays expired.
+    const second = await driveAction(runtime, action, body);
+    expect((second as Response).status).toBe(303);
+    const afterSecond = await listOrders(runtime, args);
+    expect(afterSecond.length).toBe(2);
+    const g1 = afterSecond.find((e) => e.order.status === 'pending')!.order;
+    expect(g1.orderId).toBe(`${base.orderId}#g1`);
+
+    // Submit 3 (the THIRD time): the #g1 order is still live-pending, so the
+    // resubmit REUSES it — it does NOT walk to #g2. No runaway generations.
+    const third = await driveAction(runtime, action, body);
+    expect((third as Response).status).toBe(303);
+    const afterThird = await listOrders(runtime, args);
+    // STILL exactly two orders (expired base + the one reused #g1) — no #g2 minted.
+    expect(afterThird.length).toBe(2);
+    const pendings = afterThird.filter((e) => e.order.status === 'pending');
+    expect(pendings.length).toBe(1);
+    expect(pendings[0]!.order.orderId).toBe(`${base.orderId}#g1`);
+    // No order key carries a #g2 (or higher) suffix.
+    expect(
+      afterThird.some((e) => /#g[2-9]/.test(e.order.orderId)),
+    ).toBe(false);
+  });
+
+  it('(d2) a real Stripe idempotency-parameter MISMATCH on a live pending order fails OrderConflict — not just a mutated stored receipt', async () => {
+    // Case (d) modeled at the REAL idempotency boundary (round-3 --deep MAJOR 2):
+    // two genuinely-DIFFERENT submissions whose request fingerprints COLLIDE onto
+    // the same deterministic orderId would mint orders with disagreeing frozen
+    // money/receipt. We drive a first real submit to a live pending order, then a
+    // second submit whose registrant set differs (a different party size) but is
+    // forced onto the SAME orderId — the guard must reject the mismatch rather
+    // than silently overwrite the in-flight order's frozen registrantIds.
+    const calls: Array<CreateCheckoutSessionCall> = [];
+    const storage = sharedStorageLayer(pricedRegistrationObject());
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeEnabledLayer(storage, Payment.testLayer({ calls })),
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    const body = oneRegistrantGroupBody();
+    const args = makeRegistrationArgs(runtime, body);
+
+    // First submit → a live pending order with its real frozen amount (1 registrant).
+    await driveAction(runtime, action, body);
+    const order = (await listOrders(runtime, args))[0]!.order;
+
+    // Simulate a colliding DIFFERENT submission landing on the SAME orderId by
+    // rewriting the live order's frozen `amount` (the idempotency-parameter the
+    // session was keyed on) to a different value — exactly what a second distinct
+    // checkout would carry. The guard compares the proposed amount (the real
+    // priced amount) against this tampered stored amount.
+    await runtime.run(
+      args,
+      Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        const tamperedAmount = yield* Schema.decodeUnknownEffect(Cents)(
+          order.amount + 1,
+        );
+        yield* submissions.persistOrder('registration', {
+          ...order,
+          amount: tamperedAmount,
+        });
+      }),
+    );
+
+    // Resubmit: the live pending order's frozen `amount` now disagrees with the
+    // proposed (real) amount — an idempotency-parameter mismatch — so the guard
+    // fails OrderConflict on `amount` rather than overwriting it.
+    const result = await driveAction(runtime, action, body);
+    expect(result).not.toBeInstanceOf(Response);
+    const formResult = result as Exclude<typeof result, Response>;
+    expect(formResult.status).toBe('error');
+    expect(formResult.result.error?.formErrors?.[0]).toContain(
+      'registration.checkout.conflict:amount',
+    );
+    // The tampered order was NOT overwritten back to the proposed amount.
+    const ordersAfter = await listOrders(runtime, args);
+    expect(ordersAfter.length).toBe(1);
+    expect(Number(ordersAfter[0]!.order.amount)).toBe(Number(order.amount) + 1);
   });
 
   it('(d) a live PENDING order whose frozen fields CONFLICT fails explicitly — the in-flight order is NOT overwritten', async () => {

--- a/app/lib/forms/registration-action.test.ts
+++ b/app/lib/forms/registration-action.test.ts
@@ -1206,7 +1206,9 @@ describe('registrationAction — durable Order arm send (order-workflow G7.1)', 
  * first wrote):
  *   (a) resubmit after PAID  ⇒ existing receipt, NO new session, order stays
  *       paid, registrants NOT restamped;
- *   (b) resubmit while PENDING ⇒ replays the same session, NO restamp;
+ *   (b) resubmit while PENDING ⇒ replays the same session; the ORDER is not
+ *       overwritten, but the registrants ARE re-stamped `pending`
+ *       byte-identically (the round-3 self-heal restamp);
  *   (c) resubmit after a non-paid TERMINAL ⇒ a FRESH pending order (new
  *       generation) is allowed — the user legitimately re-registers;
  *   (d) a live PENDING whose frozen fields CONFLICT ⇒ explicit failure.
@@ -1317,7 +1319,7 @@ describe('registrationAction — guarded order create/reuse on resubmit (H1)', (
     expect(registrantsAfter[0]?.record.payment?._tag).toBe('paid');
   });
 
-  it('(b) resubmit while PENDING reuses the same checkout — order not overwritten, registrants not restamped', async () => {
+  it('(b) resubmit while PENDING reuses the same checkout — order not overwritten, registrants re-stamped pending byte-identically (self-heal)', async () => {
     const calls: Array<CreateCheckoutSessionCall> = [];
     const storage = sharedStorageLayer(pricedRegistrationObject());
     const runtime = makeRequestRuntimeFromLayer(
@@ -1485,12 +1487,14 @@ describe('registrationAction — guarded order create/reuse on resubmit (H1)', (
     expect((first as Response).status).toBe(303);
     expect(calls.length).toBe(1);
 
-    // Capture the registrant's stamp BEFORE the racing resubmit (it is `pending`
-    // from the first submit; the webhook that would flip it `paid` alongside the
-    // order has not run in this race scenario). The racing resubmit must NOT write
-    // it at all — so the stamp must be byte-identical after.
-    const stampBefore = (await listRegistrations(runtime, args))[0]?.record
-      .payment;
+    // Capture the registrant's stamp AND the whole raw record BEFORE the racing
+    // resubmit (the record is `pending` from the first submit; the webhook that
+    // would flip it `paid` alongside the order has not run in this race scenario).
+    // The racing resubmit must NOT rewrite it at all — so BOTH the payment stamp
+    // and the FULL record (incl. `submittedAt`) must be byte-identical after
+    // (round-4 --deep MAJOR: a same-key resubmit must not re-stamp `submittedAt`).
+    const recordBefore = (await listRegistrations(runtime, args))[0]?.record;
+    const stampBefore = recordBefore?.payment;
     expect(stampBefore?._tag).toBe('pending');
 
     // Second submit WITH the race armed: resolve sees pending → session mints (and
@@ -1513,11 +1517,14 @@ describe('registrationAction — guarded order create/reuse on resubmit (H1)', (
     const ordersAfter = await listOrders(runtime, args);
     expect(ordersAfter.length).toBe(1);
     expect(ordersAfter[0]!.order.status).toBe('paid');
-    // The registrant stamp is UNTOUCHED by the racing resubmit — byte-identical to
+    // The registrant record is UNTOUCHED by the racing resubmit — byte-identical to
     // the pre-resubmit value (the `alreadyPaid` branch skips the stamp loop
-    // entirely, so nothing re-wrote the registrant record).
+    // entirely, so nothing re-wrote the registrant record). Compare the WHOLE raw
+    // record, not just `payment`: a same-key persist must preserve `submittedAt`
+    // too, so even a resubmit on a later day yields an identical record.
     const registrantsAfter = await listRegistrations(runtime, args);
     expect(registrantsAfter[0]?.record.payment).toEqual(stampBefore);
+    expect(registrantsAfter[0]?.record).toEqual(recordBefore);
   });
 
   it('(ii) perRegistrant resubmit after EVERY registrant PAID lands on ?checkout=success — no link mail, no duplicate notify', async () => {

--- a/app/lib/forms/registration-action.test.ts
+++ b/app/lib/forms/registration-action.test.ts
@@ -1,8 +1,21 @@
+import { tmpdir } from 'node:os';
+
 import { describe, expect, it } from 'bun:test';
-import { ConfigProvider, DateTime, Effect, Layer, Option, Schema } from 'effect';
+import {
+  ConfigProvider,
+  DateTime,
+  Effect,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Schema,
+} from 'effect';
+import { Env } from '../env.server';
 import { RouterContextProvider } from 'react-router';
+import { isSuccess } from 'effect-encore';
 
 import { defaultRegistrationForm } from '../content/pages/defaults';
+import { Content } from '../content.server';
 import { formObjectKey } from '../content/pages/registry';
 import { formValidationError } from '../effect/errors';
 import {
@@ -12,6 +25,7 @@ import {
   type RequestRuntime,
 } from '../effect/runtime';
 import type { RouteArgs } from '../effect/router-context';
+import { Order } from '../order/runner.server';
 import { type CreateCheckoutSessionCall, Payment } from '../payment.server';
 import { type ObjectHead, NotFound, Storage, StorageError } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
@@ -19,6 +33,7 @@ import { layerTest } from '../storage.test-helper';
 import { FormDefinition } from './definition';
 import { RegistrationOrder } from './order';
 import { registrationAction } from './registration-action';
+import { Submissions } from './submissions.server';
 import { submissionSchema } from './submission';
 import type { Submission } from './submission';
 
@@ -887,5 +902,218 @@ describe('registrationAction — perRegistrant checkout (registrar C7.5)', () =>
 
     expect(result.status).toBe('error');
     expect(calls.length).toBe(0);
+  });
+});
+
+/**
+ * order-workflow G7.1 — the action `send`s the durable Order `arm` op for EACH
+ * minted order. This is proven end-to-end through the REAL cross-runtime seam
+ * (order-workflow §1): a SENDER side (the action's `makeAppLayer` graph, wired
+ * with `Env.database` Some so `Order.appSenderLayer` builds the real sender over
+ * the shared sqlite FILE) and a RUNNER side (the `ServerLive` analog — the
+ * in-process Sharding runner that consumes the mailbox + runs the `arm`
+ * handler). The two graphs coordinate ONLY through (a) the shared sqlite FILE
+ * (the `cluster_messages`/`cluster_replies` rows) and (b) the shared bucket (the
+ * one Map-backed `Storage` BOTH the action's `Submissions` and the runner's
+ * `Submissions` read) — exactly the production topology, where both share the
+ * external bucket + the DB file.
+ *
+ * The assertion: after the action mints + freezes the order(s) and `send`s
+ * `arm`, the runner consumes the send, the `arm` handler read-backs the bucket
+ * order (the SHARED bucket), and a sender's `waitFor` observes the `arm` reply
+ * terminal Success — proving the action actually dispatched the durable anchor.
+ */
+
+/** A SINGLE shared Map-backed `Storage` layer (one instance across BOTH graphs). */
+const sharedStorageLayer = (
+  seed: Record<string, { body: string }> = {},
+): Layer.Layer<Storage.Service> => {
+  const entries = new Map<string, { body: string; contentType: string }>();
+  for (const [key, object] of Object.entries(seed)) {
+    entries.set(key, { body: object.body, contentType: 'application/json' });
+  }
+  return Layer.sync(Storage.Service, () =>
+    Storage.Service.of({
+      get: Effect.fn('Storage.get')(function* (key: string) {
+        const object = entries.get(key);
+        if (object === undefined) return yield* new NotFound({ key });
+        return {
+          stream: new Response(object.body).body ?? new ReadableStream<Uint8Array>(),
+          contentType: object.contentType,
+          size: new TextEncoder().encode(object.body).byteLength,
+        };
+      }),
+      put: Effect.fn('Storage.put')((key: string, body: string | Uint8Array, contentType: string) =>
+        Effect.sync(() => {
+          entries.set(key, { body: String(body), contentType });
+        }),
+      ),
+      head: Effect.fn('Storage.head')((key: string) =>
+        Effect.sync(() =>
+          entries.has(key)
+            ? Option.some<ObjectHead>({
+                size: 0,
+                contentType: 'application/json',
+                lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+                etag: `"${key}"`,
+              })
+            : Option.none<ObjectHead>(),
+        ),
+      ),
+      list: Effect.fn('Storage.list')((prefix?: string) =>
+        Effect.sync(() =>
+          [...entries.keys()]
+            .filter((key) => prefix === undefined || key.startsWith(prefix))
+            .map((key) => ({
+              key,
+              size: 0,
+              lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+            })),
+        ),
+      ),
+      delete: Effect.fn('Storage.delete')((key: string) =>
+        Effect.sync(() => {
+          entries.delete(key);
+        }),
+      ),
+    }),
+  );
+};
+
+const tmpDbFile = (suffix: string): string =>
+  `${tmpdir()}/gyc-order-action-${process.pid}-${Date.now()}-${suffix}.sqlite`;
+
+/** The DB+stripe-enabled env: a sqlite FILE on disk (NOT `:memory:` — the two graphs share it). */
+const dbStripeEnv = (dbFile: string): Record<string, string> => ({
+  ...STRIPE_ENABLED_ENV,
+  DATABASE_URL: dbFile,
+});
+
+/**
+ * Drive a registration POST through a DB-enabled action graph (the sender) over
+ * a shared sqlite FILE + shared bucket, with a live runner graph consuming the
+ * mailbox, then return the runner-side `waitFor` outcome for each minted order's
+ * `arm` op. Resolves to the orders minted + the per-order arm reply tags.
+ */
+const runActionAndAwaitArms = async (
+  body: URLSearchParams,
+  seed: Record<string, { body: string }>,
+): Promise<{ orders: ReadonlyArray<RegistrationOrder>; armTags: ReadonlyArray<string> }> => {
+  const dbFile = tmpDbFile('arms');
+  const storage = sharedStorageLayer(seed);
+  const config = ConfigProvider.layer(
+    ConfigProvider.fromEnv({ env: dbStripeEnv(dbFile) }),
+  );
+
+  // The runner graph (ServerLive analog): the FULL runner over the shared FILE +
+  // the arm/settle/… handlers, with `Submissions` over the SHARED bucket so the
+  // `arm` handler's bucket read-back sees the order the action wrote.
+  const runnerLayer = Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
+    Layer.provide(
+      Layer.provideMerge(
+        Submissions.layer,
+        Layer.provideMerge(Content.layer, storage),
+      ),
+    ),
+    Layer.provide(Payment.testLayer()),
+    Layer.provide(Env.layer),
+    Layer.provide(config),
+  );
+  const runner = ManagedRuntime.make(runnerLayer);
+
+  // The sender graph that reads the arm replies (the webhook analog), over the
+  // SAME file — a SEPARATE sender build (distinct SqlClient).
+  const sender = ManagedRuntime.make(
+    Order.senderLayer(Order.MessageStorageLive).pipe(
+      Layer.provide(Env.layer),
+      Layer.provide(config),
+    ),
+  );
+
+  try {
+    // Boot the runner so its mailbox-poll fiber consumes the shared file.
+    await runner.runPromise(Effect.void);
+
+    // The action graph (the AppRuntime sender analog): the real `makeAppLayer`
+    // over the SHARED bucket + the DB env, so `Order.appSenderLayer` builds the
+    // real sender and `armOrder` dispatches over the shared file.
+    const actionRuntime = makeRequestRuntimeFromLayer(
+      makeAppLayer(storage, Payment.testLayer()).pipe(
+        Layer.provide(config),
+      ) as AppLayer,
+    );
+    const action = registrationAction({
+      notify: () => Effect.void,
+      notifyPaymentLink: noopPaymentLink,
+      success,
+      perRegistrantSuccess,
+    });
+    await action(makeRegistrationArgs(actionRuntime, body)).catch(() => {});
+
+    const orders = await listOrders(
+      actionRuntime,
+      makeRegistrationArgs(actionRuntime, body),
+    );
+
+    // For each minted order, the runner-side `arm` reply observed terminal. The
+    // `arm` payload-input requires every key (encore's mapped type re-requires
+    // them — `id` ignores all but `orderId`, but the INPUT shape is full), so the
+    // `waitFor` payload is reconstructed from the minted order.
+    const armTags = await Promise.all(
+      orders.map((entry) =>
+        sender.runPromise(
+          Order.Entity.arm.waitFor(
+            {
+              orderId: entry.order.orderId,
+              mode: entry.order.mode,
+              amount: entry.order.amount,
+              currency: entry.order.currency,
+              receiptEmail: entry.order.receiptEmail,
+              sessionId: entry.order.sessionId,
+              registrantIds: entry.order.registrantIds,
+              deadline: entry.order.deadline,
+            },
+            { filter: (r) => isSuccess(r) },
+          ),
+        ).then((r) => r._tag),
+      ),
+    );
+
+    return { orders: orders.map((e) => e.order), armTags };
+  } finally {
+    await runner.dispose();
+    await sender.dispose();
+  }
+};
+
+describe('registrationAction — durable Order arm send (order-workflow G7.1)', () => {
+  it('group: the action sends ONE arm op that the runner anchors to Success', async () => {
+    const { orders, armTags } = await runActionAndAwaitArms(
+      groupBody(2),
+      pricedRegistrationObject(),
+    );
+    // Exactly ONE order minted (group), and its `arm` op resolved Success on the
+    // runner — the action dispatched the durable anchor.
+    expect(orders.length).toBe(1);
+    expect(armTags).toEqual(['Success']);
+  });
+
+  it('perRegistrant: the action sends N arm ops, each anchored to Success', async () => {
+    const { orders, armTags } = await runActionAndAwaitArms(
+      perRegistrantBody(3),
+      pricedRegistrationObject(),
+    );
+    // THREE orders minted (one per registrant), each `arm` op resolved Success —
+    // the N-per-request fan-out (Risk 6) each anchored its own entity.
+    expect(orders.length).toBe(3);
+    expect(armTags).toEqual(['Success', 'Success', 'Success']);
+  });
+
+  it('zero-amount (unpriced form): no order minted ⇒ no arm op sent', async () => {
+    // An unpriced form mints NO order, so there is nothing to anchor — the arm
+    // send is per-order, so zero orders ⇒ zero sends (no spurious entity).
+    const { orders, armTags } = await runActionAndAwaitArms(groupBody(2), {});
+    expect(orders.length).toBe(0);
+    expect(armTags).toEqual([]);
   });
 });

--- a/app/lib/forms/registration-action.ts
+++ b/app/lib/forms/registration-action.ts
@@ -202,11 +202,13 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
     // and a `StorageError` on registrant K aborts after 0..K-1 are already durable. A
     // user retry would otherwise re-mint fresh ids and DUPLICATE the records that did
     // land. Scoping each registrant's id to `<request fingerprint>:<index>` makes the
-    // retry overwrite the same K objects instead: the fingerprint is a stable hash of
-    // THIS submission's payload (identical on a verbatim retry, different for a new
-    // submission even with identical data), and the index pins each registrant to its
-    // position. So retrying a group of 4 that failed at #3 re-writes #1/#2 in place and
-    // completes #3/#4 — no duplicates — while a genuinely new submission gets new ids.
+    // retry overwrite the same K objects instead: each registrant id is content-addressed
+    // by `<request fingerprint>:<index>`, where the fingerprint is a stable hash of THIS
+    // submission's payload and the index pins each registrant to its position. Identical
+    // payloads intentionally reuse the same ids (a verbatim retry overwrites in place); a
+    // payload that differs in any field produces a different fingerprint and fresh ids. So
+    // retrying a group of 4 that failed at #3 re-writes #1/#2 in place and completes #3/#4
+    // — no duplicates — while a changed submission gets new ids.
     const requestFingerprint = createHash('sha256')
       .update(JSON.stringify(submission.payload))
       .digest('hex');

--- a/app/lib/forms/registration-action.ts
+++ b/app/lib/forms/registration-action.ts
@@ -20,6 +20,7 @@ import { Toast } from '../toast.server';
 
 import type { SuccessToast } from './action';
 import type { RegistrationOrder } from './order';
+import { OrderConflict } from './order-conflict';
 import { priceGroup, priceRegistrant } from './price';
 import { registrationShellSchema } from './registration-shell';
 import type { Submission } from './submission';
@@ -281,6 +282,12 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
       // we redirect the visitor to it so they begin paying. perRegistrant never
       // sets this — it cannot redirect (N sessions, one browser), it mails instead.
       let groupSessionUrl: string | undefined;
+      // A same-payload group resubmit whose order is ALREADY paid (H1 case a) —
+      // no new session is minted, the registrants are NOT restamped, and the
+      // visitor lands on the existing success/receipt toast (NOT a Stripe url, the
+      // order is settled). Distinct from `groupSessionUrl` (a live pending session
+      // to pay) so the handoff below can tell "go pay" from "already paid".
+      let groupAlreadyPaid = false;
       // The perRegistrant payment links minted this submission, one per registrant
       // session. After the loop persists every session+order `pending`, each
       // registrant is MAILED their own hosted `url` (round-2 --deep BLOCKER:
@@ -305,52 +312,98 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
           // The receipt routes to the NOMINATED payer (possibly a non-attendee),
           // frozen here so a later edit cannot retro-redirect the receipt (2b.6).
           const receiptEmail = party.payer.email;
-          // One Checkout Session per party, keyed off the request fingerprint + mode
-          // (Decision 2): a verbatim retry re-derives the same key ⇒ Stripe replays
-          // the first session (no second checkout); a changed payload ⇒ a new one.
-          const idempotencyKey = `registration:checkout:${requestFingerprint}:group`;
-          const session = yield* payment.createCheckoutSession({
-            amount,
-            currency,
-            receiptEmail,
-            productName,
-            successUrl,
-            cancelUrl,
-            metadata: { orderId: requestFingerprint, mode: 'group' },
-            idempotencyKey,
-          });
-          groupSessionUrl = session.url;
-          // Freeze the order record (Decision 7 step 3) — ONE order keyed by the
-          // fingerprint, `registrantIds` = the whole party, amount + receiptEmail
-          // frozen, `sessionId` = the Checkout Session. The webhook (C8) reads it
-          // back to mark it `paid`.
-          const order: RegistrationOrder = {
-            orderId: requestFingerprint,
-            mode: 'group',
-            sessionId: session.sessionId,
-            amount,
-            currency,
-            receiptEmail,
-            status: 'pending',
-            registrantIds: stored.map((registrant) => registrant.id),
-          };
-          yield* submissions.persistOrder('registration', order);
-          // Anchor the durable Order entity at `pending` (G7.1) — fire-and-forget
-          // after the freeze, gated on `Env.database` Some, never blocking the
-          // redirect.
-          yield* armOrder(order);
-          // Stamp each party registrant `pending` on its OWN submission envelope
-          // (plan :695) so a registrant record carries its payment lifecycle, not
-          // just the order. The webhook (C8) flips these to `paid`/`failed` in
-          // lock-step. Frozen mode/amount/currency mirror the order.
-          for (const id of order.registrantIds) {
-            yield* submissions.setRegistrantPayment('registration', id, {
-              _tag: 'pending',
-              orderId: order.orderId,
-              mode: order.mode,
-              amount: order.amount,
-              currency: order.currency,
+          // Resolve the order SLOT this resubmit lands on BEFORE minting a session
+          // (order-workflow round-2 --deep H1). The deterministic `orderId` is the
+          // request fingerprint, stable across a verbatim resubmit, so blindly
+          // re-minting + persisting would overwrite whatever order already lives
+          // there. `resolveOrderSlot` reads it first: an ALREADY-paid order short-
+          // circuits with NO new session (case a); a non-paid TERMINAL (the user
+          // re-registering past a dead order) walks to a fresh generation (case c);
+          // a live `pending` reuses the same slot (case b).
+          const slot = yield* submissions.resolveOrderSlot(
+            'registration',
+            requestFingerprint,
+          );
+          if (
+            Option.isSome(slot.existing) &&
+            slot.existing.value.status === 'paid'
+          ) {
+            // Case (a): the order is already paid — return the existing receipt,
+            // do NOT mint a new session, do NOT restamp registrants.
+            groupAlreadyPaid = true;
+          } else {
+            // One Checkout Session per party, keyed off the RESOLVED orderId + mode
+            // (Decision 2 + H1 case c): a verbatim retry re-derives the same slot ⇒
+            // Stripe replays the first session (no second checkout); a fresh
+            // generation after a dead terminal derives a NEW key ⇒ a new session.
+            const idempotencyKey = `registration:checkout:${slot.orderId}:group`;
+            const session = yield* payment.createCheckoutSession({
+              amount,
+              currency,
+              receiptEmail,
+              productName,
+              successUrl,
+              cancelUrl,
+              metadata: { orderId: slot.orderId, mode: 'group' },
+              idempotencyKey,
             });
+            groupSessionUrl = session.url;
+            // Freeze the order record (Decision 7 step 3) — ONE order keyed by the
+            // resolved orderId, `registrantIds` = the whole party, amount +
+            // receiptEmail frozen, `sessionId` = the Checkout Session. The webhook
+            // (C8) reads it back to mark it `paid`.
+            const proposed: RegistrationOrder = {
+              orderId: slot.orderId,
+              mode: 'group',
+              sessionId: session.sessionId,
+              amount,
+              currency,
+              receiptEmail,
+              status: 'pending',
+              registrantIds: stored.map((registrant) => registrant.id),
+            };
+            // Commit through the guarded create/reuse path (H1): a fresh slot
+            // WRITES the pending order; a live pending with matching frozen fields
+            // REUSES it (no overwrite, no restamp); a conflicting pending FAILS
+            // explicitly. An `OrderConflict` (case d) is surfaced as a form-level
+            // validation error — the same channel a decode failure uses — so the
+            // visitor sees an explicit conflict message rather than a silent
+            // overwrite of the in-flight order's frozen amount/receipt.
+            const outcome = yield* submissions
+              .createOrReuseOrder('registration', proposed)
+              .pipe(
+                Effect.catchTag('Order.Conflict', (conflict: OrderConflict) =>
+                  formValidationError({
+                    formErrors: [
+                      `registration.checkout.conflict:${conflict.reason}`,
+                    ],
+                  }),
+                ),
+              );
+            // Only a freshly-CREATED order is anchored + restamped; a `reused`
+            // pending was already armed + stamped on its first submit (byte-
+            // identical replay — re-doing it is harmless but unnecessary).
+            if (outcome._tag === 'created') {
+              const order = outcome.order;
+              // Anchor the durable Order entity at `pending` (G7.1) — fire-and-
+              // forget after the freeze, gated on `Env.database` Some, never
+              // blocking the redirect.
+              yield* armOrder(order);
+              // Stamp each party registrant `pending` on its OWN submission
+              // envelope (plan :695) so a registrant record carries its payment
+              // lifecycle, not just the order. The webhook (C8) flips these to
+              // `paid`/`failed` in lock-step. Frozen mode/amount/currency mirror
+              // the order.
+              for (const id of order.registrantIds) {
+                yield* submissions.setRegistrantPayment('registration', id, {
+                  _tag: 'pending',
+                  orderId: order.orderId,
+                  mode: order.mode,
+                  amount: order.amount,
+                  currency: order.currency,
+                });
+              }
+            }
           }
         }
       } else {
@@ -366,8 +419,27 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
           // line items and there is nothing to collect.
           if (amount <= 0) continue;
           const receiptEmail = registrant['email'] as string;
-          const orderId = `${requestFingerprint}:${index}`;
-          const idempotencyKey = `registration:checkout:${requestFingerprint}:perRegistrant:${index}`;
+          const baseOrderId = `${requestFingerprint}:${index}`;
+          // Resolve THIS registrant's order slot BEFORE minting a session (H1).
+          // The deterministic `<fingerprint>:<index>` orderId is stable across a
+          // verbatim resubmit; `resolveOrderSlot` reads it first so an already-paid
+          // registrant order is not re-charged (case a — skip the session + mail),
+          // a dead-terminal one walks to a fresh generation (case c), and a live
+          // pending reuses its replayed session (case b).
+          const slot = yield* submissions.resolveOrderSlot(
+            'registration',
+            baseOrderId,
+          );
+          // Case (a): this registrant's order is already paid — do NOT mint a new
+          // session, do NOT mail a payment link, do NOT restamp. The other
+          // registrants in the party still process their own slots.
+          if (
+            Option.isSome(slot.existing) &&
+            slot.existing.value.status === 'paid'
+          ) {
+            continue;
+          }
+          const idempotencyKey = `registration:checkout:${slot.orderId}:perRegistrant`;
           const session = yield* payment.createCheckoutSession({
             amount,
             currency,
@@ -375,14 +447,11 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
             productName,
             successUrl,
             cancelUrl,
-            metadata: { orderId, mode: 'perRegistrant' },
+            metadata: { orderId: slot.orderId, mode: 'perRegistrant' },
             idempotencyKey,
           });
-          // Pair THIS session's hosted url with the registrant it pays for, so the
-          // post-loop fan-out mails each registrant their own link (not a redirect).
-          paymentLinks.push({ submission: stored[index]!, url: session.url });
-          const order: RegistrationOrder = {
-            orderId,
+          const proposed: RegistrationOrder = {
+            orderId: slot.orderId,
             mode: 'perRegistrant',
             sessionId: session.sessionId,
             amount,
@@ -391,25 +460,50 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
             status: 'pending',
             registrantIds: [stored[index]!.id],
           };
-          yield* submissions.persistOrder('registration', order);
-          // Anchor the durable Order entity for THIS perRegistrant order (G7.1) —
-          // one `arm` send per minted order (N per request), each keyed by its
-          // own `<fingerprint>:<index>` orderId.
-          yield* armOrder(order);
-          // Stamp THIS registrant `pending` on its own submission envelope (plan
-          // :695) — one registrant per perRegistrant order. The webhook flips it
-          // `paid`/`failed` in lock-step.
-          yield* submissions.setRegistrantPayment(
-            'registration',
-            stored[index]!.id,
-            {
-              _tag: 'pending',
-              orderId: order.orderId,
-              mode: order.mode,
-              amount: order.amount,
-              currency: order.currency,
-            },
-          );
+          // Commit through the guarded create/reuse path (H1): a fresh slot WRITES
+          // the pending order; a live pending with matching frozen fields REUSES it
+          // (no overwrite, no restamp); a conflicting pending FAILS explicitly,
+          // surfaced as a form-level validation error (same channel as a decode
+          // failure).
+          const outcome = yield* submissions
+            .createOrReuseOrder('registration', proposed)
+            .pipe(
+              Effect.catchTag('Order.Conflict', (conflict: OrderConflict) =>
+                formValidationError({
+                  formErrors: [
+                    `registration.checkout.conflict:${conflict.reason}`,
+                  ],
+                }),
+              ),
+            );
+          // Pair the session's hosted url with the registrant it pays for, so the
+          // post-loop fan-out mails each registrant their own link. Both a fresh
+          // `created` order and a `reused` live pending get the (replayed) link —
+          // the user still needs to pay an un-settled order.
+          paymentLinks.push({ submission: stored[index]!, url: session.url });
+          // Only a freshly-CREATED order is anchored + restamped; a `reused`
+          // pending was already armed + stamped on its first submit.
+          if (outcome._tag === 'created') {
+            const order = outcome.order;
+            // Anchor the durable Order entity for THIS perRegistrant order (G7.1) —
+            // one `arm` send per minted order (N per request), each keyed by its
+            // own resolved orderId.
+            yield* armOrder(order);
+            // Stamp THIS registrant `pending` on its own submission envelope (plan
+            // :695) — one registrant per perRegistrant order. The webhook flips it
+            // `paid`/`failed` in lock-step.
+            yield* submissions.setRegistrantPayment(
+              'registration',
+              stored[index]!.id,
+              {
+                _tag: 'pending',
+                orderId: order.orderId,
+                mode: order.mode,
+                amount: order.amount,
+                currency: order.currency,
+              },
+            );
+          }
         }
       }
 
@@ -431,6 +525,20 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
       //            sessions+orders are already durable + `pending`, so a mail
       //            failure surfaces a form error WITHOUT losing them
       //            (persist-then-notify, :56).
+      // H1 case (a) for group: the order was already paid on a prior submit — no
+      // new session was minted, so there is nothing to pay. Return the existing
+      // success/receipt (the same success toast a first-time settled redirect
+      // shows), NOT a Stripe url. The webhook already delivered the receipt; this
+      // is the idempotent "you already paid" landing for a same-payload resubmit.
+      if (groupAlreadyPaid) {
+        yield* config.notify(stored);
+        return yield* toast.redirect(url.pathname, {
+          title: config.success.title,
+          description: config.success.description,
+          type: 'success',
+          form: 'registration',
+        });
+      }
       if (groupSessionUrl !== undefined) {
         return yield* redirect(groupSessionUrl, { status: 303 });
       }

--- a/app/lib/forms/registration-action.ts
+++ b/app/lib/forms/registration-action.ts
@@ -14,6 +14,7 @@ import {
 import { formatSchemaResult, parseSchema } from '../effect/form-schema';
 import { ReactRouterContext } from '../effect/router-context';
 import { Mailer } from '../mailer.server';
+import { Order } from '../order/runner.server';
 import { Payment } from '../payment.server';
 import { Toast } from '../toast.server';
 
@@ -127,6 +128,46 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
 
     const env = yield* Env.Service;
     const payment = yield* Payment.Service;
+
+    // The durable Order lifecycle anchor (order-workflow G7.1). After the action
+    // synchronously mints + freezes a `RegistrationOrder` (the freeze stays at
+    // this boundary — UNCHANGED below), it `send`s the Order `arm` op to record
+    // the entity into existence at `pending`: a durable, fire-and-forget anchor
+    // that does NOT block the redirect/mail handoff and does NOT re-create the
+    // session. Gated on `Env.database` Some — a DB-less deploy skips the send and
+    // the bucket path is byte-identically unchanged (the runner that consumes the
+    // mailbox only exists when a DB is configured). A `send` fault is NOT allowed
+    // to fail the registration: the bucket order is ALREADY durable (the
+    // authority) and the webhook still reconciles it, so an arm-send failure is
+    // logged and swallowed — the anchor is complementary to the bucket, never a
+    // gate on it. Idempotency STRENGTHENS: a verbatim retry re-`send`s `arm` for
+    // the SAME `orderId` ⇒ encore's primaryKey dedup collapses it to no second
+    // entity, complementing the existing bucket-overwrite idempotency.
+    const armOrder = (
+      order: RegistrationOrder,
+    ): Effect.Effect<void, never, Order.SenderServices> =>
+      Option.isNone(env.database) ?
+        Effect.void
+      : Order.Entity.arm
+          .send({
+            orderId: order.orderId,
+            mode: order.mode,
+            amount: order.amount,
+            currency: order.currency,
+            receiptEmail: order.receiptEmail,
+            sessionId: order.sessionId,
+            registrantIds: order.registrantIds,
+            deadline: order.deadline,
+          })
+          .pipe(
+            Effect.asVoid,
+            Effect.catchCause((cause) =>
+              Effect.logError(
+                `Order.arm send failed for ${order.orderId} (bucket order is durable; webhook still reconciles)`,
+                cause,
+              ),
+            ),
+          );
 
     const definition = yield* content.getForm('registration');
 
@@ -294,6 +335,10 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
             registrantIds: stored.map((registrant) => registrant.id),
           };
           yield* submissions.persistOrder('registration', order);
+          // Anchor the durable Order entity at `pending` (G7.1) — fire-and-forget
+          // after the freeze, gated on `Env.database` Some, never blocking the
+          // redirect.
+          yield* armOrder(order);
           // Stamp each party registrant `pending` on its OWN submission envelope
           // (plan :695) so a registrant record carries its payment lifecycle, not
           // just the order. The webhook (C8) flips these to `paid`/`failed` in
@@ -347,6 +392,10 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
             registrantIds: [stored[index]!.id],
           };
           yield* submissions.persistOrder('registration', order);
+          // Anchor the durable Order entity for THIS perRegistrant order (G7.1) —
+          // one `arm` send per minted order (N per request), each keyed by its
+          // own `<fingerprint>:<index>` orderId.
+          yield* armOrder(order);
           // Stamp THIS registrant `pending` on its own submission envelope (plan
           // :695) — one registrant per perRegistrant order. The webhook flips it
           // `paid`/`failed` in lock-step.

--- a/app/lib/forms/registration-action.ts
+++ b/app/lib/forms/registration-action.ts
@@ -294,6 +294,16 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
       // redirecting to only the first stranded registrants 2..N forever). Each
       // order reconciles independently off its own `checkout.session.completed`.
       const paymentLinks: Array<{ submission: Submission; url: string }> = [];
+      // perRegistrant idempotent all-paid resubmit (round-3 --deep MAJOR 1).
+      // Count the chargeable registrant slots (`amount > 0`) and how many of them
+      // resolved already-PAID (a same-payload resubmit after every registrant
+      // settled). When EVERY chargeable slot is already paid, `paymentLinks` is
+      // empty AND there is nothing left to pay — so the action must land on the
+      // existing `?checkout=success` receipt state, NOT fall through to the legacy
+      // notify/toast (which would re-send the admin notification + show the wrong
+      // copy). A mix (some paid, some pending) still mails the un-paid links.
+      let perRegistrantChargeable = 0;
+      let perRegistrantAlreadyPaid = 0;
       // ONE `now` for the whole submission (Decision 6) — every frozen amount in
       // this checkout reads the same instant, so a window boundary cannot split a
       // single submit across two prices.
@@ -347,7 +357,6 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
               metadata: { orderId: slot.orderId, mode: 'group' },
               idempotencyKey,
             });
-            groupSessionUrl = session.url;
             // Freeze the order record (Decision 7 step 3) — ONE order keyed by the
             // resolved orderId, `registrantIds` = the whole party, amount +
             // receiptEmail frozen, `sessionId` = the Checkout Session. The webhook
@@ -380,20 +389,45 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
                   }),
                 ),
               );
-            // Only a freshly-CREATED order is anchored + restamped; a `reused`
-            // pending was already armed + stamped on its first submit (byte-
-            // identical replay — re-doing it is harmless but unnecessary).
-            if (outcome._tag === 'created') {
+            // Branch on the FULL outcome union AT the commit boundary (round-3
+            // --deep BLOCKER 1). `resolveOrderSlot` read the slot live-pending (or
+            // absent), but the order may have flipped to PAID in the window before
+            // this guarded re-read — so the commit, not the pre-mint resolve, is
+            // the authority on whether to hand the browser to Stripe. Setting
+            // `groupSessionUrl` only on a non-paid outcome (and never on
+            // `alreadyPaid`) is what stops the action redirecting a now-settled
+            // order back to a Checkout page.
+            if (outcome._tag === 'alreadyPaid') {
+              // Paid between resolve and commit (the race): the just-minted session
+              // is moot — do NOT redirect to Stripe, do NOT restamp. Return the
+              // existing success/receipt (the confirmed UX), exactly as the
+              // pre-mint paid fast-path above does.
+              groupAlreadyPaid = true;
+            } else {
+              // `created` or `reused` ⇒ a live pending order the visitor still must
+              // pay; hand them to the (replayed) hosted Checkout url.
+              groupSessionUrl = session.url;
               const order = outcome.order;
               // Anchor the durable Order entity at `pending` (G7.1) — fire-and-
               // forget after the freeze, gated on `Env.database` Some, never
-              // blocking the redirect.
-              yield* armOrder(order);
+              // blocking the redirect. Only a freshly-CREATED order arms (a
+              // `reused` pending was already armed on its first submit; encore's
+              // primaryKey dedup would collapse a second `arm` anyway, but skipping
+              // it is the cheaper path).
+              if (outcome._tag === 'created') {
+                yield* armOrder(order);
+              }
               // Stamp each party registrant `pending` on its OWN submission
-              // envelope (plan :695) so a registrant record carries its payment
-              // lifecycle, not just the order. The webhook (C8) flips these to
-              // `paid`/`failed` in lock-step. Frozen mode/amount/currency mirror
-              // the order.
+              // envelope (plan :695) — on BOTH `created` AND `reused` (round-3
+              // --deep BLOCKER 2). A `created` order stamps for the first time; a
+              // `reused` order RE-stamps to self-heal a prior submit that wrote the
+              // order but FAILED mid-stamp-loop (the partial write would otherwise
+              // strand those registrants un-stamped FOREVER, since every retry sees
+              // the order as `reused` and used to skip stamping). Re-stamping a
+              // `pending` order's registrants is byte-identical idempotent (the
+              // order is pending ⇒ its registrants are pending by lock-step), so a
+              // clean reuse re-writes the same content. Frozen mode/amount/currency
+              // mirror the order.
               for (const id of order.registrantIds) {
                 yield* submissions.setRegistrantPayment('registration', id, {
                   _tag: 'pending',
@@ -418,6 +452,8 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
           // others in the party still mint theirs) — Stripe rejects zero-amount
           // line items and there is nothing to collect.
           if (amount <= 0) continue;
+          // A chargeable slot (counted for the all-paid resubmit decision below).
+          perRegistrantChargeable += 1;
           const receiptEmail = registrant['email'] as string;
           const baseOrderId = `${requestFingerprint}:${index}`;
           // Resolve THIS registrant's order slot BEFORE minting a session (H1).
@@ -437,6 +473,7 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
             Option.isSome(slot.existing) &&
             slot.existing.value.status === 'paid'
           ) {
+            perRegistrantAlreadyPaid += 1;
             continue;
           }
           const idempotencyKey = `registration:checkout:${slot.orderId}:perRegistrant`;
@@ -476,34 +513,46 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
                 }),
               ),
             );
-          // Pair the session's hosted url with the registrant it pays for, so the
-          // post-loop fan-out mails each registrant their own link. Both a fresh
-          // `created` order and a `reused` live pending get the (replayed) link —
-          // the user still needs to pay an un-settled order.
-          paymentLinks.push({ submission: stored[index]!, url: session.url });
-          // Only a freshly-CREATED order is anchored + restamped; a `reused`
-          // pending was already armed + stamped on its first submit.
-          if (outcome._tag === 'created') {
-            const order = outcome.order;
-            // Anchor the durable Order entity for THIS perRegistrant order (G7.1) —
-            // one `arm` send per minted order (N per request), each keyed by its
-            // own resolved orderId.
-            yield* armOrder(order);
-            // Stamp THIS registrant `pending` on its own submission envelope (plan
-            // :695) — one registrant per perRegistrant order. The webhook flips it
-            // `paid`/`failed` in lock-step.
-            yield* submissions.setRegistrantPayment(
-              'registration',
-              stored[index]!.id,
-              {
-                _tag: 'pending',
-                orderId: order.orderId,
-                mode: order.mode,
-                amount: order.amount,
-                currency: order.currency,
-              },
-            );
+          // Branch on the FULL outcome union AT the commit boundary (round-3
+          // --deep BLOCKER 1). The pre-mint `slot` read saw this registrant's
+          // order live-pending (or absent), but it may have flipped to PAID in the
+          // window before this guarded re-read. If so, do NOT mail a payment link
+          // (the order is settled — a link would re-charge an already-paid
+          // registrant) and do NOT restamp; just skip to the next registrant.
+          if (outcome._tag === 'alreadyPaid') {
+            perRegistrantAlreadyPaid += 1;
+            continue;
           }
+          const order = outcome.order;
+          // Pair the (replayed) session url with the registrant it pays for, so the
+          // post-loop fan-out mails each registrant their own link. Both a fresh
+          // `created` order and a `reused` live pending get the link — the user
+          // still must pay an un-settled order. (`alreadyPaid` already `continue`d.)
+          paymentLinks.push({ submission: stored[index]!, url: session.url });
+          // Anchor the durable Order entity for THIS perRegistrant order (G7.1) —
+          // one `arm` send per minted order — only on a freshly-CREATED order; a
+          // `reused` pending was already armed on its first submit.
+          if (outcome._tag === 'created') {
+            yield* armOrder(order);
+          }
+          // Stamp THIS registrant `pending` on its own submission envelope (plan
+          // :695) — on BOTH `created` AND `reused` (round-3 --deep BLOCKER 2). A
+          // `reused` re-stamp self-heals a prior submit that wrote the order but
+          // FAILED before stamping (every retry sees `reused` and used to skip the
+          // stamp, stranding the registrant un-stamped forever). Re-stamping a
+          // `pending` order's registrant is byte-identical idempotent. The webhook
+          // flips it `paid`/`failed` in lock-step.
+          yield* submissions.setRegistrantPayment(
+            'registration',
+            stored[index]!.id,
+            {
+              _tag: 'pending',
+              orderId: order.orderId,
+              mode: order.mode,
+              amount: order.amount,
+              currency: order.currency,
+            },
+          );
         }
       }
 
@@ -525,18 +574,24 @@ export const registrationAction = <E>(config: RegistrationActionConfig<E>) =>
       //            sessions+orders are already durable + `pending`, so a mail
       //            failure surfaces a form error WITHOUT losing them
       //            (persist-then-notify, :56).
-      // H1 case (a) for group: the order was already paid on a prior submit — no
-      // new session was minted, so there is nothing to pay. Return the existing
-      // success/receipt (the same success toast a first-time settled redirect
-      // shows), NOT a Stripe url. The webhook already delivered the receipt; this
-      // is the idempotent "you already paid" landing for a same-payload resubmit.
-      if (groupAlreadyPaid) {
-        yield* config.notify(stored);
-        return yield* toast.redirect(url.pathname, {
-          title: config.success.title,
-          description: config.success.description,
-          type: 'success',
-          form: 'registration',
+      // Idempotent already-PAID resubmit (round-3 --deep MAJOR 1): the order(s)
+      // were already paid on a prior submit, so nothing was minted to pay. The
+      // CONFIRMED UX is to land on the EXISTING `?checkout=success` receipt state —
+      // the SAME url Stripe returns the visitor to on a first-time completion (the
+      // form renders the "payment received — check your email" panel off
+      // `?checkout=success`). This explicitly does NOT call `config.notify` (that
+      // sends the admin `[!] Registration…` mail — re-sending it on every paid
+      // resubmit would duplicate the notification) and does NOT show the legacy
+      // success toast. Covers BOTH a group already-paid resubmit AND a
+      // perRegistrant resubmit where EVERY chargeable registrant is already paid
+      // (a mix still mails the un-paid links below).
+      const allPaidResubmit =
+        groupAlreadyPaid ||
+        (perRegistrantChargeable > 0 &&
+          perRegistrantAlreadyPaid === perRegistrantChargeable);
+      if (allPaidResubmit) {
+        return yield* redirect(`${url.origin}${url.pathname}?checkout=success`, {
+          status: 303,
         });
       }
       if (groupSessionUrl !== undefined) {

--- a/app/lib/forms/submission.ts
+++ b/app/lib/forms/submission.ts
@@ -110,6 +110,26 @@ export const PaymentState = Schema.TaggedUnion({
     amount: Cents,
     currency: CurrencyCode,
   },
+  // the order was cancelled before it settled (operator/abandon — G5). Carries
+  // the frozen amount/currency it would have charged; nothing was collected, so
+  // there is no `paidAt` (distinct from `failed`, which is a Stripe
+  // `async_payment_failed`).
+  cancelled: {
+    orderId: Schema.String,
+    mode: BillingMode,
+    amount: Cents,
+    currency: CurrencyCode,
+  },
+  // a settled (`paid`) order was refunded (G5) — `refundedAt` is the calendar
+  // date the refund was issued. Carries the frozen amount/currency that was
+  // charged then returned; this is the only arm reachable from `paid`.
+  refunded: {
+    orderId: Schema.String,
+    mode: BillingMode,
+    amount: Cents,
+    currency: CurrencyCode,
+    refundedAt: IsoDate,
+  },
 });
 export type PaymentState = typeof PaymentState.Type;
 

--- a/app/lib/forms/submissions.server.test.ts
+++ b/app/lib/forms/submissions.server.test.ts
@@ -6,12 +6,14 @@ import {
   defaultContactForm,
   defaultRegistrationForm,
 } from '../content/pages/defaults';
-import { submissionKey } from '../content/pages/registry';
-import { ListItemId } from '../content/schema';
+import { orderKey, submissionKey } from '../content/pages/registry';
+import { IsoDate, ListItemId, newListItemId } from '../content/schema';
 import { Storage } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
 
 import { decodeForm } from './decode';
+import { RegistrationOrder } from './order';
+import { Cents, CurrencyCode } from './pricing';
 import { submissionSchema } from './submission';
 import { Submissions } from './submissions.server';
 
@@ -238,5 +240,196 @@ describe('Submissions.persist — payload derived from the FormDefinition', () =
       )(json);
       expect(back.payload).toEqual(stored.payload);
     }).pipe(provideSubmissions()),
+  );
+});
+
+/**
+ * G5 — the durable Order actor's three NEW bucket transitions
+ * (`markOrderCancelled` / `markOrderExpired` / `markOrderRefunded`), built on the
+ * SAME `flipStatus` never-downgrade-a-terminal discipline as
+ * `markOrderPaid`/`markOrderFailed`. Each pins: the legal source (cancel/expire
+ * only from `pending`; refund only from `paid`), the illegal-source no-op (an
+ * out-of-state order is left UNTOUCHED, its registrants with it), idempotent
+ * re-flip (a second flip to the same terminal returns it unchanged), and the
+ * lock-step registrant stamp (every named registrant carries the mirrored
+ * `PaymentState` arm). `markOrderRefunded` additionally pins the FROZEN
+ * `refundedAt` (the paid → refunded `derive-dont-sync` mirror of `paidAt`).
+ */
+
+/** The two registrant ids every seeded order names — seeded as real submissions. */
+const REGISTRANT_IDS: readonly ListItemId[] = [newListItemId(), newListItemId()];
+
+/** Encode a `RegistrationOrder` to the JSON shape stored on the bucket. */
+const encodeOrder = Schema.encodeSync(Schema.fromJsonString(RegistrationOrder));
+
+/** A group order at `status`, frozen at `amount`, naming {@link REGISTRANT_IDS}. */
+const orderAt = (
+  orderId: string,
+  status: RegistrationOrder['status'],
+  extra: Partial<RegistrationOrder> = {},
+): RegistrationOrder => ({
+  orderId,
+  mode: 'group',
+  sessionId: `cs_${orderId}`,
+  amount: Cents.make(15000),
+  currency: CurrencyCode.make('cad'),
+  receiptEmail: 'leader@example.com',
+  status,
+  registrantIds: [...REGISTRANT_IDS],
+  ...extra,
+});
+
+/** A minimal valid (`payment`-less) exhibitor registrant submission JSON. */
+const registrantSubmissionJson = (id: ListItemId): string =>
+  Schema.encodeSync(
+    Schema.fromJsonString(submissionSchema(defaultRegistrationForm)),
+  )(
+    Schema.decodeUnknownSync(submissionSchema(defaultRegistrationForm))({
+      id,
+      form: 'registration',
+      submittedAt: '2026-06-17',
+      payload: {
+        name: 'Ada Co',
+        phone: '123-456-7890',
+        type: 'exhibitor',
+        synopsis: 'We sell books',
+        website: 'https://example.com',
+        company: 'Ada Books',
+      },
+    }),
+  );
+
+/** Seed one order under its `orderKey` ALONGSIDE the registrant records it names. */
+const seedOrder = (order: RegistrationOrder): Parameters<typeof layerTest>[0] => ({
+  [orderKey('registration', order.orderId)]: {
+    body: encodeOrder(order),
+    contentType: 'application/json',
+  },
+  ...Object.fromEntries(
+    order.registrantIds.map((id) => [
+      submissionKey('registration', id),
+      { body: registrantSubmissionJson(id), contentType: 'application/json' },
+    ]),
+  ),
+});
+
+/** Read one stored registrant submission's `payment._tag` (or `'none'`). */
+const readRegistrantTag = (id: ListItemId) =>
+  Effect.gen(function* () {
+    const storage = yield* Storage.Service;
+    const object = yield* storage.get(submissionKey('registration', id));
+    const text = yield* Effect.promise(() => new Response(object.stream).text());
+    const decoded = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(submissionSchema(defaultRegistrationForm)),
+    )(text);
+    return decoded.payment?._tag ?? 'none';
+  });
+
+describe('Submissions.markOrderCancelled (G5)', () => {
+  it.effect('flips a pending order to cancelled + stamps each registrant', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const flipped = yield* submissions.markOrderCancelled(
+        'registration',
+        'ordc',
+      );
+      expect(flipped.status).toBe('cancelled');
+      for (const id of REGISTRANT_IDS) {
+        expect(yield* readRegistrantTag(id)).toBe('cancelled');
+      }
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordc', 'pending')))),
+  );
+
+  it.effect('NEVER downgrades a paid order (illegal source is a no-op)', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const order = yield* submissions.markOrderCancelled('registration', 'ordc');
+      // Left untouched: a paid order does not transition, and its registrants
+      // (seeded payment-less) are not stamped cancelled.
+      expect(order.status).toBe('paid');
+      for (const id of REGISTRANT_IDS) {
+        expect(yield* readRegistrantTag(id)).toBe('none');
+      }
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordc', 'paid', {
+      paidAt: IsoDate.make('2026-06-18'),
+    })))),
+  );
+
+  it.effect('is idempotent — a re-flip of an already-cancelled order is a no-op', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      yield* submissions.markOrderCancelled('registration', 'ordc');
+      const replay = yield* submissions.markOrderCancelled('registration', 'ordc');
+      expect(replay.status).toBe('cancelled');
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordc', 'pending')))),
+  );
+});
+
+describe('Submissions.markOrderExpired (G5)', () => {
+  it.effect('flips a pending order to expired + stamps each registrant', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const flipped = yield* submissions.markOrderExpired('registration', 'orde');
+      expect(flipped.status).toBe('expired');
+      for (const id of REGISTRANT_IDS) {
+        expect(yield* readRegistrantTag(id)).toBe('expired');
+      }
+    }).pipe(provideSubmissions(seedOrder(orderAt('orde', 'pending')))),
+  );
+
+  it.effect('NEVER sweeps a paid order (illegal source is a no-op)', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const order = yield* submissions.markOrderExpired('registration', 'orde');
+      expect(order.status).toBe('paid');
+    }).pipe(provideSubmissions(seedOrder(orderAt('orde', 'paid', {
+      paidAt: IsoDate.make('2026-06-18'),
+    })))),
+  );
+});
+
+describe('Submissions.markOrderRefunded (G5)', () => {
+  it.effect('flips a PAID order to refunded + freezes refundedAt + stamps registrants', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const flipped = yield* submissions.markOrderRefunded(
+        'registration',
+        'ordr',
+      );
+      expect(flipped.status).toBe('refunded');
+      // A real refund date was frozen (the paidAt mirror).
+      expect(flipped.refundedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      for (const id of REGISTRANT_IDS) {
+        expect(yield* readRegistrantTag(id)).toBe('refunded');
+      }
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordr', 'paid', {
+      paidAt: IsoDate.make('2026-06-18'),
+    })))),
+  );
+
+  it.effect('REFUSES a pending order (only paid → refunded is legal)', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const order = yield* submissions.markOrderRefunded('registration', 'ordr');
+      // Left untouched: a pending order cannot be refunded.
+      expect(order.status).toBe('pending');
+      expect(order.refundedAt).toBeUndefined();
+      for (const id of REGISTRANT_IDS) {
+        expect(yield* readRegistrantTag(id)).toBe('none');
+      }
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordr', 'pending')))),
+  );
+
+  it.effect('freezes refundedAt once — a re-flip re-reads it (idempotent terminal)', () =>
+    Effect.gen(function* () {
+      const submissions = yield* Submissions.Service;
+      const first = yield* submissions.markOrderRefunded('registration', 'ordr');
+      const replay = yield* submissions.markOrderRefunded('registration', 'ordr');
+      expect(replay.status).toBe('refunded');
+      // The frozen refund date is re-read verbatim, never re-stamped from the clock.
+      expect(replay.refundedAt).toBe(first.refundedAt);
+    }).pipe(provideSubmissions(seedOrder(orderAt('ordr', 'paid', {
+      paidAt: IsoDate.make('2026-06-18'),
+    })))),
   );
 });

--- a/app/lib/forms/submissions.server.test.ts
+++ b/app/lib/forms/submissions.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'effect-bun-test';
-import { Effect, Layer, Result, Schema } from 'effect';
+import { Clock, Effect, Layer, Result, Schema } from 'effect';
 
 import { Content } from '../content.server';
 import {
@@ -180,6 +180,125 @@ describe('Submissions.persist — durable write (Branch 7.2)', () => {
       expect(firstHead._tag).toBe('Some');
       expect(secondHead._tag).toBe('Some');
     }).pipe(provideSubmissions()),
+  );
+});
+
+/**
+ * A `Clock` whose "now" the test advances by hand, so a SECOND keyed persist runs
+ * on a DIFFERENT calendar DAY than the first. Only `currentTimeMillis*` is
+ * exercised here (that is what `persist` reads to stamp `submittedAt`); `sleep` /
+ * the nanos accessor are derived from the same backing millis. Provided as a
+ * `Context.Reference` override (`Clock.Clock`) so the whole `persist` runs under
+ * frozen-then-advanced time.
+ */
+const controllableClock = (initialMillis: number) => {
+  let nowMillis = initialMillis;
+  const clock: Clock.Clock = {
+    currentTimeMillisUnsafe: () => nowMillis,
+    currentTimeMillis: Effect.sync(() => nowMillis),
+    currentTimeNanosUnsafe: () => BigInt(nowMillis) * 1_000_000n,
+    currentTimeNanos: Effect.sync(() => BigInt(nowMillis) * 1_000_000n),
+    sleep: () => Effect.void,
+  };
+  return {
+    clock,
+    advanceTo: (millis: number) => {
+      nowMillis = millis;
+    },
+  };
+};
+
+/**
+ * round-4 --deep MAJOR — a keyed (`idempotencyKey`) resubmit must be
+ * BYTE-IDENTICAL across days, not just `payment`-preserving.
+ *
+ * The H1 fix preserved an existing record's `payment` on a keyed overwrite, but
+ * `persist` still recomputed `submittedAt` from the clock on EVERY call. So a
+ * registrant who re-submits the SAME logical record TOMORROW (a user retrying a
+ * partially-failed group, the order/webhook flow re-persisting, …) would rewrite
+ * the registrant envelope with a DIFFERENT `submittedAt` — churn even though
+ * nothing logical changed. The fix: a keyed persist that finds a prior record at
+ * the deterministic key PRESERVES that record's original `submittedAt` (when the
+ * registration was actually made), mirroring exactly how `payment` is preserved.
+ *
+ * These pin the RAW stored record (not just `payment`) across two same-key submits
+ * separated by a real day boundary, asserting the on-bucket JSON is byte-identical.
+ */
+describe('Submissions.persist — keyed resubmit is byte-identical across days (round-4 MAJOR)', () => {
+  /** 2026-06-19T10:00:00Z and the NEXT calendar day, as UTC millis. */
+  const DAY_ONE_MILLIS = Date.UTC(2026, 5, 19, 10, 0, 0);
+  const DAY_TWO_MILLIS = Date.UTC(2026, 5, 20, 11, 30, 0);
+
+  it.effect(
+    'a verbatim keyed resubmit the NEXT day preserves the original submittedAt — raw record byte-identical',
+    () => {
+      const time = controllableClock(DAY_ONE_MILLIS);
+      return Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        const decoded = decodeRegistration();
+        const key = 'fingerprint-abc:0';
+
+        // Day one: first keyed persist mints the record + stamps today.
+        const first = yield* submissions.persist('registration', decoded, key);
+        expect(String(first.submittedAt)).toBe('2026-06-19');
+        const firstJson = yield* readStoredText(
+          submissionKey('registration', first.id),
+        );
+
+        // The clock rolls over to the NEXT calendar day, then the SAME logical
+        // record is re-submitted verbatim (same form + key → same deterministic id
+        // → same bucket object overwritten).
+        time.advanceTo(DAY_TWO_MILLIS);
+        const second = yield* submissions.persist('registration', decoded, key);
+
+        // Same key ⇒ same object, NOT a duplicate.
+        expect(second.id).toBe(first.id);
+        // The preserved date is day ONE (when the registration was made), NOT the
+        // day-two clock the naive recompute would have stamped.
+        expect(String(second.submittedAt)).toBe('2026-06-19');
+        expect(String(second.submittedAt)).not.toBe('2026-06-20');
+
+        // The whole on-bucket record is byte-identical across the cross-day resubmit
+        // (the regression the round-3 `payment`-only assertion could not catch).
+        const secondJson = yield* readStoredText(
+          submissionKey('registration', second.id),
+        );
+        expect(secondJson).toBe(firstJson);
+      }).pipe(
+        provideSubmissions(),
+        Effect.provideService(Clock.Clock, time.clock),
+      );
+    },
+  );
+
+  it.effect(
+    'a keyless (single-record) resubmit the next day mints a FRESH record stamped today — no preservation',
+    () => {
+      const time = controllableClock(DAY_ONE_MILLIS);
+      return Effect.gen(function* () {
+        const submissions = yield* Submissions.Service;
+        const decoded = decodeContact({
+          name: 'Single Record',
+          method: 'email',
+          email: 'single@example.com',
+          message: 'No idempotency key.',
+        });
+
+        // No key ⇒ each submit is a genuinely NEW record (random id, fresh stamp).
+        const first = yield* submissions.persist('contact', decoded);
+        expect(String(first.submittedAt)).toBe('2026-06-19');
+
+        time.advanceTo(DAY_TWO_MILLIS);
+        const second = yield* submissions.persist('contact', decoded);
+
+        // Distinct records, each carrying its OWN day's stamp — nothing preserved.
+        expect(second.id).not.toBe(first.id);
+        expect(String(second.submittedAt)).toBe('2026-06-20');
+      }).pipe(
+        provideSubmissions(),
+        Effect.provideService(Clock.Clock, time.clock),
+      );
+    },
   );
 });
 

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -75,11 +75,21 @@ import {
 /**
  * The outcome of committing a registration resubmit through
  * `createOrReuseOrder` (order-workflow round-2 --deep H1). A closed union so the
- * action branches exhaustively: a `created` order is the only one the action
- * stamps registrants `pending` + `arm`s; `reused` reuses the live pending order's
- * replayed session WITHOUT restamping; `alreadyPaid` returns the existing
- * success/receipt WITHOUT minting a session or restamping. `OrderConflict` (case
- * d) is a failure, not an outcome.
+ * action branches exhaustively:
+ *
+ *   - `created`: a fresh pending order. The action `arm`s it AND stamps each
+ *     registrant `pending` for the first time.
+ *   - `reused`: the live pending order is reused (its replayed session). The
+ *     ORDER itself is NOT overwritten, but the action DOES re-stamp the
+ *     registrants `pending` — a byte-identical idempotent re-stamp that
+ *     self-heals a prior submit that wrote the order but failed mid-stamp-loop
+ *     (round-3 --deep BLOCKER 2; restamp paths registration-action.ts:420-438,
+ *     :538-555). It is NOT re-`arm`ed (the first submit already armed it).
+ *   - `alreadyPaid`: returns the existing success/receipt WITHOUT minting a
+ *     session, WITHOUT overwriting the paid order, and WITHOUT touching the
+ *     registrant stamps (the action skips the stamp loop entirely).
+ *
+ * `OrderConflict` (case d) is a failure, not an outcome.
  */
 export type OrderCreateOutcome =
   | { readonly _tag: 'created'; readonly order: RegistrationOrder }
@@ -98,20 +108,26 @@ export class Service extends Context.Service<
   {
     /**
      * Persist one decoded form as a durable `Submission` object and return the
-     * stored record. Stamps `submittedAt` with the current calendar date, encodes
-     * the envelope + the definition-derived payload to JSON, and `Storage.put`s it
-     * at `submissions/<form>/<id>.json`. Persistence ONLY — the notification is a
-     * separate step (Branch 7.3); `persist` returning the record before any
-     * notification runs is what makes the record durable across a notify failure.
+     * stored record. Stamps `submittedAt` with the current calendar date for a
+     * genuinely NEW record, encodes the envelope + the definition-derived payload
+     * to JSON, and `Storage.put`s it at `submissions/<form>/<id>.json`. Persistence
+     * ONLY — the notification is a separate step (Branch 7.3); `persist` returning
+     * the record before any notification runs is what makes the record durable
+     * across a notify failure.
      *
      * `idempotencyKey` (optional) makes the write retry-safe: when supplied, the
      * record's `id` is **derived deterministically** from it (`deterministicListItemId`)
      * instead of a fresh random nanoid, so persisting the same logical record twice
      * (e.g. a user retrying a partially-failed multi-registrant registration) writes
      * to the SAME bucket key and overwrites rather than minting a duplicate object.
-     * Omit it for single-record submissions (contact/volunteer) where each submit is
-     * a genuinely new record. The caller owns what makes a record "the same"
-     * (registration scopes by per-request fingerprint + registrant index).
+     * A keyed overwrite that finds a prior record at that key is **byte-identical**:
+     * it preserves BOTH the existing record's `payment` lifecycle AND its original
+     * `submittedAt` (a verbatim resubmit TOMORROW must not re-stamp a fresh clock
+     * date — round-4 --deep MAJOR), so only a genuinely new record takes a fresh
+     * `submittedAt`. Omit the key for single-record submissions (contact/volunteer)
+     * where each submit is a genuinely new record. The caller owns what makes a
+     * record "the same" (registration scopes by per-request fingerprint +
+     * registrant index).
      */
     readonly persist: (
       form: FormId,
@@ -181,14 +197,17 @@ export class Service extends Context.Service<
      *
      *   - absent ⇒ write `proposed` as a fresh `pending` order; outcome
      *     `{ _tag: 'created' }`. The caller stamps registrants `pending` + arms.
-     *   - existing `paid` ⇒ do NOT overwrite, do NOT restamp; outcome
+     *   - existing `paid` ⇒ do NOT overwrite the order; outcome
      *     `{ _tag: 'alreadyPaid', order }` carrying the EXISTING paid order. The
-     *     caller returns the existing success/receipt (case (a)).
+     *     caller returns the existing success/receipt (case (a)) and skips the
+     *     registrant stamp loop entirely.
      *   - existing `pending` whose frozen fields MATCH `proposed`
      *     (amount/currency/receiptEmail/mode/registrantIds) ⇒ idempotent retry;
-     *     do NOT overwrite, do NOT restamp; outcome `{ _tag: 'reused', order }`
+     *     do NOT overwrite the order; outcome `{ _tag: 'reused', order }`
      *     carrying the EXISTING order (case (b)). The caller reuses the replayed
-     *     session.
+     *     session AND re-stamps the registrants `pending` (a byte-identical
+     *     idempotent re-stamp that self-heals a prior submit which wrote the
+     *     order but failed mid-stamp-loop — round-3 --deep BLOCKER 2).
      *   - existing `pending` whose frozen fields CONFLICT ⇒ fail with
      *     {@link OrderConflict} (case (d)).
      *   - existing non-paid TERMINAL ⇒ this is unreachable on the happy path
@@ -197,10 +216,14 @@ export class Service extends Context.Service<
      *     hard guard violation and FAILS `OrderConflict` rather than overwriting —
      *     NEVER restamp a terminal order back to `pending`.
      *
-     * The write is a single `persistOrder`; a `paid`/`reused` outcome performs NO
-     * write at all (byte-identical idempotent resubmit). This is the CREATE-path
-     * analog of the `markOrder*` `canTransition` guards (F1) — the resubmit can
-     * never resurrect a terminal nor restamp a settled order.
+     * The ORDER write is a single `persistOrder` on the `created` path only; a
+     * `paid`/`reused` outcome performs NO order write at all (the order is reused
+     * in place, byte-identical idempotent resubmit). The registrant `pending`
+     * re-stamp on the `reused` path is a SEPARATE caller step
+     * (registration-action.ts:420-438, :538-555), not part of this method. This is
+     * the CREATE-path analog of the `markOrder*` `canTransition` guards (F1) — the
+     * resubmit can never resurrect a terminal order nor restamp a settled ORDER's
+     * status back to `pending`.
      */
     readonly createOrReuseOrder: (
       form: FormId,
@@ -368,30 +391,48 @@ export const layer = Layer.effect(
         idempotencyKey === undefined
           ? newListItemId()
           : deterministicListItemId(`${form}:${idempotencyKey}`);
-      // `submittedAt` round-trips through the branded `IsoDate`: a clock-derived
-      // `YYYY-MM-DD` is always a real calendar date, so a decode failure here is a
-      // bug, not a user error — it dies rather than masquerading as a failure.
-      const submittedAt = yield* decodeIsoDate(isoDateString(now)).pipe(
+      // A clock-derived `submittedAt` for a genuinely NEW record. Round-trips
+      // through the branded `IsoDate`: a clock-derived `YYYY-MM-DD` is always a
+      // real calendar date, so a decode failure here is a bug, not a user error —
+      // it dies rather than masquerading as a failure. NOT necessarily the value
+      // that lands: a keyed resubmit that finds a prior record PRESERVES that
+      // record's `submittedAt` (see below), so this fresh stamp is only used when
+      // there is no existing record at this deterministic key.
+      const freshSubmittedAt = yield* decodeIsoDate(isoDateString(now)).pipe(
         Effect.orDie,
       );
 
-      // PRESERVE an already-stamped payment lifecycle on an idempotent overwrite
-      // (order-workflow round-2 --deep H1). With an `idempotencyKey` a verbatim
-      // resubmit re-derives the SAME id and OVERWRITES the existing record — but
-      // the order/webhook flow may have already stamped that registrant
-      // `pending`/`paid`/… (`setRegistrantPayment`). A naive overwrite would write
-      // a fresh record with NO `payment`, silently WIPING the paid stamp (the
-      // restamp hazard H1 closes on the order side, mirrored here on the registrant
-      // side). So a keyed persist carries the existing record's `payment` forward;
-      // a keyless persist (single-record forms) has no prior record to preserve.
-      const existingPayment: PaymentState | undefined =
+      // PRESERVE an already-stamped record's `payment` lifecycle AND its original
+      // `submittedAt` on an idempotent overwrite (order-workflow round-2 --deep H1
+      // / round-4 --deep MAJOR). With an `idempotencyKey` a verbatim resubmit
+      // re-derives the SAME id and OVERWRITES the existing record. Two fields must
+      // survive that overwrite for a resubmit to be byte-identical:
+      //
+      //   - `payment`: the order/webhook flow may have already stamped that
+      //     registrant `pending`/`paid`/… (`setRegistrantPayment`). A naive
+      //     overwrite would write a fresh record with NO `payment`, silently
+      //     WIPING the paid stamp.
+      //   - `submittedAt`: it is a CLOCK read, so recomputing it on every persist
+      //     would make a verbatim resubmit TOMORROW produce a DIFFERENT calendar
+      //     date — the registrant envelope would churn day-to-day even though
+      //     nothing logical changed and `payment`/order were preserved. The
+      //     original record's `submittedAt` is when the registration was actually
+      //     made, so it is the value that must persist across same-key resubmits.
+      //
+      // So a keyed persist re-reads any prior record once and carries BOTH fields
+      // forward; only a genuinely new record (no prior at this key, or a keyless
+      // single-record form) takes the fresh clock-stamped `submittedAt`.
+      const existing: Submission | undefined =
         idempotencyKey === undefined
           ? undefined
           : yield* readSubmissionOption(form, id).pipe(
               Effect.map((record) =>
-                Option.isSome(record) ? record.value.payment : undefined,
+                Option.isSome(record) ? record.value : undefined,
               ),
             );
+
+      const submittedAt = existing?.submittedAt ?? freshSubmittedAt;
+      const existingPayment = existing?.payment;
 
       const submission: Submission =
         existingPayment === undefined
@@ -618,8 +659,10 @@ export const layer = Layer.effect(
         }
         // Live `pending`: idempotent retry iff the frozen fields match (case b);
         // a fingerprint collision with disagreeing fields fails explicitly (case
-        // d). Either way the existing order is NOT overwritten and its registrants
-        // are NOT restamped.
+        // d). Either way the existing ORDER is NOT overwritten here. (On the
+        // matching `reused` path the CALLER still re-stamps the registrants
+        // `pending` — a byte-identical self-heal — but that is its own step, not
+        // this method's; see registration-action.ts:420-438, :538-555.)
         const reason = conflictReason(current, proposed);
         if (reason !== undefined) {
           return yield* new OrderConflict({ orderId: proposed.orderId, reason });

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -664,8 +664,11 @@ export const layer = Layer.effect(
 
     // Read-flip-persist over BOTH the order AND the registrant submissions it names
     // (`registrantIds`), idempotent end-to-end. `guard` decides which current order
-    // statuses may transition: `markOrderPaid` flips from any non-`paid` state;
-    // `markOrderFailed` refuses to downgrade an already-`paid` order. When the guard
+    // statuses may transition: `markOrderPaid` settles ONLY a `pending` order to
+    // `paid` (the G4 `canTransition` table — a late completion on an
+    // `expired`/`cancelled`/`refunded`/`failed` terminal is rejected, never
+    // resurrected); `markOrderFailed` likewise gates on `canTransition` and refuses
+    // to downgrade an already-`paid` order. When the guard
     // forbids the transition AND the order is not already at `target`, NOTHING is
     // touched (a paid order's registrants are never downgraded by a stray failure).
     //

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -17,6 +17,8 @@ import {
 } from '../content/schema';
 import { type NotFound, Storage, type StorageError } from '../storage.server';
 
+import { canTransition } from '../order/transitions';
+
 import type { DecodedForm } from './decode';
 import { RegistrationOrder } from './order';
 import {
@@ -480,18 +482,26 @@ export const layer = Layer.effect(
       form: FormId,
       orderId: string,
     ) {
-      // Any non-`paid` order (pending/failed/expired) may settle to `paid`: a
-      // confirmed charge is authoritative over an earlier non-terminal state. The
-      // settled-on calendar date (`paidAt`) is FROZEN onto the order the instant it
-      // transitions and never re-stamped, so a webhook replay on a LATER date
-      // re-reads it rather than the clock. Each registrant is stamped `paid` with
-      // the order's frozen mode/amount/currency plus that frozen `paidAt` —
+      // ONLY a `pending` order may settle to `paid` (the G4 transition table —
+      // `canTransition(current, 'paid')`, the SINGLE source of truth in
+      // `order/transitions.ts`; an already-`paid` order re-flips idempotently via
+      // the identity case). A late `checkout.session.completed` racing an
+      // `expired`/`cancelled`/`refunded`/`failed` terminal must NOT resurrect the
+      // order to `paid` (a money/support hazard) — the guard rejects it, leaving
+      // the terminal order AND its registrant stamps untouched. This guard runs at
+      // the BUCKET authority, so the webhook's direct `markOrderPaid` call honors
+      // the table BEFORE any bucket flip, even though the durable `settle` op also
+      // consults the same predicate (no second source of truth, no resurrection).
+      // The settled-on calendar date (`paidAt`) is FROZEN onto the order the
+      // instant it transitions and never re-stamped, so a webhook replay on a LATER
+      // date re-reads it rather than the clock. Each registrant is stamped `paid`
+      // with the order's frozen mode/amount/currency plus that frozen `paidAt` —
       // byte-identical on every replay (the idempotency invariant the webhook owes).
       return yield* flipStatus(
         form,
         orderId,
         'paid',
-        () => true,
+        (current) => canTransition(current, 'paid'),
         // Read the clock ONCE, here, on the real transition only — a replay
         // re-reads the already-`paid` order verbatim and never enters this branch,
         // so `paidAt` cannot drift across deliveries.
@@ -532,15 +542,21 @@ export const layer = Layer.effect(
       form: FormId,
       orderId: string,
     ) {
-      // Never downgrade a `paid` order: a completed session already reconciled it,
-      // so a stray later failure for the same session is ignored (the `guard`).
-      // Each registrant is stamped `failed`, carrying the order link + a short
-      // reason (no amount/paidAt — there is nothing settled).
+      // ONLY a `pending` order may flip to `failed` (the G4 transition table —
+      // `canTransition(current, 'failed')`, the SINGLE source of truth in
+      // `order/transitions.ts`; an already-`failed` order re-flips idempotently via
+      // the identity case). A stray `async_payment_failed` racing an
+      // `expired`/`cancelled`/`refunded`/`paid` terminal must NOT overwrite it —
+      // the guard rejects it, leaving the terminal order AND its registrant stamps
+      // untouched (the documented legal transitions are `pending → failed` plus
+      // identity ONLY; `paid` was always protected, and now every other terminal
+      // is too). Each registrant is stamped `failed`, carrying the order link + a
+      // short reason (no amount/paidAt — there is nothing settled).
       return yield* flipStatus(
         form,
         orderId,
         'failed',
-        (current) => current !== 'paid',
+        (current) => canTransition(current, 'failed'),
         // A failed transition freezes no timestamp — there is nothing settled.
         (order) => Effect.succeed({ ...order, status: 'failed' } satisfies RegistrationOrder),
         (order) =>

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -180,6 +180,47 @@ export class Service extends Context.Service<
       form: FormId,
       orderId: string,
     ) => Effect.Effect<RegistrationOrder, StorageError | NotFound>;
+    /**
+     * Flip the order to `cancelled` AND stamp each registrant it names
+     * `cancelled` in lock-step, returning the order (the durable Order actor's
+     * operator/abandon `cancel` op, G5/G7). ONLY a `pending` order transitions —
+     * the same never-downgrade-a-terminal guard as {@link markOrderFailed}: a
+     * `paid`/`failed`/`expired`/`refunded` order is left untouched (and its
+     * registrants with it). `cancelled` is DISTINCT from `failed` (operator
+     * abandon vs Stripe `async_payment_failed`). Idempotent in the same shape: a
+     * re-flip of an already-`cancelled` order returns it unchanged and re-stamps
+     * each registrant byte-identically. Same failure channel.
+     */
+    readonly markOrderCancelled: (
+      form: FormId,
+      orderId: string,
+    ) => Effect.Effect<RegistrationOrder, StorageError | NotFound>;
+    /**
+     * Flip the order to `expired` AND stamp each registrant it names `expired` in
+     * lock-step, returning the order (the deadline-sweep `expire` op, G7). ONLY a
+     * `pending` order transitions — a settled (`paid`) or otherwise-terminal
+     * order is never swept. Idempotent like {@link markOrderCancelled}.
+     */
+    readonly markOrderExpired: (
+      form: FormId,
+      orderId: string,
+    ) => Effect.Effect<RegistrationOrder, StorageError | NotFound>;
+    /**
+     * Flip the order to `refunded` AND stamp each registrant it names `refunded`
+     * in lock-step, returning the order (the `refund` op, G7 — the only
+     * transition reachable FROM `paid`). ONLY a `paid` order transitions; a
+     * `pending`/`failed`/`expired`/`cancelled` order is left untouched (refunding
+     * an unsettled order is meaningless). The refund's calendar date
+     * (`refundedAt`) is FROZEN onto the order the instant it transitions and
+     * never re-stamped — so a re-flip on a LATER date re-reads it rather than the
+     * clock, and each registrant's `refundedAt` derives FROM the order's frozen
+     * stamp (`derive-dont-sync`), byte-identical on every replay. Same failure
+     * channel.
+     */
+    readonly markOrderRefunded: (
+      form: FormId,
+      orderId: string,
+    ) => Effect.Effect<RegistrationOrder, StorageError | NotFound>;
   }
 >()('gycc/lib/forms/submissions.server/Service') {}
 
@@ -456,6 +497,118 @@ export const layer = Layer.effect(
       );
     });
 
+    const markOrderCancelled = Effect.fn('Submissions.markOrderCancelled')(
+      function* (form: FormId, orderId: string) {
+        // Only a `pending` order may be cancelled — a settled (`paid`) or
+        // otherwise-terminal order is never downgraded (the same guard shape as
+        // `markOrderFailed`). Each registrant is stamped `cancelled`, carrying the
+        // order link + its frozen amount/currency (nothing was collected, so no
+        // `paidAt`).
+        return yield* flipStatus(
+          form,
+          orderId,
+          'cancelled',
+          (current) => current === 'pending',
+          // A cancellation freezes no timestamp — there is nothing settled.
+          (order) =>
+            Effect.succeed({
+              ...order,
+              status: 'cancelled',
+            } satisfies RegistrationOrder),
+          (order) =>
+            Effect.succeed({
+              _tag: 'cancelled',
+              orderId: order.orderId,
+              mode: order.mode,
+              amount: order.amount,
+              currency: order.currency,
+            } satisfies PaymentState),
+        );
+      },
+    );
+
+    const markOrderExpired = Effect.fn('Submissions.markOrderExpired')(
+      function* (form: FormId, orderId: string) {
+        // Only a `pending` order may be swept to `expired` — a settled or
+        // otherwise-terminal order is never swept.
+        return yield* flipStatus(
+          form,
+          orderId,
+          'expired',
+          (current) => current === 'pending',
+          // Expiry freezes no timestamp.
+          (order) =>
+            Effect.succeed({
+              ...order,
+              status: 'expired',
+            } satisfies RegistrationOrder),
+          (order) =>
+            Effect.succeed({
+              _tag: 'expired',
+              orderId: order.orderId,
+              mode: order.mode,
+              amount: order.amount,
+              currency: order.currency,
+            } satisfies PaymentState),
+        );
+      },
+    );
+
+    const markOrderRefunded = Effect.fn('Submissions.markOrderRefunded')(
+      function* (form: FormId, orderId: string) {
+        // ONLY a `paid` order may be refunded — the single transition reachable
+        // FROM `paid`. A `pending`/`failed`/`expired`/`cancelled` order is left
+        // untouched (refunding an unsettled order is meaningless). The refund's
+        // calendar date is FROZEN onto the order the instant it transitions and
+        // never re-stamped; each registrant's `refundedAt` derives FROM it, so a
+        // re-flip on a LATER date rewrites byte-identical records.
+        return yield* flipStatus(
+          form,
+          orderId,
+          'refunded',
+          (current) => current === 'paid',
+          // Read the clock ONCE, on the real transition only — a re-flip re-reads
+          // the already-`refunded` order verbatim and never enters this branch,
+          // so `refundedAt` cannot drift across deliveries.
+          (order) =>
+            Effect.gen(function* () {
+              const now = yield* Clock.currentTimeMillis;
+              const refundedAt = yield* decodeIsoDate(isoDateString(now)).pipe(
+                Effect.orDie,
+              );
+              return {
+                ...order,
+                status: 'refunded',
+                refundedAt,
+              } satisfies RegistrationOrder;
+            }),
+          // Derive the registrant `refundedAt` FROM the order's frozen stamp
+          // (`derive-dont-sync`), never from the clock. The settled order always
+          // carries `refundedAt` (the transition froze it, and an already-
+          // `refunded` order was written with it), so a missing value is bucket
+          // corruption and dies rather than masquerading as an undated refund.
+          (order) =>
+            Effect.gen(function* () {
+              if (order.refundedAt === undefined) {
+                return yield* Effect.die(
+                  new Error(
+                    `refunded order ${order.orderId} has no frozen refundedAt`,
+                  ),
+                );
+              }
+              return {
+                _tag: 'refunded',
+                orderId: order.orderId,
+                mode: order.mode,
+                amount: order.amount,
+                currency: order.currency,
+                refundedAt: order.refundedAt,
+              } satisfies PaymentState;
+            }),
+        );
+      },
+    );
+
     return Service.of({
       persist,
       persistOrder,
@@ -463,6 +616,9 @@ export const layer = Layer.effect(
       getOrder: readOrder,
       markOrderPaid,
       markOrderFailed,
+      markOrderCancelled,
+      markOrderExpired,
+      markOrderRefunded,
     });
   }),
 );

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -21,6 +21,7 @@ import { canTransition } from '../order/transitions';
 
 import type { DecodedForm } from './decode';
 import { RegistrationOrder } from './order';
+import { OrderConflict } from './order-conflict';
 import {
   type PaymentState,
   submissionSchema,
@@ -71,6 +72,20 @@ import {
  * a submission must never look like success.
  */
 
+/**
+ * The outcome of committing a registration resubmit through
+ * `createOrReuseOrder` (order-workflow round-2 --deep H1). A closed union so the
+ * action branches exhaustively: a `created` order is the only one the action
+ * stamps registrants `pending` + `arm`s; `reused` reuses the live pending order's
+ * replayed session WITHOUT restamping; `alreadyPaid` returns the existing
+ * success/receipt WITHOUT minting a session or restamping. `OrderConflict` (case
+ * d) is a failure, not an outcome.
+ */
+export type OrderCreateOutcome =
+  | { readonly _tag: 'created'; readonly order: RegistrationOrder }
+  | { readonly _tag: 'reused'; readonly order: RegistrationOrder }
+  | { readonly _tag: 'alreadyPaid'; readonly order: RegistrationOrder };
+
 /** Format a UTC millisecond instant as a `YYYY-MM-DD` calendar-date string. */
 const isoDateString = (millis: number): string =>
   DateTime.formatIso(DateTime.makeUnsafe(millis)).slice(0, 10);
@@ -118,6 +133,79 @@ export class Service extends Context.Service<
       form: FormId,
       order: RegistrationOrder,
     ) => Effect.Effect<RegistrationOrder, StorageError>;
+    /**
+     * Resolve the order SLOT a same-payload registration resubmit must land on
+     * (order-workflow round-2 --deep H1). The deterministic `baseOrderId` (the
+     * request fingerprint, possibly `:index`) is stable across a verbatim
+     * resubmit, so a naive `persistOrder` at that key would silently OVERWRITE
+     * whatever order already lives there — including an already-PAID order
+     * (restamping its registrants `pending`, the F1 resurrection class through
+     * the CREATE path) or a non-paid TERMINAL (cancelled/expired/refunded/failed)
+     * the user is legitimately re-registering after.
+     *
+     * This reads the order(s) at `baseOrderId` FIRST and returns the slot the
+     * resubmit should use, WITHOUT writing anything:
+     *
+     *   - the LIVE order at `baseOrderId` is `pending` or `paid` ⇒ that
+     *     generation is still the active one; the caller reuses it (case (b)
+     *     pending reuse / case (a) already-paid). `existing` is `Some(order)`,
+     *     `orderId` is `baseOrderId`.
+     *   - the order at `baseOrderId` is a non-paid TERMINAL (case (c)) ⇒ it is a
+     *     DEAD order the user is re-registering past. A new pending must NOT
+     *     overwrite it, and it cannot reuse the same key, so this walks to the
+     *     NEXT free generation (`baseOrderId#g1`, `#g2`, …) — the lowest
+     *     generation whose slot is absent OR live — and returns THAT as the fresh
+     *     `orderId` (`existing` `None`). Deterministic: a verbatim resubmit
+     *     re-walks the same dead terminals to the same generation, so it
+     *     idempotently lands on the same fresh slot (no runaway generations).
+     *   - no order at `baseOrderId` at all ⇒ a first submission; `orderId` is
+     *     `baseOrderId`, `existing` `None`.
+     *
+     * The caller mints its Checkout session keyed off the RETURNED `orderId` (so
+     * a fresh generation gets a fresh session, and a reuse replays the same one)
+     * and then commits through {@link createOrReuseOrder}.
+     */
+    readonly resolveOrderSlot: (
+      form: FormId,
+      baseOrderId: string,
+    ) => Effect.Effect<
+      { readonly orderId: string; readonly existing: Option.Option<RegistrationOrder> },
+      StorageError
+    >;
+    /**
+     * Commit a registration resubmit against the slot {@link resolveOrderSlot}
+     * resolved, implementing the CONFIRMED resubmit UX (order-workflow round-2
+     * --deep H1). The caller passes the freshly-built `proposed` order (carrying
+     * the resolved `orderId` + the just-minted `sessionId`); this re-reads the
+     * order at `proposed.orderId` to decide:
+     *
+     *   - absent ⇒ write `proposed` as a fresh `pending` order; outcome
+     *     `{ _tag: 'created' }`. The caller stamps registrants `pending` + arms.
+     *   - existing `paid` ⇒ do NOT overwrite, do NOT restamp; outcome
+     *     `{ _tag: 'alreadyPaid', order }` carrying the EXISTING paid order. The
+     *     caller returns the existing success/receipt (case (a)).
+     *   - existing `pending` whose frozen fields MATCH `proposed`
+     *     (amount/currency/receiptEmail/mode/registrantIds) ⇒ idempotent retry;
+     *     do NOT overwrite, do NOT restamp; outcome `{ _tag: 'reused', order }`
+     *     carrying the EXISTING order (case (b)). The caller reuses the replayed
+     *     session.
+     *   - existing `pending` whose frozen fields CONFLICT ⇒ fail with
+     *     {@link OrderConflict} (case (d)).
+     *   - existing non-paid TERMINAL ⇒ this is unreachable on the happy path
+     *     ({@link resolveOrderSlot} already walked past a dead terminal to a fresh
+     *     generation), but if a terminal somehow lands here it is treated as a
+     *     hard guard violation and FAILS `OrderConflict` rather than overwriting —
+     *     NEVER restamp a terminal order back to `pending`.
+     *
+     * The write is a single `persistOrder`; a `paid`/`reused` outcome performs NO
+     * write at all (byte-identical idempotent resubmit). This is the CREATE-path
+     * analog of the `markOrder*` `canTransition` guards (F1) — the resubmit can
+     * never resurrect a terminal nor restamp a settled order.
+     */
+    readonly createOrReuseOrder: (
+      form: FormId,
+      proposed: RegistrationOrder,
+    ) => Effect.Effect<OrderCreateOutcome, StorageError | OrderConflict>;
     /**
      * Stamp a `PaymentState` onto an already-persisted registrant `Submission`
      * (`submissions/<form>/<id>.json`) and return the updated record. Re-reads the
@@ -287,7 +375,28 @@ export const layer = Layer.effect(
         Effect.orDie,
       );
 
-      const submission: Submission = { id, form, submittedAt, payload: decoded };
+      // PRESERVE an already-stamped payment lifecycle on an idempotent overwrite
+      // (order-workflow round-2 --deep H1). With an `idempotencyKey` a verbatim
+      // resubmit re-derives the SAME id and OVERWRITES the existing record — but
+      // the order/webhook flow may have already stamped that registrant
+      // `pending`/`paid`/… (`setRegistrantPayment`). A naive overwrite would write
+      // a fresh record with NO `payment`, silently WIPING the paid stamp (the
+      // restamp hazard H1 closes on the order side, mirrored here on the registrant
+      // side). So a keyed persist carries the existing record's `payment` forward;
+      // a keyless persist (single-record forms) has no prior record to preserve.
+      const existingPayment: PaymentState | undefined =
+        idempotencyKey === undefined
+          ? undefined
+          : yield* readSubmissionOption(form, id).pipe(
+              Effect.map((record) =>
+                Option.isSome(record) ? record.value.payment : undefined,
+              ),
+            );
+
+      const submission: Submission =
+        existingPayment === undefined
+          ? { id, form, submittedAt, payload: decoded }
+          : { id, form, submittedAt, payload: decoded, payment: existingPayment };
 
       // A decoded `Submission` ALWAYS re-encodes through its derived codec; a
       // failure here is an upstream bug (a `decoded` that never came from
@@ -324,6 +433,19 @@ export const layer = Layer.effect(
         text,
       ).pipe(Effect.orDie);
     });
+
+    // `readSubmission`'s Option flavour: a missing record is a benign absence
+    // (`None`), not a `NotFound` — `persist` uses it to discover whether an
+    // idempotent overwrite has a prior record whose `payment` lifecycle must be
+    // carried forward (H1). A real `StorageError` still propagates.
+    const readSubmissionOption = Effect.fn('Submissions.readSubmissionOption')(
+      function* (form: FormId, id: ListItemId) {
+        return yield* readSubmission(form, id).pipe(
+          Effect.map(Option.some<Submission>),
+          Effect.catchTag('Storage.NotFound', () => Effect.succeedNone),
+        );
+      },
+    );
 
     const setRegistrantPayment = Effect.fn('Submissions.setRegistrantPayment')(
       function* (form: FormId, id: ListItemId, payment: PaymentState) {
@@ -384,6 +506,127 @@ export const layer = Layer.effect(
         Schema.fromJsonString(RegistrationOrder),
       )(text).pipe(Effect.orDie);
     });
+
+    // `readOrder`'s Option flavour for the resubmit guard: a missing order is a
+    // benign absence (`None`), not a user-facing `NotFound` — `resolveOrderSlot`
+    // probes generations expecting most to be absent. A real `StorageError` (a
+    // bucket fault) still propagates; only the `NotFound` is folded to `None`.
+    const readOrderOption = Effect.fn('Submissions.readOrderOption')(function* (
+      form: FormId,
+      orderId: string,
+    ) {
+      return yield* readOrder(form, orderId).pipe(
+        Effect.map(Option.some<RegistrationOrder>),
+        Effect.catchTag('Storage.NotFound', () => Effect.succeedNone),
+      );
+    });
+
+    // A non-paid TERMINAL order is a DEAD slot the resubmit must walk past
+    // (cancelled/expired/refunded/failed). `pending` is live (reuse), `paid` is
+    // live-and-settled (return the receipt) — neither is "dead". The transition
+    // table is the source of truth for terminality, but the resubmit's branch is
+    // status-shaped (live-pending / live-paid / dead-terminal), so it reads the
+    // status directly here rather than `canTransition` (which answers a different
+    // question — "may from→to flip").
+    const isDeadTerminal = (status: RegistrationOrder['status']): boolean =>
+      status === 'cancelled' ||
+      status === 'expired' ||
+      status === 'refunded' ||
+      status === 'failed';
+
+    // Resolve the generation a resubmit lands on (H1 case (c)). Walk
+    // `baseOrderId`, `baseOrderId#g1`, `#g2`, … until the slot is absent OR live
+    // (pending/paid): a dead terminal at a generation means the user re-registered
+    // past it, so the next generation is the fresh slot. Deterministic — a
+    // verbatim resubmit re-walks the same dead terminals to the same generation,
+    // so it never runs away minting new generations. The cap is a safety bound
+    // (a real submission re-registering hundreds of times is pathological); it
+    // dies loudly rather than looping unbounded.
+    const generationOrderId = (baseOrderId: string, generation: number): string =>
+      generation === 0 ? baseOrderId : `${baseOrderId}#g${generation}`;
+    const MAX_GENERATIONS = 1000;
+    const resolveOrderSlot = Effect.fn('Submissions.resolveOrderSlot')(
+      function* (form: FormId, baseOrderId: string) {
+        for (let generation = 0; generation < MAX_GENERATIONS; generation += 1) {
+          const orderId = generationOrderId(baseOrderId, generation);
+          const existing = yield* readOrderOption(form, orderId);
+          // Absent ⇒ a fresh slot at this generation.
+          if (Option.isNone(existing)) {
+            return { orderId, existing: Option.none<RegistrationOrder>() };
+          }
+          // Live (pending/paid) ⇒ this generation is the active one; reuse it.
+          if (!isDeadTerminal(existing.value.status)) {
+            return { orderId, existing };
+          }
+          // Dead terminal ⇒ walk to the next generation.
+        }
+        return yield* Effect.die(
+          new Error(
+            `resolveOrderSlot exhausted ${MAX_GENERATIONS} generations for ${baseOrderId}`,
+          ),
+        );
+      },
+    );
+
+    // Compare the frozen fields a resubmit must agree on with a live `pending`
+    // order to be an idempotent retry (H1 case (b) vs (d)). The session id is
+    // DELIBERATELY excluded: a verbatim resubmit replays the SAME Stripe session
+    // (idempotency key), so a matching resubmit re-mints the same `sessionId`, but
+    // the equality that decides reuse-vs-conflict is the MONEY + receipt routing
+    // (amount/currency/receiptEmail/mode) and which registrants the order pays for
+    // — those are what must never be silently overwritten. Returns the first
+    // disagreeing field name, or `undefined` when every frozen field matches.
+    const conflictReason = (
+      existing: RegistrationOrder,
+      proposed: RegistrationOrder,
+    ): string | undefined => {
+      if (existing.mode !== proposed.mode) return 'mode';
+      if (existing.amount !== proposed.amount) return 'amount';
+      if (existing.currency !== proposed.currency) return 'currency';
+      if (existing.receiptEmail !== proposed.receiptEmail) return 'receiptEmail';
+      if (
+        existing.registrantIds.length !== proposed.registrantIds.length ||
+        existing.registrantIds.some((id, i) => id !== proposed.registrantIds[i])
+      ) {
+        return 'registrantIds';
+      }
+      return undefined;
+    };
+
+    const createOrReuseOrder = Effect.fn('Submissions.createOrReuseOrder')(
+      function* (form: FormId, proposed: RegistrationOrder) {
+        const existing = yield* readOrderOption(form, proposed.orderId);
+        // No order at this slot ⇒ write the fresh `pending` order.
+        if (Option.isNone(existing)) {
+          const order = yield* persistOrder(form, proposed);
+          return { _tag: 'created', order } satisfies OrderCreateOutcome;
+        }
+        const current = existing.value;
+        // Already PAID (case a) ⇒ return the existing receipt; NEVER overwrite or
+        // restamp. The action skips the session + the registrant restamp.
+        if (current.status === 'paid') {
+          return { _tag: 'alreadyPaid', order: current } satisfies OrderCreateOutcome;
+        }
+        // A non-paid TERMINAL must never reach here — `resolveOrderSlot` already
+        // walked past it to a fresh generation. If one does (a caller that bypassed
+        // the slot resolver), fail rather than overwrite it back to `pending`.
+        if (isDeadTerminal(current.status)) {
+          return yield* new OrderConflict({
+            orderId: proposed.orderId,
+            reason: `terminal order (${current.status}) cannot be reused`,
+          });
+        }
+        // Live `pending`: idempotent retry iff the frozen fields match (case b);
+        // a fingerprint collision with disagreeing fields fails explicitly (case
+        // d). Either way the existing order is NOT overwritten and its registrants
+        // are NOT restamped.
+        const reason = conflictReason(current, proposed);
+        if (reason !== undefined) {
+          return yield* new OrderConflict({ orderId: proposed.orderId, reason });
+        }
+        return { _tag: 'reused', order: current } satisfies OrderCreateOutcome;
+      },
+    );
 
     // List every frozen order under `ordersPrefix(form)` and decode each. The
     // sweep (G9) reads this to find pending orders past their deadline. A stored
@@ -684,6 +927,8 @@ export const layer = Layer.effect(
     return Service.of({
       persist,
       persistOrder,
+      resolveOrderSlot,
+      createOrReuseOrder,
       setRegistrantPayment,
       getOrder: readOrder,
       listOrders,

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -1,9 +1,14 @@
 export * as Submissions from './submissions.server';
 
-import { Clock, Context, DateTime, Effect, Layer, Schema } from 'effect';
+import { Clock, Context, DateTime, Effect, Layer, Option, Schema } from 'effect';
 
 import { Content } from '../content.server';
-import { type FormId, orderKey, submissionKey } from '../content/pages/registry';
+import {
+  type FormId,
+  orderKey,
+  ordersPrefix,
+  submissionKey,
+} from '../content/pages/registry';
 import {
   deterministicListItemId,
   IsoDate,
@@ -144,6 +149,23 @@ export class Service extends Context.Service<
       form: FormId,
       orderId: string,
     ) => Effect.Effect<RegistrationOrder, StorageError | NotFound>;
+    /**
+     * List every frozen order of a form (the objects under `ordersPrefix(form)`
+     * = `submissions/<form>/orders/`), decoding each back to a
+     * `RegistrationOrder`. The deadline sweep (order-workflow G9) lists the
+     * pending orders past their `deadline` to `expire` them; this is the read
+     * half (the sweep filters + dispatches). The `orders/` prefix nests UNDER the
+     * form's submission root but the registrant submissions sit one level up
+     * (`submissions/<form>/<id>.json`, NOT under `orders/`), so this returns
+     * orders ONLY — never a registrant record. A stored order ALWAYS decodes (it
+     * was written by `persistOrder` from this same schema), so a decode failure
+     * is bucket corruption and dies (mirroring `getOrder`), never a soft skip
+     * that would silently drop an order from the sweep. `StorageError` on a
+     * bucket-list fault.
+     */
+    readonly listOrders: (
+      form: FormId,
+    ) => Effect.Effect<readonly RegistrationOrder[], StorageError>;
     /**
      * Flip the order at `submissions/<form>/orders/<orderId>.json` to `paid` AND
      * stamp each registrant submission it names (`registrantIds`) `paid` in
@@ -359,6 +381,40 @@ export const layer = Layer.effect(
       return yield* Schema.decodeUnknownEffect(
         Schema.fromJsonString(RegistrationOrder),
       )(text).pipe(Effect.orDie);
+    });
+
+    // List every frozen order under `ordersPrefix(form)` and decode each. The
+    // sweep (G9) reads this to find pending orders past their deadline. A stored
+    // order ALWAYS decodes (written by `persistOrder` from this same schema), so
+    // a decode failure is bucket corruption and dies — never a soft skip that
+    // would silently drop an order from the sweep. The `orders/` prefix returns
+    // ORDERS ONLY (registrant submissions sit one level up, not under it).
+    const decodeOrder = Schema.decodeUnknownEffect(
+      Schema.fromJsonString(RegistrationOrder),
+    );
+    const listOrders = Effect.fn('Submissions.listOrders')(function* (
+      form: FormId,
+    ) {
+      const listed = yield* storage.list(ordersPrefix(form));
+      const orders = yield* Effect.forEach(listed, (object) =>
+        Effect.gen(function* () {
+          const stored = yield* storage.get(object.key);
+          const text = yield* Effect.promise(() =>
+            new Response(stored.stream).text(),
+          );
+          return yield* decodeOrder(text).pipe(Effect.orDie);
+        }).pipe(
+          Effect.map(Option.some<RegistrationOrder>),
+          // An order LISTED then `get`-missed is a benign TOCTOU race (it was
+          // deleted between the list and the read) — skip it rather than failing
+          // the whole sweep, keeping the channel `StorageError` (the list/get
+          // bucket fault), never `NotFound`.
+          Effect.catchTag('Storage.NotFound', () => Effect.succeedNone),
+        ),
+      );
+      return orders.flatMap((order) =>
+        Option.isSome(order) ? [order.value] : [],
+      );
     });
 
     // Read-flip-persist over BOTH the order AND the registrant submissions it names
@@ -614,6 +670,7 @@ export const layer = Layer.effect(
       persistOrder,
       setRegistrantPayment,
       getOrder: readOrder,
+      listOrders,
       markOrderPaid,
       markOrderFailed,
       markOrderCancelled,

--- a/app/lib/forms/webhook.server.test.ts
+++ b/app/lib/forms/webhook.server.test.ts
@@ -17,7 +17,7 @@ import { isSuccess } from 'effect-encore';
 
 import { Content } from '../content.server';
 import { Env } from '../env.server';
-import { type ListItemId, newListItemId } from '../content/schema';
+import { IsoDate, type ListItemId, newListItemId } from '../content/schema';
 import { defaultRegistrationForm } from '../content/pages/defaults';
 import { orderKey, submissionKey } from '../content/pages/registry';
 import {
@@ -556,6 +556,102 @@ describe('/api/stripe/webhook (C8 route)', () => {
     const response = await action(args);
     expect(response.status).toBe(200);
     expect(await readStatus(runtime, args, 'ord1')).toBe('pending');
+  });
+});
+
+// ── (2b) the webhook cannot RESURRECT a terminal order (F1 — transition guards) ─
+
+/**
+ * F1 (final --deep BLOCKERs) — the webhook's bucket flips MUST agree with the G4
+ * transition table (`order/transitions.ts`, the single source of truth). A late
+ * `checkout.session.completed` racing a terminal `expired`/`cancelled`/`refunded`/
+ * `failed` order must NOT resurrect it to `paid`, and a stray
+ * `checkout.session.async_payment_failed` racing one of those terminals must NOT
+ * overwrite it to `failed`. The guard runs at the BUCKET authority
+ * (`markOrderPaid` / `markOrderFailed`), so the order AND its named registrant
+ * submissions both stay frozen at the terminal state.
+ *
+ * A `paid` terminal carries the frozen `paidAt` (the bucket schema requires it on
+ * a paid order); the other terminals carry no `paidAt`. None of these is `pending`,
+ * so the late event's flip is illegal and a no-op.
+ */
+const terminalOrder = (
+  orderId: string,
+  amount: number,
+  status: 'expired' | 'cancelled' | 'refunded' | 'failed' | 'paid',
+): RegistrationOrder => ({
+  ...pendingOrder(orderId, amount),
+  status,
+  ...(status === 'paid' ? { paidAt: IsoDate.make('2026-06-01') } : {}),
+});
+
+describe('/api/stripe/webhook — terminal orders cannot be resurrected (F1)', () => {
+  const TERMINALS = ['expired', 'cancelled', 'refunded', 'failed'] as const;
+
+  for (const terminal of TERMINALS) {
+    it(`a completed (paid) event does NOT resurrect a ${terminal} order to paid, nor restamp registrants`, async () => {
+      const runtime = makeRequestRuntimeFromLayer(
+        stripeAppLayer(seed(terminalOrder('ord1', 15000, terminal))),
+      );
+      const body = eventBody('checkout.session.completed', 'ord1', 15000);
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      const args = webhookArgs(runtime, body, signature);
+      const { action } = await import('../../routes/api.stripe-webhook');
+      const response = await action(args);
+      // The bucket flip is a guarded no-op (the order is already terminal), so the
+      // webhook still 200s — but the order STAYS at its terminal state, and the
+      // registrants are NOT restamped `paid`.
+      expect(response.status).toBe(200);
+      expect(await readStatus(runtime, args, 'ord1')).toBe(terminal);
+      expect(await readRegistrantTag(runtime, args, REGISTRANT_IDS[0]!)).toBe(
+        'none',
+      );
+      expect(await readRegistrantTag(runtime, args, REGISTRANT_IDS[1]!)).toBe(
+        'none',
+      );
+    });
+
+    it(`an async_payment_failed event leaves a ${terminal} order UNTOUCHED (no overwrite to failed)`, async () => {
+      const runtime = makeRequestRuntimeFromLayer(
+        stripeAppLayer(seed(terminalOrder('ord1', 15000, terminal))),
+      );
+      const body = eventBody(
+        'checkout.session.async_payment_failed',
+        'ord1',
+        15000,
+      );
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      const args = webhookArgs(runtime, body, signature);
+      const { action } = await import('../../routes/api.stripe-webhook');
+      const response = await action(args);
+      // `markOrderFailed` is now pending-or-failed ONLY, so a stray failure event
+      // for a terminal order keeps the order at its terminal STATE — it is never
+      // overwritten to a DIFFERENT state. For `expired`/`cancelled`/`refunded` the
+      // guard rejects the flip outright (registrants untouched); for an already-
+      // `failed` order the flip is the legal IDENTITY case (`failed → failed`), a
+      // byte-identical idempotent re-stamp, NOT a resurrection or downgrade.
+      expect(response.status).toBe(200);
+      expect(await readStatus(runtime, args, 'ord1')).toBe(terminal);
+      expect(await readRegistrantTag(runtime, args, REGISTRANT_IDS[0]!)).toBe(
+        terminal === 'failed' ? 'failed' : 'none',
+      );
+    });
+  }
+
+  it('a completed (paid) event on a paid order is idempotent — no registrant restamp drift', async () => {
+    // `paid → paid` is the identity case (legal), so the flip converges to the
+    // SAME bytes (the frozen `paidAt`), not a resurrection: the registrant
+    // re-stamp is byte-identical (idempotent), never a downgrade or a re-clock.
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeAppLayer(seed(terminalOrder('ord1', 15000, 'paid'))),
+    );
+    const body = eventBody('checkout.session.completed', 'ord1', 15000);
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(runtime, body, signature);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const response = await action(args);
+    expect(response.status).toBe(200);
+    expect(await readStatus(runtime, args, 'ord1')).toBe('paid');
   });
 });
 

--- a/app/lib/forms/webhook.server.test.ts
+++ b/app/lib/forms/webhook.server.test.ts
@@ -1,13 +1,19 @@
+import { tmpdir } from 'node:os';
+
 import { describe, expect, it } from 'bun:test';
 import {
   ConfigProvider,
+  DateTime,
   Effect,
   Layer,
+  ManagedRuntime,
+  Option,
   Result,
   Schema,
 } from 'effect';
 import { TestClock } from 'effect/testing';
 import { RouterContextProvider } from 'react-router';
+import { isSuccess } from 'effect-encore';
 
 import { Content } from '../content.server';
 import { Env } from '../env.server';
@@ -21,7 +27,10 @@ import {
   type RequestRuntime,
 } from '../effect/runtime';
 import type { RouteArgs } from '../effect/router-context';
-import { Storage } from '../storage.server';
+import { Order } from '../order/runner.server';
+import { OrderActor } from '../order/order.actor';
+import { Payment } from '../payment.server';
+import { type ObjectHead, NotFound, Storage } from '../storage.server';
 import { layerTest } from '../storage.test-helper';
 
 import { RegistrationOrder } from './order';
@@ -547,5 +556,417 @@ describe('/api/stripe/webhook (C8 route)', () => {
     const response = await action(args);
     expect(response.status).toBe(200);
     expect(await readStatus(runtime, args, 'ord1')).toBe('pending');
+  });
+});
+
+// ── (3) the durable Order loop — webhook resolves `settle` via SQL MessageStorage ─
+
+/**
+ * order-workflow G8 — the webhook's `settle` drive end-to-end across the REAL
+ * two-runtime topology. The webhook (the `AppRuntime` SENDER) `send`s the durable
+ * `settle` op through the SAME SQL MessageStorage the `ServerLive` RUNNER
+ * consumes; the runner runs the `pending → paid` continuation (mirrored into actor
+ * State) and writes the durable reply, which a separate sender's `waitFor`
+ * observes terminal. The two graphs coordinate ONLY through ONE shared sqlite FILE
+ * + ONE shared bucket (the production seam, §1 two-runtime topology) — never an
+ * in-memory layer instance.
+ *
+ * The webhook's bucket `markOrderPaid` flip stays the RECEIPT AUTHORITY (asserted
+ * unchanged); the durable `settle` is the ADDITIVE durable lifecycle. The DB-less
+ * path degrades to the bucket-only flip (backward compatible), proven below.
+ */
+
+/** A SINGLE shared Map-backed `Storage` layer (one bucket across BOTH graphs). */
+const sharedStorageLayer = (
+  seed: Parameters<typeof layerTest>[0] = {},
+): Layer.Layer<Storage.Service> => {
+  const entries = new Map<string, { body: string; contentType: string }>();
+  for (const [key, object] of Object.entries(seed)) {
+    entries.set(key, {
+      body: String(object.body),
+      contentType: object.contentType ?? 'application/json',
+    });
+  }
+  return Layer.sync(Storage.Service, () =>
+    Storage.Service.of({
+      get: Effect.fn('Storage.get')(function* (key: string) {
+        const object = entries.get(key);
+        if (object === undefined) return yield* new NotFound({ key });
+        return {
+          stream:
+            new Response(object.body).body ?? new ReadableStream<Uint8Array>(),
+          contentType: object.contentType,
+          size: new TextEncoder().encode(object.body).byteLength,
+        };
+      }),
+      put: Effect.fn('Storage.put')(
+        (key: string, body: string | Uint8Array, contentType: string) =>
+          Effect.sync(() => {
+            entries.set(key, { body: String(body), contentType });
+          }),
+      ),
+      head: Effect.fn('Storage.head')((key: string) =>
+        Effect.sync(() =>
+          entries.has(key)
+            ? Option.some<ObjectHead>({
+                size: 0,
+                contentType: 'application/json',
+                lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+                etag: `"${key}"`,
+              })
+            : Option.none<ObjectHead>(),
+        ),
+      ),
+      list: Effect.fn('Storage.list')((prefix?: string) =>
+        Effect.sync(() =>
+          [...entries.keys()]
+            .filter((key) => prefix === undefined || key.startsWith(prefix))
+            .map((key) => ({
+              key,
+              size: 0,
+              lastModified: DateTime.toDateUtc(DateTime.makeUnsafe(0)),
+            })),
+        ),
+      ),
+      delete: Effect.fn('Storage.delete')((key: string) =>
+        Effect.sync(() => {
+          entries.delete(key);
+        }),
+      ),
+    }),
+  );
+};
+
+const tmpDbFile = (suffix: string): string =>
+  `${tmpdir()}/gyc-order-webhook-${process.pid}-${Date.now()}-${suffix}.sqlite`;
+
+/** The DB+stripe-enabled env: a sqlite FILE on disk (NOT `:memory:` — both graphs share it). */
+const dbStripeEnv = (dbFile: string): Record<string, string> => ({
+  ...STRIPE_ENV,
+  DATABASE_URL: dbFile,
+});
+
+/**
+ * Stand up the full durable two-runtime stack over ONE shared bucket + ONE shared
+ * sqlite FILE, seeded with `order`:
+ *
+ *   - a live RUNNER graph (the `ServerLive` analog): the FULL Order runner over
+ *     the shared file + the `arm`/`settle`/… handlers, with `Submissions` over the
+ *     SHARED bucket so the `settle` handler's bucket read/flip lands where the
+ *     webhook reads it;
+ *   - a webhook AppRuntime (the `AppRuntime` SENDER analog): the real
+ *     `makeAppLayer` over the SHARED bucket + the DB+stripe env, so the webhook's
+ *     `settleOrder` drive builds the real sender over the SAME file;
+ *   - a side SENDER graph (a SEPARATE sender build, distinct SqlClient over the
+ *     SAME file) the assertions use to `waitFor`/`peek`/`executionId` the durable
+ *     `settle` reply WITHOUT going through the webhook.
+ *
+ * `arm`s the order to `pending` on the runner first (the durable lifecycle anchor,
+ * exactly as the registration action does, G7.1) so the entity exists before the
+ * webhook drives `settle`. Returns the graphs + a disposer.
+ */
+const durableStack = async (order: RegistrationOrder) => {
+  const dbFile = tmpDbFile(order.orderId);
+  const storage = sharedStorageLayer(seed(order));
+  const config = ConfigProvider.layer(
+    ConfigProvider.fromEnv({ env: dbStripeEnv(dbFile) }),
+  );
+
+  const submissions = Layer.provideMerge(
+    Submissions.layer,
+    Layer.provideMerge(Content.layer, storage),
+  );
+
+  // RUNNER graph (ServerLive analog): the handlers consume the shared mailbox and
+  // flip the SHARED bucket.
+  const runner = ManagedRuntime.make(
+    Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
+      Layer.provide(submissions),
+      Layer.provide(Payment.testLayer()),
+      Layer.provide(Env.layer),
+      Layer.provide(config),
+    ),
+  );
+
+  // Side SENDER graph (the webhook analog for assertions) over the SAME file.
+  const sender = ManagedRuntime.make(
+    Order.senderLayer(Order.MessageStorageLive).pipe(
+      Layer.provide(Env.layer),
+      Layer.provide(config),
+    ),
+  );
+
+  // The webhook AppRuntime (the real request graph) over the SHARED bucket + DB env.
+  const webhookRuntime = makeRequestRuntimeFromLayer(
+    makeAppLayer(storage).pipe(Layer.provide(config)) as AppLayer,
+  );
+
+  // A read runtime that EXPOSES `Submissions.Service` over the SHARED bucket, so
+  // the assertions can derive the actor `OrderState` VIEW (`OrderActor.readState`)
+  // off the very bucket the runner's handlers flipped.
+  const readRuntime = ManagedRuntime.make(submissions);
+
+  // Boot the runner so its mailbox-poll fiber consumes the shared file.
+  await runner.runPromise(Effect.void);
+  // Anchor the entity at `pending` (the action's `arm`, G7.1) before settling.
+  await sender.runPromise(
+    Order.Entity.arm.send({
+      orderId: order.orderId,
+      mode: order.mode,
+      amount: order.amount,
+      currency: order.currency,
+      receiptEmail: order.receiptEmail,
+      sessionId: order.sessionId,
+      registrantIds: order.registrantIds,
+      deadline: order.deadline,
+    }),
+  );
+
+  return {
+    webhookRuntime,
+    /** Resolve the durable `settle` reply for `orderId` from the side sender. */
+    settleResult: (orderId: string) =>
+      sender.runPromise(
+        Order.Entity.settle.waitFor(
+          {
+            orderId,
+            outcome: undefined,
+            sessionId: undefined,
+            paymentIntentId: undefined,
+          },
+          { filter: (result) => result._tag !== 'Pending' },
+        ),
+      ),
+    /** Peek the durable `settle` reply WITHOUT waiting (for the unresolved case). */
+    settlePeek: (orderId: string) =>
+      sender.runPromise(
+        Order.Entity.settle.peek({
+          orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        }),
+      ),
+    /** The derived actor `OrderState` VIEW, read on the runner's SHARED bucket. */
+    actorState: (orderId: string) =>
+      readRuntime.runPromise(OrderActor.readState(orderId)),
+    /** The webhook-side `settle` ExecId derived from the `{ orderId }`-only payload. */
+    webhookExecId: (orderId: string) =>
+      sender.runPromise(
+        Order.Entity.settle.executionId({
+          orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        }),
+      ),
+    dispose: async () => {
+      await runner.dispose();
+      await sender.dispose();
+      await readRuntime.dispose();
+    },
+  };
+};
+
+describe('/api/stripe/webhook — durable Order settle drive (order-workflow G8)', () => {
+  it('resolves settle to Success across the SQL MessageStorage: State + bucket paid, replay byte-identical', async () => {
+    const order = pendingOrder('ord-g8-paid', 15000);
+    const stack = await durableStack(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    try {
+      const body = eventBody('checkout.session.completed', order.orderId, 15000);
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      const args = webhookArgs(stack.webhookRuntime, body, signature);
+
+      const response = await action(args);
+      expect(response.status).toBe(200);
+
+      // The durable `settle` op resolved Success on the runner ...
+      const settled = await stack.settleResult(order.orderId);
+      expect(settled._tag).toBe('Success');
+
+      // ... the actor State (derived view over the SHARED bucket) reads `paid` ...
+      const state = await stack.actorState(order.orderId);
+      expect(state.status).toBe('paid');
+      expect(state.paidAt).toBeDefined();
+
+      // ... and the bucket order (the RECEIPT AUTHORITY the webhook flipped) is
+      // `paid` with a frozen `paidAt`.
+      const paid = await readStatus(stack.webhookRuntime, args, order.orderId);
+      expect(paid).toBe('paid');
+
+      // A verbatim REPLAY POST is a 200 no-op leaving `paidAt` byte-identical
+      // (encore dedup re-resolves the already-terminal ExecId; `markOrderPaid`
+      // freezes `paidAt`).
+      const replayBody = eventBody(
+        'checkout.session.completed',
+        order.orderId,
+        15000,
+      );
+      const replaySig = await signPayload(
+        replayBody,
+        Math.floor(Date.now() / 1000),
+      );
+      const replayArgs = webhookArgs(
+        stack.webhookRuntime,
+        replayBody,
+        replaySig,
+      );
+      const firstPaidAt = String(state.paidAt);
+      expect((await action(replayArgs)).status).toBe(200);
+      const afterReplay = await stack.actorState(order.orderId);
+      expect(String(afterReplay.paidAt)).toBe(firstPaidAt);
+    } finally {
+      await stack.dispose();
+    }
+  });
+
+  it('ExecId round-trip (Decision 4): the webhook `{ orderId }`-only ExecId equals the manual format the runner replied to', async () => {
+    const order = pendingOrder('ord-g8-execid', 15000);
+    const stack = await durableStack(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    try {
+      const body = eventBody('checkout.session.completed', order.orderId, 15000);
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      await action(webhookArgs(stack.webhookRuntime, body, signature));
+
+      // The webhook holds only `metadata.orderId`, yet its `{ orderId }`-only
+      // payload derives the SAME ExecId the runner keyed its reply by — `id`
+      // ignores every other payload field (the property the whole G8 resolution
+      // hinges on). It also equals the manually formatted
+      // `entityId\x00tag\x00primaryKey` string.
+      const webhookExecId = await stack.webhookExecId(order.orderId);
+      const manual = `${order.orderId}\x00settle\x00${order.orderId}`;
+      expect(String(webhookExecId)).toBe(manual);
+
+      // And the reply that ExecId resolves is the runner's terminal Success.
+      const settled = await stack.settleResult(order.orderId);
+      expect(isSuccess(settled)).toBe(true);
+    } finally {
+      await stack.dispose();
+    }
+  });
+
+  it('an amount MISMATCH leaves the settle op UNRESOLVED + the order pending + 400', async () => {
+    const order = pendingOrder('ord-g8-mismatch', 15000);
+    const stack = await durableStack(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    try {
+      // The charged amount (9999) differs from the frozen order amount (15000) —
+      // the verified-amount guard short-circuits BEFORE the settle drive.
+      const body = eventBody('checkout.session.completed', order.orderId, 9999);
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      const args = webhookArgs(stack.webhookRuntime, body, signature);
+
+      const response = await action(args);
+      expect(response.status).toBe(400);
+
+      // The order stays pending (the bucket authority never flipped) ...
+      expect(await readStatus(stack.webhookRuntime, args, order.orderId)).toBe(
+        'pending',
+      );
+      // ... and the durable `settle` op was NEVER sent — its reply is Pending
+      // (only the `arm` anchor exists, no settle send happened).
+      const peeked = await stack.settlePeek(order.orderId);
+      expect(peeked._tag).toBe('Pending');
+    } finally {
+      await stack.dispose();
+    }
+  });
+
+  it('async_payment_failed flips the bucket failed AND resolves settle to a Failure (no regression, Decision 7)', async () => {
+    const order = pendingOrder('ord-g8-failed', 15000);
+    const stack = await durableStack(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    try {
+      const body = eventBody(
+        'checkout.session.async_payment_failed',
+        order.orderId,
+        15000,
+      );
+      const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+      const args = webhookArgs(stack.webhookRuntime, body, signature);
+
+      const response = await action(args);
+      expect(response.status).toBe(200);
+
+      // The bucket flipped `failed` (the existing webhook behavior, preserved) ...
+      expect(await readStatus(stack.webhookRuntime, args, order.orderId)).toBe(
+        'failed',
+      );
+      // ... and the durable `settle` resolved to a Failure (`SettleFailed`) — the
+      // op terminal, the durable reply a Failure, mirroring the bucket `failed`.
+      const settled = await stack.settleResult(order.orderId);
+      expect(settled._tag).toBe('Failure');
+    } finally {
+      await stack.dispose();
+    }
+  });
+});
+
+/**
+ * Build the webhook AppRuntime (the `AppRuntime` SENDER) over a DB-configured env
+ * + shared bucket but DELIBERATELY boot NO runner: the SQL MessageStorage exists
+ * (the `settle` `send` lands durably) but NOTHING consumes the mailbox, so the
+ * persisted reply never goes terminal. This models the single-instance partial
+ * failure where the runner/sweep fiber has defected while the HTTP server keeps
+ * serving — `waitFor` would poll the never-terminal reply forever. Returns the
+ * webhook runtime (no runner/sender exist to tear down; the bucket is in-memory).
+ */
+const runnerlessWebhookRuntime = (order: RegistrationOrder): RequestRuntime => {
+  const dbFile = tmpDbFile(order.orderId);
+  const storage = sharedStorageLayer(seed(order));
+  const config = ConfigProvider.layer(
+    ConfigProvider.fromEnv({ env: dbStripeEnv(dbFile) }),
+  );
+  return makeRequestRuntimeFromLayer(
+    makeAppLayer(storage).pipe(Layer.provide(config)) as AppLayer,
+  );
+};
+
+describe('/api/stripe/webhook — settle drive is BOUNDED when the runner is down (G8 200-guarantee)', () => {
+  it('returns 200 within the timeout bound (not hang) when NO runner consumes the mailbox', async () => {
+    // DB IS configured (so `settleOrder` runs the real `send` + bounded `waitFor`),
+    // but no runner is booted — the mailbox is never consumed, so the durable reply
+    // stays Pending FOREVER. An unbounded `waitFor` would hang the request fiber and
+    // never return; the `Effect.timeout('5 seconds')` bound degrades to the
+    // swallow-and-200 path the drive already claims. The bucket flip (the receipt
+    // authority) still earned the 200.
+    const order = pendingOrder('ord-g8-norunner', 15000);
+    const runtime = runnerlessWebhookRuntime(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const body = eventBody('checkout.session.completed', order.orderId, 15000);
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(runtime, body, signature);
+
+    const started = Date.now();
+    const response = await action(args);
+    const elapsed = Date.now() - started;
+
+    // The action returned 200 (the bucket flip's status) rather than hanging ...
+    expect(response.status).toBe(200);
+    // ... and it returned within the bound + slack (well under an unbounded hang).
+    expect(elapsed).toBeLessThan(8000);
+    // ... and the bucket order (the receipt authority) is `paid` regardless of
+    // the dead runner — the durable `send` landed and reconciles on recovery.
+    expect(await readStatus(runtime, args, order.orderId)).toBe('paid');
+  }, 15000);
+});
+
+describe('/api/stripe/webhook — DB-less degrades to the bucket-only flip (G8 backward compat)', () => {
+  it('a completed paid event still 200s + flips the bucket paid with NO DB configured', async () => {
+    // The default `stripeAppLayer` has NO `DATABASE_URL`, so `Env.database` is
+    // None — the webhook's `settleOrder` drive is skipped entirely and the bucket
+    // flip is the sole reconcile (the pre-G8 behavior, unchanged).
+    const runtime = makeRequestRuntimeFromLayer(
+      stripeAppLayer(seed(pendingOrder('ord-no-db', 15000))),
+    );
+    const body = eventBody('checkout.session.completed', 'ord-no-db', 15000);
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(runtime, body, signature);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const response = await action(args);
+    expect(response.status).toBe(200);
+    expect(await readStatus(runtime, args, 'ord-no-db')).toBe('paid');
   });
 });

--- a/app/lib/forms/webhook.server.test.ts
+++ b/app/lib/forms/webhook.server.test.ts
@@ -11,6 +11,7 @@ import {
   Result,
   Schema,
 } from 'effect';
+import { ClusterError, MessageStorage } from 'effect/unstable/cluster';
 import { TestClock } from 'effect/testing';
 import { RouterContextProvider } from 'react-router';
 import { isSuccess } from 'effect-encore';
@@ -1047,6 +1048,214 @@ describe('/api/stripe/webhook — settle drive is BOUNDED when the runner is dow
     // the dead runner — the durable `send` landed and reconciles on recovery.
     expect(await readStatus(runtime, args, order.orderId)).toBe('paid');
   }, 15000);
+});
+
+/**
+ * (F3) A webhook AppRuntime whose Order SENDER is wired over a FAULTY
+ * `MessageStorage`: it DELEGATES every method to the real `MessageStorageLive`
+ * (over a real shared sqlite FILE, so `Env.database` is genuinely Some and the
+ * `settleOrder` drive runs) EXCEPT `saveRequest`, which fails with a typed
+ * `PersistenceError` — modelling a SQL/mailbox fault on the durable `settle.send`
+ * write. `send` calls `mailbox.send → storage.saveRequest` (effect-encore
+ * `actor-mailbox.js`), so this fails the `send` with a `PersistenceError` (mapped
+ * by `Entity.settle.send` into `Order.SettleSendError`) BEFORE any durable row
+ * lands. The faulty sender is injected through `makeAppLayer`'s `senderLayer`
+ * test seam (mirroring the existing `paymentLayer` seam), shadowing the real
+ * `appSenderLayer` for this one runtime only.
+ */
+const faultySenderWebhookRuntime = (order: RegistrationOrder): RequestRuntime => {
+  const dbFile = tmpDbFile(order.orderId);
+  const storage = sharedStorageLayer(seed(order));
+  const config = ConfigProvider.layer(
+    ConfigProvider.fromEnv({ env: dbStripeEnv(dbFile) }),
+  );
+  // Decorate the real storage: every method delegates to `MessageStorageLive`
+  // (resolved from the underlying provide), but `saveRequest` fails — so the
+  // `settle.send` write fails with a `PersistenceError` while every other read
+  // (the runner has none here anyway) stays faithful.
+  const faultyStorage = Layer.effect(
+    MessageStorage.MessageStorage,
+    Effect.gen(function* () {
+      const real = yield* MessageStorage.MessageStorage;
+      return MessageStorage.MessageStorage.of({
+        ...real,
+        saveRequest: () =>
+          Effect.fail(
+            new ClusterError.PersistenceError({
+              cause: new Error('injected: settle.send mailbox write failed'),
+            }),
+          ),
+      });
+    }),
+  ).pipe(Layer.provide(Order.MessageStorageLive));
+
+  // Mirror `appSenderLayer`'s `orDie` on the real DB branch: `Env.database` IS Some
+  // here, so `MessageStorageLive`'s `DatabaseUnconfigured` gate cannot fire — `orDie`
+  // discharges it to keep the sender's error channel `never` (the seam `makeAppLayer`
+  // requires). The INJECTED `saveRequest` `PersistenceError` is in the per-op `send`
+  // channel, not the layer build, so it is untouched by `orDie`.
+  const appLayer = makeAppLayer(
+    storage,
+    undefined,
+    Order.senderLayer(faultyStorage).pipe(Layer.orDie),
+  ).pipe(Layer.provide(config)) as AppLayer;
+  return makeRequestRuntimeFromLayer(appLayer);
+};
+
+describe('/api/stripe/webhook — settle `send` persistence failure fails the response so Stripe retries (F3)', () => {
+  it('a completed paid event whose durable `settle.send` cannot persist returns a retryable 502', async () => {
+    // The `settle.send` write fails with a `PersistenceError` BEFORE the durable
+    // row lands. F3: this MUST NOT be swallowed into a 200 — with no durable
+    // settle the runner has nothing to reconcile (a lost-settle money hazard), so
+    // the webhook returns a retryable 502 and Stripe retries until the send lands.
+    const order = pendingOrder('ord-f3-sendfail', 15000);
+    const runtime = faultySenderWebhookRuntime(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const body = eventBody(
+      'checkout.session.completed',
+      order.orderId,
+      15000,
+    );
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(runtime, body, signature);
+
+    const response = await action(args);
+    // Non-2xx — Stripe retries (the durable settle never persisted).
+    expect(response.status).toBe(502);
+    // The bucket DID flip paid (the receipt authority earned it before the drive);
+    // the F1 `canTransition` identity case makes the inevitable Stripe RETRY a safe
+    // no-op on the already-paid bucket, re-driving only the failed `send`.
+    expect(await readStatus(runtime, args, order.orderId)).toBe('paid');
+  });
+
+  it('an async_payment_failed event whose durable `settle.send` cannot persist also returns a retryable 502', async () => {
+    // The `async_payment_failed` path drives `settle` with `outcome: 'failed'`;
+    // its `send` persistence failure is fatal for the same reason — fail the
+    // response so Stripe retries. The bucket already flipped `failed`; the F1
+    // `markOrderFailed` identity case makes the retry a safe no-op.
+    const order = pendingOrder('ord-f3-failsend', 15000);
+    const runtime = faultySenderWebhookRuntime(order);
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const body = eventBody(
+      'checkout.session.async_payment_failed',
+      order.orderId,
+      15000,
+    );
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(runtime, body, signature);
+
+    const response = await action(args);
+    expect(response.status).toBe(502);
+    expect(await readStatus(runtime, args, order.orderId)).toBe('failed');
+  });
+});
+
+describe('/api/stripe/webhook — wait-timeout AFTER a successful `send` still 200s + converges (F3)', () => {
+  it('the durable `send` LANDS, the runner is down so the wait times out, yet the webhook 200s and the runner converges on recovery', async () => {
+    // The F3 split swallows ONLY the post-`send` `waitFor`/timeout. Here the
+    // `send` SUCCEEDS (the durable row lands in the shared mailbox) but NO runner
+    // consumes it, so the bounded `waitFor` times out. That is safe to 200: the
+    // durable row is persisted, so the runner reconciles it on recovery. This is
+    // the SAME runner-down stack as the G8 200-guarantee, asserted here for the
+    // `send`-succeeds-wait-fails half of the split — and we prove convergence by
+    // booting a runner against the SAME file afterward and observing the durable
+    // settle resolve to a terminal reply.
+    const order = pendingOrder('ord-f3-waittimeout', 15000);
+    const dbFile = tmpDbFile(order.orderId);
+    const storage = sharedStorageLayer(seed(order));
+    const config = ConfigProvider.layer(
+      ConfigProvider.fromEnv({ env: dbStripeEnv(dbFile) }),
+    );
+
+    const submissions = Layer.provideMerge(
+      Submissions.layer,
+      Layer.provideMerge(Content.layer, storage),
+    );
+    // The webhook AppRuntime over the REAL sender (durable send LANDS), no runner.
+    const webhookRuntime = makeRequestRuntimeFromLayer(
+      makeAppLayer(storage).pipe(Layer.provide(config)) as AppLayer,
+    );
+    // A side sender over the SAME file to anchor `arm` and later read the reply.
+    const sender = ManagedRuntime.make(
+      Order.senderLayer(Order.MessageStorageLive).pipe(
+        Layer.provide(Env.layer),
+        Layer.provide(config),
+      ),
+    );
+    // Anchor the entity at `pending` (the action's `arm`) before settling.
+    await sender.runPromise(
+      Order.Entity.arm.send({
+        orderId: order.orderId,
+        mode: order.mode,
+        amount: order.amount,
+        currency: order.currency,
+        receiptEmail: order.receiptEmail,
+        sessionId: order.sessionId,
+        registrantIds: order.registrantIds,
+        deadline: order.deadline,
+      }),
+    );
+
+    const { action } = await import('../../routes/api.stripe-webhook');
+    const body = eventBody('checkout.session.completed', order.orderId, 15000);
+    const signature = await signPayload(body, Math.floor(Date.now() / 1000));
+    const args = webhookArgs(webhookRuntime, body, signature);
+
+    try {
+      const started = Date.now();
+      const response = await action(args);
+      const elapsed = Date.now() - started;
+
+      // 200 (the bucket flip's status) — the post-send wait timed out but was
+      // swallowed, NOT propagated, because the durable `send` already landed.
+      expect(response.status).toBe(200);
+      expect(elapsed).toBeLessThan(8000);
+      expect(await readStatus(webhookRuntime, args, order.orderId)).toBe('paid');
+
+      // The durable `settle` row PERSISTED (the send succeeded): the reply is
+      // Pending while no runner consumes it — proving the row is in storage to
+      // reconcile, not lost.
+      const pending = await sender.runPromise(
+        Order.Entity.settle.peek({
+          orderId: order.orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        }),
+      );
+      expect(pending._tag).toBe('Pending');
+
+      // CONVERGENCE: boot a runner against the SAME file; it consumes the
+      // persisted `send` and resolves the durable settle to a terminal reply.
+      const runner = ManagedRuntime.make(
+        Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
+          Layer.provide(submissions),
+          Layer.provide(Payment.testLayer()),
+          Layer.provide(Env.layer),
+          Layer.provide(config),
+        ),
+      );
+      await runner.runPromise(Effect.void);
+      try {
+        const settled = await sender.runPromise(
+          Order.Entity.settle.waitFor(
+            {
+              orderId: order.orderId,
+              outcome: undefined,
+              sessionId: undefined,
+              paymentIntentId: undefined,
+            },
+            { filter: (result) => result._tag !== 'Pending' },
+          ),
+        );
+        expect(settled._tag).toBe('Success');
+      } finally {
+        await runner.dispose();
+      }
+    } finally {
+      await sender.dispose();
+    }
+  }, 20000);
 });
 
 describe('/api/stripe/webhook — DB-less degrades to the bucket-only flip (G8 backward compat)', () => {

--- a/app/lib/order/cross-runtime.test.ts
+++ b/app/lib/order/cross-runtime.test.ts
@@ -1,0 +1,139 @@
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Layer, ManagedRuntime, Schema } from 'effect';
+
+import { Actor, isSuccess, fromSqlClient } from 'effect-encore';
+import { SqliteClient } from '@effect/sql-sqlite-bun';
+
+import { Order } from './runner.server';
+
+/**
+ * G3 — the BLOCKER test (cross-review mustFix). The ONLY test that exercises the
+ * REAL two-runtime topology: a RUNNER graph (the `ServerLive` analog — consumes
+ * the mailbox, runs handlers, writes replies) and a SENDER graph (the
+ * `AppRuntime` analog — the registration action / Stripe webhook side) built as
+ * SEPARATE layer graphs with SEPARATE `SqlClient` builds.
+ *
+ * The two graphs coordinate the durable Order lifecycle ONLY through the shared
+ * `cluster_messages` / `cluster_replies` rows — which means ONLY if both point
+ * at the SAME sqlite FILE. The positive case proves a sender-graph `send` is
+ * consumed by the runner-graph handler and a SECOND independent sender's `peek`
+ * sees it terminal over the shared file.
+ *
+ * The negative control repeats the same orchestration with `':memory:'` on each
+ * graph and proves the send is NOT observed cross-graph — the two-disjoint-DBs
+ * failure mode the whole topology hinges on. It is kept permanently so a future
+ * `':memory:'` regression (which would silently break the production
+ * route → runner → webhook loop) is caught by the suite.
+ */
+
+const ProbeEntity = Actor.fromEntity('CrossRuntimeProbe', {
+  Ping: {
+    payload: { key: Schema.String },
+    success: Schema.String,
+    persisted: true,
+    id: (p: { key: string }) => p.key,
+  },
+});
+
+const probeHandlers = Actor.toLayer(ProbeEntity, {
+  Ping: ({ operation }) => Effect.succeed(`pong: ${operation.key}`),
+});
+
+const storageOver = (filename: string) =>
+  fromSqlClient().pipe(
+    Layer.provide(SqliteClient.layer({ filename })),
+  );
+
+/** A long-lived runner ManagedRuntime over `filename` (the `ServerLive` analog). */
+const acquireRunner = (filename: string) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      ManagedRuntime.make(
+        probeHandlers.pipe(
+          Layer.provideMerge(Order.runnerLayer(storageOver(filename))),
+        ),
+      ),
+    ),
+    (rt) => Effect.promise(() => rt.dispose()),
+  );
+
+/** A sender ManagedRuntime over `filename` (the `AppRuntime` analog). */
+const acquireSender = (filename: string) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      ManagedRuntime.make(Order.senderLayer(storageOver(filename))),
+    ),
+    (rt) => Effect.promise(() => rt.dispose()),
+  );
+
+const tmpFile = (suffix: string) =>
+  `${tmpdir()}/gyc-order-cross-runtime-${process.pid}-${Date.now()}-${suffix}.sqlite`;
+
+describe('Order cross-runtime topology (the production seam)', () => {
+  it.scopedLive(
+    'a sender-graph send is consumed by the runner-graph handler over ONE shared sqlite FILE',
+    () =>
+      Effect.gen(function* () {
+        const file = tmpFile('positive');
+
+        // The runner graph (ServerLive analog) must be live BEFORE the send so
+        // its mailbox-poll fiber is consuming the shared file.
+        const runner = yield* acquireRunner(file);
+        // Boot the runner graph (force the Sharding poll fiber to start).
+        yield* Effect.promise(() => runner.runPromise(Effect.void));
+
+        // Sender graph 1 (the registration-action analog): enqueue the op.
+        const sender1 = yield* acquireSender(file);
+        yield* Effect.promise(() =>
+          sender1.runPromise(ProbeEntity.Ping.send({ key: 'shared' })),
+        );
+
+        // Sender graph 2 — a SEPARATE sender build (the webhook analog, distinct
+        // SqlClient) over the SAME file — observes the reply the runner wrote.
+        const sender2 = yield* acquireSender(file);
+        const result = yield* Effect.promise(() =>
+          sender2.runPromise(
+            ProbeEntity.Ping.waitFor(
+              { key: 'shared' },
+              { filter: (r) => isSuccess(r) },
+            ),
+          ),
+        );
+
+        expect(result._tag).toBe('Success');
+        if (isSuccess(result)) {
+          expect(result.value).toBe('pong: shared');
+        }
+      }),
+  );
+
+  it.scopedLive(
+    'NEGATIVE CONTROL: :memory: gives each graph a DISJOINT DB so the send is NOT observed cross-graph',
+    () =>
+      Effect.gen(function* () {
+        // Each ManagedRuntime over ':memory:' builds its OWN in-memory DB — the
+        // runner and the sender share NO rows, so the runner never sees the send
+        // and the sender never sees a reply. This is exactly why production MUST
+        // use a shared FILE.
+        const runner = yield* acquireRunner(':memory:');
+        yield* Effect.promise(() => runner.runPromise(Effect.void));
+
+        const sender1 = yield* acquireSender(':memory:');
+        yield* Effect.promise(() =>
+          sender1.runPromise(ProbeEntity.Ping.send({ key: 'isolated' })),
+        );
+
+        const sender2 = yield* acquireSender(':memory:');
+        const result = yield* Effect.promise(() =>
+          sender2.runPromise(ProbeEntity.Ping.peek({ key: 'isolated' })),
+        );
+
+        // sender2's disjoint in-memory DB never saw the send → Pending, never
+        // Success. Proves the seam: cross-runtime coordination REQUIRES the
+        // shared file.
+        expect(result._tag).toBe('Pending');
+      }),
+  );
+});

--- a/app/lib/order/lifecycle.test.ts
+++ b/app/lib/order/lifecycle.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Layer, Schema } from 'effect';
+
+import { Content } from '../content.server';
+import { defaultRegistrationForm } from '../content/pages/defaults';
+import { orderKey, submissionKey } from '../content/pages/registry';
+import { newListItemId, type ListItemId } from '../content/schema';
+import { RegistrationOrder } from '../forms/order';
+import { Payment } from '../payment.server';
+import { Cents, CurrencyCode } from '../forms/pricing';
+import { submissionSchema } from '../forms/submission';
+import { Submissions } from '../forms/submissions.server';
+import { layerTest as storageLayerTest } from '../storage.test-helper';
+
+import { Order } from './runner.server';
+import { OrderActor } from './order.actor';
+
+/**
+ * G9 — the durable-lifecycle CAPSTONE. End-to-end over the REAL
+ * `Order.MessageStorageLive`-shaped SQL runner (`Order.layerTest`, SQLite
+ * `:memory:`) + a network-free `Payment.testLayer`, exercising EVERY edge of the
+ * Order state machine as one durable narrative against the bucket authority:
+ *
+ *   - `pending → paid`       (settle, the webhook-resolved continuation)
+ *   - `pending → cancelled`  (cancel, operator/abandon)
+ *   - `paid → refunded`      (refund, the Stripe-refund terminal)
+ *   - `pending → expired`    (expire, the deadline sweep)
+ *   - the ILLEGAL transitions, all rejected by the handlers' State guards:
+ *       refund-while-pending, expire-while-paid, cancel-while-paid.
+ *
+ * And the THREE cross-cutting invariants:
+ *
+ *   1. the `settle` ExecId is STABLE across a replay, so `paidAt` is
+ *      byte-identical (the idempotency contract, `order.ts` / `c8c4abd`);
+ *   2. the FROZEN `amount` / `receiptEmail` are never re-derived by any op (read
+ *      back from the bucket, compared to the create-time freeze);
+ *   3. the actor State and the bucket `RegistrationOrder.status` NEVER diverge —
+ *      every transition writes both within the one handler (Decision 1).
+ */
+
+const REGISTRANT_IDS: readonly ListItemId[] = [newListItemId(), newListItemId()];
+
+const encodeOrder = Schema.encodeSync(Schema.fromJsonString(RegistrationOrder));
+
+/** The FROZEN amount + receipt every order in this suite is minted with. */
+const FROZEN_AMOUNT = Cents.make(15000);
+const FROZEN_RECEIPT = 'leader@example.com';
+
+/** A pending group order at `orderId`, frozen at $150, naming {@link REGISTRANT_IDS}. */
+const pendingOrder = (orderId: string): RegistrationOrder => ({
+  orderId,
+  mode: 'group',
+  sessionId: `cs_${orderId}`,
+  amount: FROZEN_AMOUNT,
+  currency: CurrencyCode.make('cad'),
+  receiptEmail: FROZEN_RECEIPT,
+  status: 'pending',
+  registrantIds: [...REGISTRANT_IDS],
+});
+
+/** A minimal valid (`payment`-less) exhibitor registrant submission JSON. */
+const registrantSubmissionJson = (id: ListItemId): string =>
+  Schema.encodeSync(
+    Schema.fromJsonString(submissionSchema(defaultRegistrationForm)),
+  )(
+    Schema.decodeUnknownSync(submissionSchema(defaultRegistrationForm))({
+      id,
+      form: 'registration',
+      submittedAt: '2026-06-17',
+      payload: {
+        name: 'Ada Co',
+        phone: '123-456-7890',
+        type: 'exhibitor',
+        synopsis: 'We sell books',
+        website: 'https://example.com',
+        company: 'Ada Books',
+      },
+    }),
+  );
+
+/** Seed one pending order under its `orderKey` ALONGSIDE the registrants it names. */
+const seed = (
+  order: RegistrationOrder,
+): Parameters<typeof storageLayerTest>[0] => ({
+  [orderKey('registration', order.orderId)]: {
+    body: encodeOrder(order),
+    contentType: 'application/json',
+  },
+  ...Object.fromEntries(
+    order.registrantIds.map((id) => [
+      submissionKey('registration', id),
+      { body: registrantSubmissionJson(id), contentType: 'application/json' },
+    ]),
+  ),
+});
+
+/** Read the on-bucket order (the durable authority). */
+const bucketOrder = (orderId: string) =>
+  Effect.gen(function* () {
+    const submissions = yield* Submissions.Service;
+    return yield* submissions.getOrder('registration', orderId);
+  });
+
+/**
+ * Assert invariants 2 + 3 for `orderId` at an expected status: the actor State
+ * and the bucket status agree (never diverge), and the frozen amount/receipt are
+ * intact (never re-derived). Returns the bucket order for further assertions.
+ */
+// The expected status is one of the FIVE actor-visible states (the derived
+// `OrderState` view never carries the bucket-only `failed`); every transition in
+// this suite lands on one of them, so both the bucket status AND the State agree.
+const assertCoherent = (orderId: string, status: OrderActor.OrderStatus) =>
+  Effect.gen(function* () {
+    const order = yield* bucketOrder(orderId);
+    const state = yield* OrderActor.readState(orderId);
+    // Invariant 3: State ↔ bucket never diverge.
+    expect(order.status).toBe(status);
+    expect(state.status).toBe(status);
+    // Invariant 2: the freeze is intact across every transition.
+    expect(order.amount).toBe(FROZEN_AMOUNT);
+    expect(order.receiptEmail).toBe(FROZEN_RECEIPT);
+    return order;
+  });
+
+/** The full durable stack: SQL runner + the `arm`/.../`refund` handlers + bucket authority. */
+const provideStack = (
+  order: RegistrationOrder,
+  paymentLayer: Layer.Layer<Payment.Service> = Payment.testLayer(),
+) => {
+  const storage = storageLayerTest(seed(order));
+  const submissions = Layer.provideMerge(
+    Submissions.layer,
+    Layer.provideMerge(Content.layer, storage),
+  );
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provide(Order.fullRunnerLayer(Order.layerTest)),
+      Effect.provide(submissions),
+      Effect.provide(paymentLayer),
+    );
+};
+
+const settlePaid = (orderId: string) =>
+  Order.Entity.settle.sendAndAwait(
+    { orderId, outcome: undefined, sessionId: undefined, paymentIntentId: undefined },
+    { timeout: '5 seconds' },
+  );
+
+describe('Order durable lifecycle capstone (G9)', () => {
+  it.scopedLive(
+    'pending → paid (settle): ExecId stable across replay, paidAt byte-identical, State/bucket coherent',
+    () => {
+      const order = pendingOrder('ord-paid');
+      return Effect.gen(function* () {
+        // Invariant 1, part A: the action-side full payload and the
+        // webhook-side `{ orderId }`-only payload derive the SAME ExecId (Decision
+        // 4 — `id` ignores every field but `orderId`).
+        const actionExecId = yield* Order.Entity.settle.executionId({
+          orderId: order.orderId,
+          outcome: 'paid',
+          sessionId: order.sessionId,
+          paymentIntentId: 'pi_x',
+        });
+        const webhookExecId = yield* Order.Entity.settle.executionId({
+          orderId: order.orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        });
+        expect(String(actionExecId)).toBe(String(webhookExecId));
+
+        yield* Order.Entity.arm.sendAndAwait(
+          {
+            orderId: order.orderId,
+            mode: order.mode,
+            amount: order.amount,
+            currency: order.currency,
+            receiptEmail: order.receiptEmail,
+            sessionId: order.sessionId,
+            registrantIds: order.registrantIds,
+            deadline: undefined,
+          },
+          { timeout: '5 seconds' },
+        );
+        yield* assertCoherent(order.orderId, 'pending');
+
+        yield* settlePaid(order.orderId);
+        const paid = yield* assertCoherent(order.orderId, 'paid');
+        expect(paid.paidAt).toBeDefined();
+        const firstPaidAt = paid.paidAt;
+
+        // Invariant 1, part B: a verbatim REPLAY re-resolves the same ExecId to a
+        // no-op (encore dedup + `markOrderPaid` idempotency) — `paidAt` does not
+        // drift.
+        yield* settlePaid(order.orderId);
+        const replayed = yield* bucketOrder(order.orderId);
+        expect(replayed.paidAt).toBe(firstPaidAt);
+      }).pipe(provideStack(order));
+    },
+  );
+
+  it.scopedLive('pending → cancelled (cancel): State/bucket coherent', () => {
+    const order = pendingOrder('ord-cancelled');
+    return Effect.gen(function* () {
+      yield* Order.Entity.cancel.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      yield* assertCoherent(order.orderId, 'cancelled');
+    }).pipe(provideStack(order));
+  });
+
+  it.scopedLive(
+    'paid → refunded (refund): Stripe refund against the FROZEN amount, State/bucket coherent',
+    () => {
+      const order = pendingOrder('ord-refunded');
+      const refundCalls: Array<Payment.CreateRefundCall> = [];
+      return Effect.gen(function* () {
+        // Drive it to `paid` first (the only refundable source), then refund.
+        yield* settlePaid(order.orderId);
+        yield* assertCoherent(order.orderId, 'paid');
+
+        yield* Order.Entity.refund.sendAndAwait(
+          { orderId: order.orderId },
+          { timeout: '5 seconds' },
+        );
+
+        // The Stripe refund was issued ONCE, against the order's session + its
+        // FROZEN amount (never re-derived), keyed deterministically.
+        expect(refundCalls.length).toBe(1);
+        expect(refundCalls[0]?.amount).toBe(FROZEN_AMOUNT);
+        expect(refundCalls[0]?.sessionId).toBe(order.sessionId);
+        expect(refundCalls[0]?.idempotencyKey).toBe(
+          `registration:refund:${order.orderId}`,
+        );
+
+        yield* assertCoherent(order.orderId, 'refunded');
+      }).pipe(provideStack(order, Payment.testLayer({ refundCalls })));
+    },
+  );
+
+  it.scopedLive('pending → expired (expire): State/bucket coherent', () => {
+    const order = pendingOrder('ord-expired');
+    return Effect.gen(function* () {
+      yield* Order.Entity.expire.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      yield* assertCoherent(order.orderId, 'expired');
+    }).pipe(provideStack(order));
+  });
+
+  it.scopedLive(
+    'ILLEGAL: refund-while-pending is rejected (RefundNotAllowed), no Stripe call, order untouched',
+    () => {
+      const order = pendingOrder('ord-illegal-refund');
+      const refundCalls: Array<Payment.CreateRefundCall> = [];
+      return Effect.gen(function* () {
+        const exit = yield* Order.Entity.refund
+          .sendAndAwait({ orderId: order.orderId }, { timeout: '5 seconds' })
+          .pipe(Effect.exit);
+        expect(exit._tag).toBe('Failure');
+        expect(refundCalls.length).toBe(0);
+        // The order is left UNTOUCHED at pending (State + bucket coherent).
+        yield* assertCoherent(order.orderId, 'pending');
+      }).pipe(provideStack(order, Payment.testLayer({ refundCalls })));
+    },
+  );
+
+  it.scopedLive(
+    'ILLEGAL: expire-while-paid is a no-op (a settled order is never swept)',
+    () => {
+      const order = pendingOrder('ord-illegal-expire');
+      return Effect.gen(function* () {
+        yield* settlePaid(order.orderId);
+        yield* assertCoherent(order.orderId, 'paid');
+
+        // `expire` against a `paid` order — `markOrderExpired`'s never-downgrade
+        // guard leaves it paid (the State guard, make-impossible-states).
+        yield* Order.Entity.expire.sendAndAwait(
+          { orderId: order.orderId },
+          { timeout: '5 seconds' },
+        );
+        yield* assertCoherent(order.orderId, 'paid');
+      }).pipe(provideStack(order));
+    },
+  );
+
+  it.scopedLive(
+    'ILLEGAL: cancel-while-paid is a no-op (the never-downgrade guard)',
+    () => {
+      const order = pendingOrder('ord-illegal-cancel');
+      return Effect.gen(function* () {
+        yield* settlePaid(order.orderId);
+        yield* assertCoherent(order.orderId, 'paid');
+
+        yield* Order.Entity.cancel.sendAndAwait(
+          { orderId: order.orderId },
+          { timeout: '5 seconds' },
+        );
+        yield* assertCoherent(order.orderId, 'paid');
+      }).pipe(provideStack(order));
+    },
+  );
+
+  it.scopedLive(
+    'LATE-PAYMENT-ON-EXPIRED (Open Q4): a paid settle AFTER expire does NOT resurrect to paid',
+    () => {
+      const order = pendingOrder('ord-late-paid');
+      return Effect.gen(function* () {
+        // The deadline sweep expires the order first ...
+        yield* Order.Entity.expire.sendAndAwait(
+          { orderId: order.orderId },
+          { timeout: '5 seconds' },
+        );
+        yield* assertCoherent(order.orderId, 'expired');
+
+        // ... then a LATE `checkout.session.completed` resolves `settle` (paid).
+        // The reject-and-log guard leaves the order TERMINAL at `expired` — it is
+        // NOT silently resurrected to `paid` (the plan default; honor-vs-auto-
+        // refund is a product decision, see flags). The op still resolves Success
+        // (a no-op), so a sender's `waitFor` terminates cleanly.
+        yield* settlePaid(order.orderId);
+        yield* assertCoherent(order.orderId, 'expired');
+      }).pipe(provideStack(order));
+    },
+  );
+});

--- a/app/lib/order/order.actor.handlers.test.ts
+++ b/app/lib/order/order.actor.handlers.test.ts
@@ -5,8 +5,9 @@ import { ShardingConfig } from 'effect/unstable/cluster';
 import { Content } from '../content.server';
 import { defaultRegistrationForm } from '../content/pages/defaults';
 import { orderKey, submissionKey } from '../content/pages/registry';
-import { newListItemId, type ListItemId } from '../content/schema';
+import { IsoDate, newListItemId, type ListItemId } from '../content/schema';
 import { RegistrationOrder } from '../forms/order';
+import { Payment } from '../payment.server';
 import { Cents, CurrencyCode } from '../forms/pricing';
 import { submissionSchema } from '../forms/submission';
 import { Submissions } from '../forms/submissions.server';
@@ -40,6 +41,13 @@ const pendingOrder = (orderId: string): RegistrationOrder => ({
   receiptEmail: 'leader@example.com',
   status: 'pending',
   registrantIds: [...REGISTRANT_IDS],
+});
+
+/** A PAID order at `orderId` (the only refundable source state, G4 table). */
+const paidOrder = (orderId: string): RegistrationOrder => ({
+  ...pendingOrder(orderId),
+  status: 'paid',
+  paidAt: IsoDate.make('2026-06-20'),
 });
 
 /** A minimal valid (`payment`-less) exhibitor registrant submission JSON. */
@@ -90,7 +98,15 @@ const actorState = (orderId: string) => OrderActor.readState(orderId);
  * the seeded `Storage`), all sharing the one in-memory `Storage` so the test
  * effect reads back exactly what a handler wrote.
  */
-const provideStack = (objects: Parameters<typeof storageLayerTest>[0]) => {
+const provideStack = (
+  objects: Parameters<typeof storageLayerTest>[0],
+  // The `refund` handler (G7) requires `Payment` — a network-free double. The
+  // G6 `arm`/`settle` cases never touch Stripe, so they take the default
+  // (capture-free) double; the G7 refund case passes one with a `refundCalls`
+  // capture so it can assert the frozen amount + idempotency key threaded
+  // through.
+  paymentLayer: Layer.Layer<Payment.Service> = Payment.testLayer(),
+) => {
   const storage = storageLayerTest(objects);
   const submissions = Layer.provideMerge(
     Submissions.layer,
@@ -100,6 +116,7 @@ const provideStack = (objects: Parameters<typeof storageLayerTest>[0]) => {
     effect.pipe(
       Effect.provide(Order.fullRunnerLayer(Order.layerTest)),
       Effect.provide(submissions),
+      Effect.provide(paymentLayer),
     );
 };
 
@@ -191,6 +208,104 @@ describe('Order arm + settle handlers (G6, SQL-backed runner over the bucket aut
       // ... while the bucket has durably flipped to `failed` (no regression,
       // Decision 7) — the existing webhook `markOrderFailed` behavior preserved.
       expect((yield* bucketStatus(order.orderId)).status).toBe('failed');
+    }).pipe(provideStack(seed(order)));
+  });
+});
+
+describe('Order refund + cancel + expire handlers (G7, durable lifecycle continuations)', () => {
+  it.scopedLive(
+    'refund (paid → refunded) issues the Stripe refund against the FROZEN amount + flips the bucket refunded',
+    () => {
+      const order = paidOrder('ord-refund');
+      const refundCalls: Array<Payment.CreateRefundCall> = [];
+      return Effect.gen(function* () {
+        yield* Order.Entity.refund.sendAndAwait(
+          { orderId: order.orderId },
+          { timeout: '5 seconds' },
+        );
+
+        // (1) Exactly ONE Stripe refund was issued, against the order's session
+        // + its FROZEN amount (never re-derived), keyed deterministically so a
+        // re-send replays it.
+        expect(refundCalls.length).toBe(1);
+        expect(refundCalls[0]?.sessionId).toBe(order.sessionId);
+        expect(refundCalls[0]?.amount).toBe(order.amount);
+        expect(refundCalls[0]?.idempotencyKey).toBe(
+          `registration:refund:${order.orderId}`,
+        );
+
+        // (2) The bucket authority + the derived State both read `refunded`.
+        expect((yield* bucketStatus(order.orderId)).status).toBe('refunded');
+        expect((yield* actorState(order.orderId)).status).toBe('refunded');
+      }).pipe(provideStack(seed(order), Payment.testLayer({ refundCalls })));
+    },
+  );
+
+  it.scopedLive(
+    'refund while PENDING resolves to RefundNotAllowed WITHOUT touching Stripe (make-impossible-states)',
+    () => {
+      const order = pendingOrder('ord-refund-pending');
+      const refundCalls: Array<Payment.CreateRefundCall> = [];
+      return Effect.gen(function* () {
+        const exit = yield* Order.Entity.refund
+          .sendAndAwait({ orderId: order.orderId }, { timeout: '5 seconds' })
+          .pipe(Effect.exit);
+
+        // A non-`paid` order is a typed Failure (the durable reply), and NO
+        // Stripe refund was attempted — the guard runs before the money side.
+        expect(exit._tag).toBe('Failure');
+        expect(refundCalls.length).toBe(0);
+        // The order is left UNTOUCHED at pending (no spurious transition).
+        expect((yield* bucketStatus(order.orderId)).status).toBe('pending');
+      }).pipe(provideStack(seed(order), Payment.testLayer({ refundCalls })));
+    },
+  );
+
+  it.scopedLive('cancel (pending → cancelled) flips the bucket + State, no Stripe call', () => {
+    const order = pendingOrder('ord-cancel');
+    return Effect.gen(function* () {
+      yield* Order.Entity.cancel.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      expect((yield* bucketStatus(order.orderId)).status).toBe('cancelled');
+      expect((yield* actorState(order.orderId)).status).toBe('cancelled');
+    }).pipe(provideStack(seed(order)));
+  });
+
+  it.scopedLive('cancel against a PAID order is a no-op (never-downgrade guard)', () => {
+    const order = paidOrder('ord-cancel-paid');
+    return Effect.gen(function* () {
+      yield* Order.Entity.cancel.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      // `markOrderCancelled` only transitions a `pending` order — a paid order
+      // stays paid (the G4 transition table / flipStatus discipline).
+      expect((yield* bucketStatus(order.orderId)).status).toBe('paid');
+    }).pipe(provideStack(seed(order)));
+  });
+
+  it.scopedLive('expire (pending → expired) flips the bucket + State', () => {
+    const order = pendingOrder('ord-expire');
+    return Effect.gen(function* () {
+      yield* Order.Entity.expire.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      expect((yield* bucketStatus(order.orderId)).status).toBe('expired');
+      expect((yield* actorState(order.orderId)).status).toBe('expired');
+    }).pipe(provideStack(seed(order)));
+  });
+
+  it.scopedLive('expire against a PAID order is a no-op (a settled order is never swept)', () => {
+    const order = paidOrder('ord-expire-paid');
+    return Effect.gen(function* () {
+      yield* Order.Entity.expire.sendAndAwait(
+        { orderId: order.orderId },
+        { timeout: '5 seconds' },
+      );
+      expect((yield* bucketStatus(order.orderId)).status).toBe('paid');
     }).pipe(provideStack(seed(order)));
   });
 });

--- a/app/lib/order/order.actor.handlers.test.ts
+++ b/app/lib/order/order.actor.handlers.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Layer, Schema } from 'effect';
+import { ShardingConfig } from 'effect/unstable/cluster';
+
+import { Content } from '../content.server';
+import { defaultRegistrationForm } from '../content/pages/defaults';
+import { orderKey, submissionKey } from '../content/pages/registry';
+import { newListItemId, type ListItemId } from '../content/schema';
+import { RegistrationOrder } from '../forms/order';
+import { Cents, CurrencyCode } from '../forms/pricing';
+import { submissionSchema } from '../forms/submission';
+import { Submissions } from '../forms/submissions.server';
+import { layerTest as storageLayerTest } from '../storage.test-helper';
+
+import { Order } from './runner.server';
+import { OrderActor } from './order.actor';
+
+/**
+ * G6 — the `arm` + `settle` handlers driven END-TO-END through the SQL-backed
+ * in-process Sharding runner (`Order.fullRunnerLayer` over `Order.layerTest`)
+ * against the REAL bucket-authority `Submissions` (over a Map-backed `Storage`).
+ * This proves the load-bearing G6 contract: each op writes BOTH the bucket
+ * transition (the authority) AND the mirrored actor `State`, within the one
+ * handler, so the two never diverge — and the async-payment-failed path
+ * resolves `settle` to a durable Failure while the bucket flips `failed` (no
+ * regression, Decision 7).
+ */
+
+const REGISTRANT_IDS: readonly ListItemId[] = [newListItemId(), newListItemId()];
+
+const encodeOrder = Schema.encodeSync(Schema.fromJsonString(RegistrationOrder));
+
+/** A pending group order at `orderId`, frozen at $150, naming {@link REGISTRANT_IDS}. */
+const pendingOrder = (orderId: string): RegistrationOrder => ({
+  orderId,
+  mode: 'group',
+  sessionId: `cs_${orderId}`,
+  amount: Cents.make(15000),
+  currency: CurrencyCode.make('cad'),
+  receiptEmail: 'leader@example.com',
+  status: 'pending',
+  registrantIds: [...REGISTRANT_IDS],
+});
+
+/** A minimal valid (`payment`-less) exhibitor registrant submission JSON. */
+const registrantSubmissionJson = (id: ListItemId): string =>
+  Schema.encodeSync(Schema.fromJsonString(submissionSchema(defaultRegistrationForm)))(
+    Schema.decodeUnknownSync(submissionSchema(defaultRegistrationForm))({
+      id,
+      form: 'registration',
+      submittedAt: '2026-06-17',
+      payload: {
+        name: 'Ada Co',
+        phone: '123-456-7890',
+        type: 'exhibitor',
+        synopsis: 'We sell books',
+        website: 'https://example.com',
+        company: 'Ada Books',
+      },
+    }),
+  );
+
+/** Seed one pending order under its `orderKey` ALONGSIDE the registrants it names. */
+const seed = (order: RegistrationOrder): Parameters<typeof storageLayerTest>[0] => ({
+  [orderKey('registration', order.orderId)]: {
+    body: encodeOrder(order),
+    contentType: 'application/json',
+  },
+  ...Object.fromEntries(
+    order.registrantIds.map((id) => [
+      submissionKey('registration', id),
+      { body: registrantSubmissionJson(id), contentType: 'application/json' },
+    ]),
+  ),
+});
+
+/** Read the on-bucket order (the durable authority). */
+const bucketStatus = (orderId: string) =>
+  Effect.gen(function* () {
+    const submissions = yield* Submissions.Service;
+    return yield* submissions.getOrder('registration', orderId);
+  });
+
+/** Read the derived actor `OrderState` VIEW (Decision 1 — projected from the bucket). */
+const actorState = (orderId: string) => OrderActor.readState(orderId);
+
+/**
+ * The full G6 stack over ONE Map-backed bucket: the SQL-backed runner + the
+ * `arm`/`settle` handlers, the bucket-authority `Submissions` (over `Content` +
+ * the seeded `Storage`), all sharing the one in-memory `Storage` so the test
+ * effect reads back exactly what a handler wrote.
+ */
+const provideStack = (objects: Parameters<typeof storageLayerTest>[0]) => {
+  const storage = storageLayerTest(objects);
+  const submissions = Layer.provideMerge(
+    Submissions.layer,
+    Layer.provideMerge(Content.layer, storage),
+  );
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provide(Order.fullRunnerLayer(Order.layerTest)),
+      Effect.provide(submissions),
+    );
+};
+
+describe('Order arm + settle handlers (G6, SQL-backed runner over the bucket authority)', () => {
+  it.scopedLive('arm anchors the entity at pending, mirroring the bucket', () => {
+    const order = pendingOrder('ord-arm');
+    return Effect.gen(function* () {
+      yield* Order.Entity.arm.sendAndAwait(
+        {
+          orderId: order.orderId,
+          mode: 'group',
+          amount: order.amount,
+          currency: order.currency,
+          receiptEmail: order.receiptEmail,
+          sessionId: order.sessionId,
+          registrantIds: order.registrantIds,
+          deadline: undefined,
+        },
+        { timeout: '5 seconds' },
+      );
+
+      const state = yield* actorState(order.orderId);
+      expect(state.status).toBe('pending');
+      expect(state.sessionId).toBe(order.sessionId);
+
+      // The bucket authority is untouched at pending (arm does NOT settle).
+      expect((yield* bucketStatus(order.orderId)).status).toBe('pending');
+    }).pipe(provideStack(seed(order)));
+  });
+
+  it.scopedLive('settle (paid) flips the bucket to paid + State paid with a frozen paidAt', () => {
+    const order = pendingOrder('ord-paid');
+    return Effect.gen(function* () {
+      yield* Order.Entity.settle.sendAndAwait(
+        {
+          orderId: order.orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        },
+        { timeout: '5 seconds' },
+      );
+
+      const settled = yield* bucketStatus(order.orderId);
+      expect(settled.status).toBe('paid');
+      // `paidAt` is frozen by `markOrderPaid` (the idempotency contract).
+      expect(settled.paidAt).toBeDefined();
+
+      const state = yield* actorState(order.orderId);
+      expect(state.status).toBe('paid');
+      expect(state.paidAt).toBe(settled.paidAt);
+
+      // A verbatim settle REPLAY is a byte-identical no-op (encore dedup +
+      // `markOrderPaid` idempotency): `paidAt` does not drift.
+      yield* Order.Entity.settle.sendAndAwait(
+        {
+          orderId: order.orderId,
+          outcome: undefined,
+          sessionId: undefined,
+          paymentIntentId: undefined,
+        },
+        { timeout: '5 seconds' },
+      );
+      const replayed = yield* bucketStatus(order.orderId);
+      expect(replayed.paidAt).toBe(settled.paidAt);
+    }).pipe(provideStack(seed(order)));
+  });
+
+  it.scopedLive('settle (failed) flips the bucket to failed + resolves the op to a Failure', () => {
+    const order = pendingOrder('ord-failed');
+    return Effect.gen(function* () {
+      // A persisted Failure reply surfaces in the op's error channel
+      // (`OperationHandle.sendAndAwait` semantics): the async-payment-failed
+      // `settle` resolves to `SettleFailed`.
+      const exit = yield* Order.Entity.settle
+        .sendAndAwait(
+          {
+            orderId: order.orderId,
+            outcome: 'failed',
+            sessionId: undefined,
+            paymentIntentId: undefined,
+          },
+          { timeout: '5 seconds' },
+        )
+        .pipe(Effect.exit);
+
+      expect(exit._tag).toBe('Failure');
+
+      // ... while the bucket has durably flipped to `failed` (no regression,
+      // Decision 7) — the existing webhook `markOrderFailed` behavior preserved.
+      expect((yield* bucketStatus(order.orderId)).status).toBe('failed');
+    }).pipe(provideStack(seed(order)));
+  });
+});
+
+describe('Order cross-runtime shard-parity (G6)', () => {
+  it.scopedLive(
+    'the runner and the sender build from the same ShardingConfig (identical shard count)',
+    () =>
+      Effect.gen(function* () {
+        const readShards = ShardingConfig.ShardingConfig.pipe(
+          Effect.map((config) => config.shardsPerGroup),
+        );
+
+        // The runner (`server.ts`) and the sender (`makeAppLayer`) BOTH build
+        // their `ShardingConfig` from the one exported `Order.ShardingConfigLive`
+        // (`runnerLayer` / `senderLayer` each close over it). Reading the shard
+        // count from two independent builds of that same definition yields the
+        // identical number — a divergent count would route a `send` to a shard
+        // the runner never polls (the cross-runtime parity invariant, §1).
+        const runnerShards = yield* readShards.pipe(
+          Effect.provide(Order.ShardingConfigLive),
+        );
+        const senderShards = yield* readShards.pipe(
+          Effect.provide(Order.ShardingConfigLive),
+        );
+
+        expect(senderShards).toBe(runnerShards);
+        expect(Number.isFinite(runnerShards)).toBe(true);
+      }),
+  );
+});

--- a/app/lib/order/order.actor.test.ts
+++ b/app/lib/order/order.actor.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from 'bun:test';
+import { Result, Schema } from 'effect';
+
+import { IsoDate, newListItemId } from '../content/schema';
+import { Cents, CurrencyCode } from '../forms/pricing';
+
+import {
+  canTransition,
+  OrderState,
+  type BucketStatus,
+} from './order.actor';
+
+/**
+ * G4 — unit tests for the Order entity's STATE MACHINE, exercised WITHOUT a
+ * runtime (no SQL, no runner — that is G3's probe and G6's lifecycle test). Two
+ * things are pinned here:
+ *
+ *   1. the pure transition-table predicate (`canTransition`) — every legal flip
+ *      passes and every illegal flip is rejected, including the
+ *      never-downgrade-a-terminal-state discipline;
+ *   2. the persisted `OrderState` schema round-trips losslessly through
+ *      `encode → JSON → decode` (the shape the actor's durable State cache
+ *      serializes as) and rejects out-of-domain tokens.
+ */
+
+const ALL_STATUSES: ReadonlyArray<BucketStatus> = [
+  'pending',
+  'paid',
+  'cancelled',
+  'refunded',
+  'expired',
+  'failed',
+];
+
+/**
+ * The authoritative legal set (Decision 5): `pending → {paid,cancelled,expired,
+ * failed}`, `paid → refunded`, plus every identity flip. Expressed here
+ * independently of the implementation so the test is a real spec, not a mirror.
+ */
+const LEGAL: ReadonlyArray<readonly [BucketStatus, BucketStatus]> = [
+  ['pending', 'paid'],
+  ['pending', 'cancelled'],
+  ['pending', 'expired'],
+  ['pending', 'failed'],
+  ['paid', 'refunded'],
+];
+
+describe('canTransition (Order lifecycle predicate)', () => {
+  test('every declared transition is legal', () => {
+    for (const [from, to] of LEGAL) {
+      expect(canTransition(from, to)).toBe(true);
+    }
+  });
+
+  test('every identity flip is legal (idempotent replay no-op)', () => {
+    for (const status of ALL_STATUSES) {
+      expect(canTransition(status, status)).toBe(true);
+    }
+  });
+
+  test('every non-declared, non-identity flip is illegal', () => {
+    const legalSet = new Set(LEGAL.map(([from, to]) => `${from}->${to}`));
+    for (const from of ALL_STATUSES) {
+      for (const to of ALL_STATUSES) {
+        if (from === to) continue;
+        const expected = legalSet.has(`${from}->${to}`);
+        expect(canTransition(from, to)).toBe(expected);
+      }
+    }
+  });
+
+  test('terminal states never downgrade (cancelled/refunded/expired/failed are sinks)', () => {
+    const terminals: ReadonlyArray<BucketStatus> = [
+      'cancelled',
+      'refunded',
+      'expired',
+      'failed',
+    ];
+    for (const from of terminals) {
+      for (const to of ALL_STATUSES) {
+        if (to === from) continue;
+        expect(canTransition(from, to)).toBe(false);
+      }
+    }
+  });
+
+  test('paid may ONLY advance to refunded', () => {
+    for (const to of ALL_STATUSES) {
+      if (to === 'paid' || to === 'refunded') continue;
+      expect(canTransition('paid', to)).toBe(false);
+    }
+  });
+});
+
+describe('OrderState schema', () => {
+  const validState = {
+    status: 'paid' as const,
+    sessionId: 'cs_test_1',
+    paidAt: IsoDate.make('2026-06-22'),
+  };
+
+  test('round-trips losslessly through encode → JSON → decode', () => {
+    const json = Schema.encodeSync(Schema.fromJsonString(OrderState))(
+      validState,
+    );
+    const back = Schema.decodeUnknownResult(Schema.fromJsonString(OrderState))(
+      json,
+    );
+    expect(Result.isSuccess(back)).toBe(true);
+    if (Result.isSuccess(back)) {
+      expect(back.success).toEqual(validState);
+    }
+  });
+
+  test('round-trips a pending state with no paidAt (optionalKey absent)', () => {
+    const pending = { status: 'pending' as const, sessionId: 'cs_test_2' };
+    const json = Schema.encodeSync(Schema.fromJsonString(OrderState))(pending);
+    const back = Schema.decodeUnknownResult(Schema.fromJsonString(OrderState))(
+      json,
+    );
+    expect(Result.isSuccess(back)).toBe(true);
+    if (Result.isSuccess(back)) {
+      expect(back.success).toEqual(pending);
+    }
+  });
+
+  test('carries the five actor-visible states (NOT failed)', () => {
+    for (const status of ['pending', 'paid', 'cancelled', 'refunded', 'expired'] as const) {
+      const result = Schema.decodeUnknownResult(OrderState)({
+        status,
+        sessionId: 'cs_test',
+      });
+      expect(Result.isSuccess(result)).toBe(true);
+    }
+  });
+
+  test('rejects failed (a bucket-only terminal, never an actor State value)', () => {
+    const result = Schema.decodeUnknownResult(OrderState)({
+      status: 'failed',
+      sessionId: 'cs_test',
+    });
+    expect(Result.isFailure(result)).toBe(true);
+  });
+
+  test('rejects an off-list status token', () => {
+    const result = Schema.decodeUnknownResult(OrderState)({
+      status: 'bogus',
+      sessionId: 'cs_test',
+    });
+    expect(Result.isFailure(result)).toBe(true);
+  });
+});
+
+/**
+ * The reused registrar brands compile into the actor payloads — a compile-time
+ * smoke that `ArmPayload`'s `Cents` / `CurrencyCode` / `ListItemId` are the
+ * shared definitions (`derive-dont-sync`), not redeclared. Constructing the
+ * branded values here keeps the import live and asserts the brand makers accept
+ * in-domain values.
+ */
+describe('Order actor payload brands (reused, not redeclared)', () => {
+  test('the frozen-linkage brands construct from in-domain values', () => {
+    expect(Cents.make(15000)).toBe(15000 as typeof Cents.Type);
+    expect(CurrencyCode.make('cad')).toBe('cad' as typeof CurrencyCode.Type);
+    expect(typeof newListItemId()).toBe('string');
+  });
+});

--- a/app/lib/order/order.actor.test.ts
+++ b/app/lib/order/order.actor.test.ts
@@ -7,6 +7,7 @@ import { Cents, CurrencyCode } from '../forms/pricing';
 import {
   canTransition,
   OrderState,
+  RefundNotAllowed,
   type BucketStatus,
 } from './order.actor';
 
@@ -89,6 +90,17 @@ describe('canTransition (Order lifecycle predicate)', () => {
       if (to === 'paid' || to === 'refunded') continue;
       expect(canTransition('paid', to)).toBe(false);
     }
+  });
+});
+
+describe('RefundNotAllowed (G7 — the typed non-refundable guard)', () => {
+  test('is a tagged error carrying the orderId + the offending bucket status', () => {
+    // The status field is the BUCKET literal — `failed` (a bucket-only terminal,
+    // never an actor-State value) is a legitimate non-refundable source.
+    const error = new RefundNotAllowed({ orderId: 'ord-1', status: 'failed' });
+    expect(error._tag).toBe('Order.RefundNotAllowed');
+    expect(error.orderId).toBe('ord-1');
+    expect(error.status).toBe('failed');
   });
 });
 

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -9,8 +9,19 @@ import { Submissions } from '../forms/submissions.server';
 import { RegistrationOrder } from '../forms/order';
 import { Payment } from '../payment.server';
 import { NotFound, StorageError } from '../storage.server';
+import {
+  type BucketStatus,
+  canTransition,
+  OrderStatus,
+} from './transitions';
 
 import { Actor } from 'effect-encore';
+
+// Re-export the pure transition surface from its dependency-free home
+// (`transitions.ts`) so existing `OrderActor.*` importers keep resolving these
+// off this module while `submissions.server.ts` imports the SAME predicate
+// directly — one source of truth, no circular import (Decision 5).
+export { type BucketStatus, canTransition, OrderStatus };
 
 /**
  * G4 — the durable **Order entity**: definition + state machine ONLY (no Stripe
@@ -121,15 +132,6 @@ export const OrderIdPayload = {
  * `paidAt` is set the instant `settle` first succeeds and never re-stamped
  * (the byte-identical idempotency contract, `order.ts:62-71`).
  */
-export const OrderStatus = Schema.Literals([
-  'pending',
-  'paid',
-  'cancelled',
-  'refunded',
-  'expired',
-]);
-export type OrderStatus = typeof OrderStatus.Type;
-
 export const OrderState = Schema.Struct({
   status: OrderStatus,
   sessionId: Schema.String,
@@ -218,50 +220,6 @@ export const Order = Actor.fromEntity(
   },
   { state: { schema: OrderState } },
 );
-
-/**
- * The full bucket-status set the transition table reconciles over. It is the
- * UNION of the actor's five visible states PLUS `failed` (bucket-only,
- * `async_payment_failed`) — because legality is a property of the bucket
- * `RegistrationOrder.status` lifecycle, not just the actor cache. Widened in G5
- * to this same closed set on the bucket schema (Decision 5).
- */
-export type BucketStatus =
-  | OrderStatus
-  | 'failed';
-
-/**
- * The pure transition predicate (Decision 5 / G4 scope): which `status → status`
- * flip is legal. The runtime handlers (G6/G7) consult this so an out-of-order or
- * replayed op is a typed no-op rather than a corrupt downgrade — the same
- * never-downgrade-a-terminal-state discipline `flipStatus` enforces at the
- * bucket boundary (`submissions.server.ts`).
- *
- * Legal:
- *   - `pending → { paid, cancelled, expired, failed }`
- *   - `paid    → refunded`
- *   - any `x → x` (idempotent re-flip to the same terminal is a no-op)
- * Everything else is illegal.
- *
- * Terminal states (`cancelled`, `refunded`, `expired`, `failed`) have no legal
- * onward transition except to themselves; `paid` may ONLY go to `refunded`.
- */
-const LEGAL_TRANSITIONS: Readonly<Record<BucketStatus, ReadonlySet<BucketStatus>>> = {
-  pending: new Set<BucketStatus>(['paid', 'cancelled', 'expired', 'failed']),
-  paid: new Set<BucketStatus>(['refunded']),
-  cancelled: new Set<BucketStatus>(),
-  refunded: new Set<BucketStatus>(),
-  expired: new Set<BucketStatus>(),
-  failed: new Set<BucketStatus>(),
-};
-
-/**
- * `true` iff `from → to` is a legal Order lifecycle transition. An identity flip
- * (`from === to`) is always legal (idempotent replay no-op); otherwise the
- * target must be in `from`'s legal target set.
- */
-export const canTransition = (from: BucketStatus, to: BucketStatus): boolean =>
-  from === to || LEGAL_TRANSITIONS[from].has(to);
 
 /**
  * The bucket form every Order entity reconciles. The Order lifecycle is the

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -1,0 +1,200 @@
+export * as OrderActor from './order.actor';
+
+import { Schema } from 'effect';
+
+import { IsoDate, ListItemId } from '../content/schema';
+import { BillingMode } from '../forms/party';
+import { Cents, CurrencyCode } from '../forms/pricing';
+
+import { Actor } from 'effect-encore';
+
+/**
+ * G4 — the durable **Order entity**: definition + state machine ONLY (no Stripe
+ * calls, no bucket writes, no runner wiring — those land in G6/G7).
+ *
+ * The Order WRAPS the registrar freeze (it does NOT replace it). The bucket
+ * `RegistrationOrder` (`app/lib/forms/order.ts`) is the durable source of truth;
+ * this actor's in-process `OrderState` is a derived cache (Architecture Decision
+ * 1). Every op handler (G6/G7) writes the bucket transition (`Submissions`
+ * `flipStatus`, the authority) AND mirrors it into `OrderState` atomically within
+ * the handler.
+ *
+ * ## The op surface (state machine `pending | paid | cancelled | refunded | expired`)
+ *
+ *   - `arm`     — the durable lifecycle ANCHOR. The registration action mints the
+ *                 frozen order + Checkout session synchronously (the freeze stays
+ *                 at the action boundary), then `send`s `arm` to record the entity
+ *                 into existence at `pending`. Fire-and-forget; never re-creates
+ *                 the session.
+ *   - `settle`  — the post-payment continuation the Stripe webhook resolves on
+ *                 `checkout.session.completed` (`pending → paid`). On the
+ *                 async-payment-failed path the webhook resolves `settle` to a
+ *                 Failure → bucket `failed` (no regression, Decision 7).
+ *   - `cancel`  — operator/abandon (`pending → cancelled`). Distinct from `failed`
+ *                 (which is Stripe async-payment-failed).
+ *   - `refund`  — genuinely new (`paid → refunded`); issues a Stripe refund (G7).
+ *   - `expire`  — deadline lapse (`pending → expired`).
+ *
+ * ## The `id` rule (Architecture Decision 4 — the webhook ExecId reconstruction)
+ *
+ * Every op's `id` is a PURE STRING fn of `orderId` alone: `id: (p) => p.orderId`.
+ * When `id` returns a string, `resolveId` sets `entityId === primaryKey ===
+ * orderId` and `id` IGNORES every other payload field. So the webhook — which
+ * holds only `metadata.orderId` — resolves the op's ExecId by calling the op's
+ * own method with a payload carrying only `{ orderId }`
+ * (`Order.settle.waitFor({ orderId })` / `.peek({ orderId })`), WITHOUT
+ * reconstructing the full payload, and WITHOUT `entityIdCodec`/`makeExecId`
+ * string-surgery. The G3 probe (`runner.test.ts`) already proves this property
+ * end-to-end; the round-trip assertion against the REAL ops lands with the
+ * handlers (G6+).
+ */
+
+/**
+ * The frozen order linkage the registration action `send`s into `arm` — every
+ * field that drives the durable lifecycle. The brands are REUSED from the
+ * registrar domain (`derive-dont-sync`, never redeclared): `Cents` /
+ * `CurrencyCode` / `BillingMode` / `ListItemId` / `IsoDate`. This payload
+ * mirrors the bucket `RegistrationOrder` (`app/lib/forms/order.ts`) — the actor
+ * does not invent a parallel shape, it carries the same frozen receipt linkage.
+ */
+export const ArmPayload = {
+  orderId: Schema.String,
+  mode: BillingMode,
+  amount: Cents,
+  currency: CurrencyCode,
+  receiptEmail: Schema.String,
+  sessionId: Schema.String,
+  registrantIds: Schema.Array(ListItemId),
+  deadline: Schema.optionalKey(IsoDate),
+} as const;
+
+/**
+ * The webhook (`checkout.session.completed`) resolves `settle` holding only
+ * `metadata.orderId`, so `orderId` is the ONLY required field. The Stripe
+ * session fields the webhook also carries (`sessionId`, the resolved
+ * `paymentIntentId` for a later refund, G7) ride along as `optionalKey` — `id`
+ * ignores them, so they never perturb the ExecId, but the handler can read them
+ * when present.
+ */
+export const SettlePayload = {
+  orderId: Schema.String,
+  sessionId: Schema.optionalKey(Schema.String),
+  paymentIntentId: Schema.optionalKey(Schema.String),
+} as const;
+
+/** `cancel` / `refund` / `expire` are keyed on `orderId` alone. */
+export const OrderIdPayload = {
+  orderId: Schema.String,
+} as const;
+
+/**
+ * The persisted actor State — a DERIVED in-process cache of the bucket order's
+ * lifecycle (Decision 1). It carries the FIVE actor-visible states; it does NOT
+ * carry `failed` — `failed` is a bucket-only terminal from
+ * `checkout.session.async_payment_failed`, which the actor maps to a Failure
+ * reply (G6), never an `OrderState` value. `sessionId` mirrors the bucket order;
+ * `paidAt` is set the instant `settle` first succeeds and never re-stamped
+ * (the byte-identical idempotency contract, `order.ts:62-71`).
+ */
+export const OrderStatus = Schema.Literals([
+  'pending',
+  'paid',
+  'cancelled',
+  'refunded',
+  'expired',
+]);
+export type OrderStatus = typeof OrderStatus.Type;
+
+export const OrderState = Schema.Struct({
+  status: OrderStatus,
+  sessionId: Schema.String,
+  paidAt: Schema.optionalKey(IsoDate),
+});
+export type OrderState = typeof OrderState.Type;
+
+/**
+ * The Order durable entity. Definition only — handler bodies (the bucket
+ * transitions + Stripe calls) land in G6/G7. Every op is `persisted: true` (the
+ * durable SQL mailbox is the coordination seam between the action sender, the
+ * runner, and the webhook) and keyed `id: (p) => p.orderId` (Decision 4).
+ */
+export const Order = Actor.fromEntity(
+  'Order',
+  {
+    arm: {
+      payload: ArmPayload,
+      success: Schema.Void,
+      persisted: true,
+      id: (p: { readonly orderId: string }) => p.orderId,
+    },
+    settle: {
+      payload: SettlePayload,
+      success: Schema.Void,
+      persisted: true,
+      id: (p: { readonly orderId: string }) => p.orderId,
+    },
+    cancel: {
+      payload: OrderIdPayload,
+      success: Schema.Void,
+      persisted: true,
+      id: (p: { readonly orderId: string }) => p.orderId,
+    },
+    refund: {
+      payload: OrderIdPayload,
+      success: Schema.Void,
+      persisted: true,
+      id: (p: { readonly orderId: string }) => p.orderId,
+    },
+    expire: {
+      payload: OrderIdPayload,
+      success: Schema.Void,
+      persisted: true,
+      id: (p: { readonly orderId: string }) => p.orderId,
+    },
+  },
+  { state: { schema: OrderState } },
+);
+
+/**
+ * The full bucket-status set the transition table reconciles over. It is the
+ * UNION of the actor's five visible states PLUS `failed` (bucket-only,
+ * `async_payment_failed`) — because legality is a property of the bucket
+ * `RegistrationOrder.status` lifecycle, not just the actor cache. Widened in G5
+ * to this same closed set on the bucket schema (Decision 5).
+ */
+export type BucketStatus =
+  | OrderStatus
+  | 'failed';
+
+/**
+ * The pure transition predicate (Decision 5 / G4 scope): which `status → status`
+ * flip is legal. The runtime handlers (G6/G7) consult this so an out-of-order or
+ * replayed op is a typed no-op rather than a corrupt downgrade — the same
+ * never-downgrade-a-terminal-state discipline `flipStatus` enforces at the
+ * bucket boundary (`submissions.server.ts`).
+ *
+ * Legal:
+ *   - `pending → { paid, cancelled, expired, failed }`
+ *   - `paid    → refunded`
+ *   - any `x → x` (idempotent re-flip to the same terminal is a no-op)
+ * Everything else is illegal.
+ *
+ * Terminal states (`cancelled`, `refunded`, `expired`, `failed`) have no legal
+ * onward transition except to themselves; `paid` may ONLY go to `refunded`.
+ */
+const LEGAL_TRANSITIONS: Readonly<Record<BucketStatus, ReadonlySet<BucketStatus>>> = {
+  pending: new Set<BucketStatus>(['paid', 'cancelled', 'expired', 'failed']),
+  paid: new Set<BucketStatus>(['refunded']),
+  cancelled: new Set<BucketStatus>(),
+  refunded: new Set<BucketStatus>(),
+  expired: new Set<BucketStatus>(),
+  failed: new Set<BucketStatus>(),
+};
+
+/**
+ * `true` iff `from → to` is a legal Order lifecycle transition. An identity flip
+ * (`from === to`) is always legal (idempotent replay no-op); otherwise the
+ * target must be in `from`'s legal target set.
+ */
+export const canTransition = (from: BucketStatus, to: BucketStatus): boolean =>
+  from === to || LEGAL_TRANSITIONS[from].has(to);

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -343,14 +343,15 @@ export const handlers = Actor.toLayer(
       // ## Late-payment-on-expired (G9, Open Question 4 — reject-and-log default)
       //
       // A `checkout.session.completed` can race a deadline `expire`: the sweep
-      // flips the order `expired` and THEN a late paid event arrives. The bucket
-      // `markOrderPaid` guard is permissive (any non-`paid` → `paid`), so calling
-      // it unconditionally would silently RESURRECT an `expired`/`cancelled`/
-      // `refunded`/`failed` order to `paid` — a money/support hazard. The G4
-      // transition table (`canTransition`) is the authority: `paid` is reachable
-      // ONLY from `pending` (or idempotently from `paid`). So the paid arm reads
-      // the bucket status FIRST and, when the transition is ILLEGAL (a late settle
-      // on a terminal order), LOGS and leaves the order untouched (the plan
+      // flips the order `expired` and THEN a late paid event arrives. Resurrecting
+      // an `expired`/`cancelled`/`refunded`/`failed` order to `paid` would be a
+      // money/support hazard. The G4 transition table (`canTransition`) is the
+      // authority: `paid` is reachable ONLY from `pending` (or idempotently from
+      // `paid`). `Submissions.markOrderPaid` already enforces this same predicate at
+      // the bucket boundary (F1), so this arm consults the SAME table — no second
+      // source of truth — and reads the bucket status FIRST: when the transition is
+      // ILLEGAL (a late settle on a terminal order), it LOGS and leaves the order
+      // untouched (the plan
       // default — honor-vs-auto-refund is a product decision surfaced for the
       // operator, see flags). The op still resolves Success (a no-op), so the
       // webhook's `waitFor` terminates without a spurious failure — the bucket

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -381,13 +381,39 @@ export const handlers = Actor.toLayer(
       // flips the bucket to `failed` (`Submissions.markOrderFailed`, preserving
       // the existing webhook behavior — no regression, Decision 7) and FAILS the
       // op with `SettleFailed`, so the durable reply is a Failure.
+      //
+      // ## Late-payment-on-expired (G9, Open Question 4 — reject-and-log default)
+      //
+      // A `checkout.session.completed` can race a deadline `expire`: the sweep
+      // flips the order `expired` and THEN a late paid event arrives. The bucket
+      // `markOrderPaid` guard is permissive (any non-`paid` → `paid`), so calling
+      // it unconditionally would silently RESURRECT an `expired`/`cancelled`/
+      // `refunded`/`failed` order to `paid` — a money/support hazard. The G4
+      // transition table (`canTransition`) is the authority: `paid` is reachable
+      // ONLY from `pending` (or idempotently from `paid`). So the paid arm reads
+      // the bucket status FIRST and, when the transition is ILLEGAL (a late settle
+      // on a terminal order), LOGS and leaves the order untouched (the plan
+      // default — honor-vs-auto-refund is a product decision surfaced for the
+      // operator, see flags). The op still resolves Success (a no-op), so the
+      // webhook's `waitFor` terminates without a spurious failure — the bucket
+      // authority stays at its terminal state, unchanged.
       settle: ({ operation }) =>
         (operation.outcome ?? 'paid') === 'failed' ?
           dieOnBucketFault(
             submissions.markOrderFailed(ORDER_FORM, orderId).pipe(Effect.asVoid),
           ).pipe(Effect.flatMap(() => new SettleFailed({ orderId })))
-        : dieOnBucketFault(
-            submissions.markOrderPaid(ORDER_FORM, orderId).pipe(Effect.asVoid),
+        : dieOnBucketFault(submissions.getOrder(ORDER_FORM, orderId)).pipe(
+            Effect.flatMap((order) =>
+              canTransition(order.status, 'paid') ?
+                dieOnBucketFault(
+                  submissions.markOrderPaid(ORDER_FORM, orderId).pipe(Effect.asVoid),
+                )
+                // A late paid settle on a terminal (`expired`/`cancelled`/
+                // `refunded`/`failed`) order — reject-and-log, do NOT resurrect.
+              : Effect.logWarning(
+                  `Order.settle (paid) ignored for ${orderId}: order is already terminal at '${order.status}' (late-payment-on-expired guard — not resurrecting to paid)`,
+                ),
+            ),
           ),
       // `cancel` (`pending → cancelled`) / `expire` (`pending → expired`): the
       // operator-abandon and deadline-lapse terminals. Each is a pure bucket

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -1,10 +1,13 @@
 export * as OrderActor from './order.actor';
 
-import { Schema } from 'effect';
+import { Effect, Schema } from 'effect';
 
 import { IsoDate, ListItemId } from '../content/schema';
 import { BillingMode } from '../forms/party';
 import { Cents, CurrencyCode } from '../forms/pricing';
+import { Submissions } from '../forms/submissions.server';
+import type { RegistrationOrder } from '../forms/order';
+import { NotFound, StorageError } from '../storage.server';
 
 import { Actor } from 'effect-encore';
 
@@ -65,21 +68,42 @@ export const ArmPayload = {
   receiptEmail: Schema.String,
   sessionId: Schema.String,
   registrantIds: Schema.Array(ListItemId),
-  deadline: Schema.optionalKey(IsoDate),
+  // `Schema.optional` (value `IsoDate | undefined`), NOT `optionalKey`: encore's
+  // payload-input mapped type re-requires every key (it does not honor a Type
+  // that omits the key), so an `optionalKey` field would be UNPASSABLE — the
+  // input would demand a non-`undefined` `IsoDate`. `Schema.optional` keeps the
+  // key present in the input type while letting the action pass `undefined` for
+  // a deadline-less order.
+  deadline: Schema.optional(IsoDate),
 } as const;
 
 /**
  * The webhook (`checkout.session.completed`) resolves `settle` holding only
  * `metadata.orderId`, so `orderId` is the ONLY required field. The Stripe
  * session fields the webhook also carries (`sessionId`, the resolved
- * `paymentIntentId` for a later refund, G7) ride along as `optionalKey` — `id`
- * ignores them, so they never perturb the ExecId, but the handler can read them
- * when present.
+ * `paymentIntentId` for a later refund, G7) ride along as `Schema.optional` —
+ * `id` ignores them, so they never perturb the ExecId, but the handler can read
+ * them when present.
+ *
+ * These are `Schema.optional` (value `T | undefined`), NOT `optionalKey`:
+ * encore's payload-input mapped type re-requires every key, so an `optionalKey`
+ * field would demand a non-`undefined` value — `Schema.optional` lets a sender
+ * (the webhook, G8) pass `undefined` for the fields it lacks while still
+ * deriving the same `orderId`-keyed ExecId (Decision 4 — `id` ignores them).
  */
 export const SettlePayload = {
   orderId: Schema.String,
-  sessionId: Schema.optionalKey(Schema.String),
-  paymentIntentId: Schema.optionalKey(Schema.String),
+  // The settlement outcome the webhook resolves `settle` with: a
+  // `checkout.session.completed` carries `'paid'` (⇒ `markOrderPaid` + State
+  // `paid`), a `checkout.session.async_payment_failed` carries `'failed'` (⇒
+  // `markOrderFailed` + the op resolves to a `SettleFailed` Failure reply,
+  // preserving the existing webhook `failed` behavior, Decision 7). `id`
+  // ignores it (it is a pure fn of `orderId`), so a webhook holding only
+  // `metadata.orderId` still resolves the same ExecId; an absent/`undefined`
+  // outcome defaults to `'paid'` (the common completed-session path).
+  outcome: Schema.optional(Schema.Literals(['paid', 'failed'])),
+  sessionId: Schema.optional(Schema.String),
+  paymentIntentId: Schema.optional(Schema.String),
 } as const;
 
 /** `cancel` / `refund` / `expire` are keyed on `orderId` alone. */
@@ -113,6 +137,18 @@ export const OrderState = Schema.Struct({
 export type OrderState = typeof OrderState.Type;
 
 /**
+ * The persisted Failure reply the `settle` op resolves to on the
+ * async-payment-failed path (Decision 7): the bucket has already flipped
+ * `failed` (`Submissions.markOrderFailed`) and the durable reply is a Failure,
+ * so a sender (the webhook, G8) observing it knows the order settled to
+ * `failed`. Carries the `orderId` so the Failure is self-describing.
+ */
+export class SettleFailed extends Schema.TaggedErrorClass<SettleFailed>()(
+  'Order.SettleFailed',
+  { orderId: Schema.String },
+) {}
+
+/**
  * The Order durable entity. Definition only — handler bodies (the bucket
  * transitions + Stripe calls) land in G6/G7. Every op is `persisted: true` (the
  * durable SQL mailbox is the coordination seam between the action sender, the
@@ -130,6 +166,10 @@ export const Order = Actor.fromEntity(
     settle: {
       payload: SettlePayload,
       success: Schema.Void,
+      // The async-payment-failed path resolves `settle` to a Failure reply
+      // (Decision 7) — a persisted, durable Failure the webhook/sender observes
+      // while the bucket has already flipped `failed`.
+      error: SettleFailed,
       persisted: true,
       id: (p: { readonly orderId: string }) => p.orderId,
     },
@@ -198,3 +238,155 @@ const LEGAL_TRANSITIONS: Readonly<Record<BucketStatus, ReadonlySet<BucketStatus>
  */
 export const canTransition = (from: BucketStatus, to: BucketStatus): boolean =>
   from === to || LEGAL_TRANSITIONS[from].has(to);
+
+/**
+ * The bucket form every Order entity reconciles. The Order lifecycle is the
+ * registration-payment lifecycle, and the registration order bucket
+ * (`submissions/registration/orders/<orderId>.json`) is keyed by `'registration'`
+ * — the same form id the Stripe webhook and the registration action use
+ * (`api.stripe-webhook.ts`, `registration-action.ts`). One form, one durable
+ * source of truth.
+ */
+const ORDER_FORM = 'registration';
+
+/**
+ * Project a bucket `RegistrationOrder` onto the actor's derived `OrderState`
+ * cache (Decision 1: bucket = authority, State = mirror). The bucket carries a
+ * `failed` terminal the actor State cannot (it is a Failure REPLY, never a
+ * State value); a `failed` bucket order therefore mirrors as the pre-failure
+ * actor-visible `pending` (the entity exists, awaiting/awaited settlement —
+ * its terminal `failed` outcome lives on the durable reply, not the State).
+ * Every other bucket status is an actor-visible state and passes through.
+ */
+const orderStateFromBucket = (order: RegistrationOrder): OrderState => ({
+  status: order.status === 'failed' ? 'pending' : order.status,
+  sessionId: order.sessionId,
+  ...(order.paidAt === undefined ? {} : { paidAt: order.paidAt }),
+});
+
+/**
+ * G6 — the `arm` + `settle` handler layer. This is the runner-side bytecode the
+ * `ServerLive` Sharding runner registers (`runner.server.ts`); the request side
+ * (registration action + webhook) only `send`s/`waitFor`s against it.
+ *
+ * ## State model (Decision 1 — the bucket IS the authority)
+ *
+ * Every handler reads/writes the durable bucket order through `Submissions`
+ * (the `flipStatus` discipline, `submissions.server.ts`). The actor's
+ * `OrderState` is a DERIVED VIEW (`readState`) projected from that bucket on
+ * read — NOT a separately-stored cache that could drift, and NOT encore's
+ * registered per-entity `State` (whose `registerState`/`getState` protocol is
+ * only wired through the `toTestLayer` activation path, not the production
+ * Sharding `toLayer` runner this lifecycle uses). A process restart between
+ * `arm` and `settle` therefore loses nothing — the bucket order is the durable
+ * record, and the view is recomputed from it.
+ *
+ * ## `arm` — the durable lifecycle anchor
+ *
+ * `arm` does NOT create a session (the action already did, synchronously). It
+ * read-backs the frozen bucket order — re-asserting the entity exists at the
+ * bucket authority at `pending`. Idempotent: a duplicate `arm` for the same
+ * `orderId` re-reads the same order (encore's primaryKey dedup also collapses a
+ * verbatim re-`send`).
+ *
+ * ## `settle` — the post-payment continuation
+ *
+ * Success ⇒ `pending → paid`: `Submissions.markOrderPaid` (the byte-identical
+ * `paidAt` freeze, the idempotency contract). The async-payment-failed path is
+ * the webhook resolving `settle` with `outcome: 'failed'` (G8): the handler
+ * flips the bucket to `failed` via `Submissions.markOrderFailed` and FAILS the
+ * op with `SettleFailed`, so the persisted reply is a Failure — preserving the
+ * existing webhook `failed` behavior with no regression (Decision 7).
+ */
+/**
+ * The derived `OrderState` VIEW: the bucket order projected onto the actor's
+ * lifecycle state (Decision 1 — the bucket is the authority; the "actor State"
+ * is a derived view, computed FROM the bucket on read, never a separately-stored
+ * cache that could drift). The webhook/sweep/admin reads consult this (G8/G9).
+ * A genuinely-missing order surfaces as `NotFound`; a bucket fault as
+ * `StorageError`.
+ *
+ * (encore's registered per-entity `State` protocol — `registerState` /
+ * `getState` — is only wired through the `toTestLayer` activation path today,
+ * NOT the production Sharding `toLayer` runner this lifecycle uses; deriving the
+ * view from the bucket authority is both the supported path AND the
+ * divergence-free one Decision 1 calls for.)
+ */
+export const readState = (
+  orderId: string,
+): Effect.Effect<OrderState, StorageError | NotFound, Submissions.Service> =>
+  Submissions.Service.pipe(
+    Effect.flatMap((submissions) => submissions.getOrder(ORDER_FORM, orderId)),
+    Effect.map(orderStateFromBucket),
+  );
+
+export const handlers = Actor.toLayer(
+  Order,
+  Effect.gen(function* () {
+    const submissions = yield* Submissions.Service;
+    const address = yield* Actor.CurrentAddress;
+    const orderId = address.entityId;
+
+    // A bucket fault (an unreachable bucket, or a stored order that fails to
+    // decode — impossible barring corruption, since orders are written from the
+    // same schema) is a real DEFECT, not a domain outcome: die, exactly as the
+    // bucket-authority layer treats a decode failure (`submissions.server.ts`).
+    // This keeps the ops' typed failure channel to `SettleFailed` ALONE — the
+    // only durable Failure the lifecycle models (the async-payment-failed
+    // settlement). A genuinely-missing bucket order surfaces as `NotFound`,
+    // likewise a defect here (there is nothing to anchor/settle/transition).
+    const dieOnBucketFault = <A, R>(
+      effect: Effect.Effect<A, StorageError | NotFound, R>,
+    ): Effect.Effect<A, never, R> => effect.pipe(Effect.orDie);
+
+    return Order.of({
+      // `arm`: re-assert the bucket order exists (the bucket is the authority;
+      // `arm` does NOT re-create the session). Idempotent — a duplicate `arm`
+      // re-reads the same order (encore's primaryKey dedup also collapses a
+      // verbatim re-`send`). A vanished bucket order is a defect (nothing to
+      // anchor).
+      arm: () =>
+        dieOnBucketFault(
+          submissions.getOrder(ORDER_FORM, orderId).pipe(Effect.asVoid),
+        ),
+      // `settle`: the settlement continuation. `outcome === 'paid'` (the absent
+      // default, the common `checkout.session.completed` path) flips the bucket
+      // to `paid` (idempotent `paidAt` freeze, read back FROM the bucket — never
+      // the clock). `outcome === 'failed'` (the `async_payment_failed` path)
+      // flips the bucket to `failed` (`Submissions.markOrderFailed`, preserving
+      // the existing webhook behavior — no regression, Decision 7) and FAILS the
+      // op with `SettleFailed`, so the durable reply is a Failure.
+      settle: ({ operation }) =>
+        (operation.outcome ?? 'paid') === 'failed' ?
+          dieOnBucketFault(
+            submissions.markOrderFailed(ORDER_FORM, orderId).pipe(Effect.asVoid),
+          ).pipe(Effect.flatMap(() => new SettleFailed({ orderId })))
+        : dieOnBucketFault(
+            submissions.markOrderPaid(ORDER_FORM, orderId).pipe(Effect.asVoid),
+          ),
+      // `cancel` (`pending → cancelled`) / `expire` (`pending → expired`): the
+      // operator-abandon and deadline-lapse terminals. Each is a pure bucket
+      // flip; the `Submissions` helpers (G5) carry the never-downgrade-a-terminal
+      // guard (only a `pending` order transitions), so a flip against a settled
+      // order is a byte-identical no-op. G7 wires the SENDERS (the action/sweep)
+      // that reach these; the bucket transition that IS the authority is here now.
+      cancel: () =>
+        dieOnBucketFault(
+          submissions.markOrderCancelled(ORDER_FORM, orderId).pipe(Effect.asVoid),
+        ),
+      expire: () =>
+        dieOnBucketFault(
+          submissions.markOrderExpired(ORDER_FORM, orderId).pipe(Effect.asVoid),
+        ),
+      // `refund` (`paid → refunded`): the bucket transition (the authority) is
+      // wired now; the additive Stripe refund call (`Payment.createRefund`) + the
+      // `RefundNotAllowed` guard land in G7 BEFORE this flip. `markOrderRefunded`
+      // (G5) already refuses to refund a non-`paid` order, so the flip alone is
+      // safe — G7 only adds the money side and the typed pre-guard.
+      refund: () =>
+        dieOnBucketFault(
+          submissions.markOrderRefunded(ORDER_FORM, orderId).pipe(Effect.asVoid),
+        ),
+    });
+  }),
+);

--- a/app/lib/order/order.actor.ts
+++ b/app/lib/order/order.actor.ts
@@ -6,7 +6,8 @@ import { IsoDate, ListItemId } from '../content/schema';
 import { BillingMode } from '../forms/party';
 import { Cents, CurrencyCode } from '../forms/pricing';
 import { Submissions } from '../forms/submissions.server';
-import type { RegistrationOrder } from '../forms/order';
+import { RegistrationOrder } from '../forms/order';
+import { Payment } from '../payment.server';
 import { NotFound, StorageError } from '../storage.server';
 
 import { Actor } from 'effect-encore';
@@ -149,6 +150,24 @@ export class SettleFailed extends Schema.TaggedErrorClass<SettleFailed>()(
 ) {}
 
 /**
+ * The persisted Failure reply the `refund` op resolves to when the order is NOT
+ * in a refundable state (`make-impossible-states-unrepresentable`): a refund is
+ * legal ONLY from `paid` (`paid → refunded`, the G4 transition table), so a
+ * `refund` against a `pending`/`cancelled`/`expired`/`refunded`/`failed` order
+ * is a typed domain failure — NOT a Stripe call. It carries the `orderId` and
+ * the offending `status` so the operator entrypoint (the manual `/admin`
+ * trigger) can report WHY the refund was refused. Distinct from `PaymentError`
+ * (an actual Stripe/transport fault): this never reaches Stripe.
+ */
+export class RefundNotAllowed extends Schema.TaggedErrorClass<RefundNotAllowed>()(
+  'Order.RefundNotAllowed',
+  // The offending status is the BUCKET status (the authority the guard reads),
+  // so it carries the full closed 6-literal — `failed` included — not the
+  // 5-state actor view: a `failed` order is a legitimate non-refundable source.
+  { orderId: Schema.String, status: RegistrationOrder.fields.status },
+) {}
+
+/**
  * The Order durable entity. Definition only — handler bodies (the bucket
  * transitions + Stripe calls) land in G6/G7. Every op is `persisted: true` (the
  * durable SQL mailbox is the coordination seam between the action sender, the
@@ -182,6 +201,11 @@ export const Order = Actor.fromEntity(
     refund: {
       payload: OrderIdPayload,
       success: Schema.Void,
+      // A `refund` against a non-`paid` order resolves to a typed
+      // `RefundNotAllowed` Failure (make-impossible-states) — the only
+      // transition reachable FROM `paid` (G4 table). The Stripe call only fires
+      // on the `paid` happy path (G7 handler).
+      error: RefundNotAllowed,
       persisted: true,
       id: (p: { readonly orderId: string }) => p.orderId,
     },
@@ -324,6 +348,7 @@ export const handlers = Actor.toLayer(
   Order,
   Effect.gen(function* () {
     const submissions = yield* Submissions.Service;
+    const payment = yield* Payment.Service;
     const address = yield* Actor.CurrentAddress;
     const orderId = address.entityId;
 
@@ -378,15 +403,43 @@ export const handlers = Actor.toLayer(
         dieOnBucketFault(
           submissions.markOrderExpired(ORDER_FORM, orderId).pipe(Effect.asVoid),
         ),
-      // `refund` (`paid → refunded`): the bucket transition (the authority) is
-      // wired now; the additive Stripe refund call (`Payment.createRefund`) + the
-      // `RefundNotAllowed` guard land in G7 BEFORE this flip. `markOrderRefunded`
-      // (G5) already refuses to refund a non-`paid` order, so the flip alone is
-      // safe — G7 only adds the money side and the typed pre-guard.
+      // `refund` (`paid → refunded`): the ONLY transition reachable FROM `paid`
+      // (G4 table). The handler (1) reads the order back from the bucket
+      // authority (NEVER re-deriving the amount — the freeze discipline,
+      // Decision 6), (2) GUARDS `status === 'paid'`: a non-`paid` order resolves
+      // to a typed `RefundNotAllowed` Failure WITHOUT touching Stripe
+      // (make-impossible-states); (3) issues the Stripe refund against the FROZEN
+      // amount + the order's `sessionId` (`Payment.createRefund` resolves the
+      // PaymentIntent from the session, since the order stores only a
+      // `sessionId`), keyed by a deterministic `idempotencyKey` so a verbatim
+      // re-send replays the first refund; (4) flips the bucket `refunded`
+      // (`markOrderRefunded`, G5 — itself never-downgrade-guarded and idempotent)
+      // and mirrors it into State. A Stripe/transport fault (`PaymentError` /
+      // `PaymentDisabled`) is a DEFECT, not a domain outcome (the typed failure
+      // channel is `RefundNotAllowed` alone): it dies, leaving the op unresolved
+      // so the operator retry re-issues against the same idempotency key.
       refund: () =>
-        dieOnBucketFault(
-          submissions.markOrderRefunded(ORDER_FORM, orderId).pipe(Effect.asVoid),
-        ),
+        Effect.gen(function* () {
+          const order = yield* dieOnBucketFault(
+            submissions.getOrder(ORDER_FORM, orderId),
+          );
+          if (order.status !== 'paid') {
+            return yield* new RefundNotAllowed({
+              orderId,
+              status: order.status,
+            });
+          }
+          yield* payment
+            .createRefund({
+              sessionId: order.sessionId,
+              amount: order.amount,
+              idempotencyKey: `registration:refund:${orderId}`,
+            })
+            .pipe(Effect.orDie);
+          yield* dieOnBucketFault(
+            submissions.markOrderRefunded(ORDER_FORM, orderId).pipe(Effect.asVoid),
+          );
+        }),
     });
   }),
 );

--- a/app/lib/order/runner.server.ts
+++ b/app/lib/order/runner.server.ts
@@ -2,6 +2,7 @@ export * as Order from './runner.server';
 
 import { Effect, Layer, Option } from 'effect';
 import {
+  ClusterError,
   MessageStorage,
   RunnerHealth,
   Runners,
@@ -13,6 +14,7 @@ import {
   ActorAddressResolverLayer,
   ClientLayer,
   Client,
+  MailboxError,
 } from 'effect-encore';
 
 import { Env } from '../env.server';
@@ -142,6 +144,23 @@ export type SenderServices =
   | Client
   | ActorAddressResolver
   | MessageStorage.MessageStorage;
+
+/**
+ * The error channel of `Entity.<op>.send` — the PERSISTENCE failures of writing
+ * a durable op row into the SQL mailbox (a SQL/transport fault, a full mailbox,
+ * a concurrent processing claim). The webhook (F3) treats a `send` failure as
+ * fatal — the durable settle row never LANDED, so it must fail the response and
+ * let Stripe retry — distinct from the POST-send `waitFor` observation, which is
+ * safely swallowed. Mirrors `Entity.settle.send`'s declared error set
+ * (`MailboxError | PersistenceError | MailboxFull | AlreadyProcessingMessage`,
+ * `effect-encore` `actor.d.ts:230`); typed here so callers map it to a retryable
+ * 5xx without re-deriving the union or reaching into encore internals.
+ */
+export type SettleSendError =
+  | MailboxError
+  | ClusterError.PersistenceError
+  | ClusterError.MailboxFull
+  | ClusterError.AlreadyProcessingMessage;
 
 /**
  * G6 — the SENDER seam threaded into `makeAppLayer` (the `AppRuntime` request

--- a/app/lib/order/runner.server.ts
+++ b/app/lib/order/runner.server.ts
@@ -1,0 +1,104 @@
+export * as Order from './runner.server';
+
+import { Layer } from 'effect';
+import {
+  MessageStorage,
+  RunnerHealth,
+  Runners,
+  RunnerStorage,
+  Sharding,
+} from 'effect/unstable/cluster';
+import {
+  ActorAddressResolver,
+  ActorAddressResolverLayer,
+  ClientLayer,
+  Client,
+} from 'effect-encore';
+
+import { ShardingConfigLive } from './storage.server';
+
+export { MessageStorageLive, ShardingConfigLive, layerTest } from './storage.server';
+
+/**
+ * The single-process in-process Sharding **runner** — the consumer side of the
+ * durable Order lifecycle. It registers the entity handlers (`Actor.toLayer`,
+ * wired in G6) and consumes the SQL-backed mailbox, running the `process` /
+ * `settle` / `cancel` / `refund` / `expire` handlers and writing their durable
+ * replies into `cluster_replies`.
+ *
+ * ## Where this lives (the load-bearing topology)
+ *
+ * This cluster stack belongs in the **long-lived `ServerLive` graph**
+ * (`server.ts`, `Layer.launch`-ed) — NOT the request-handler `makeAppLayer`
+ * graph (consumed once into the `AppRuntime` singleton, never `Layer.launch`-ed).
+ * The runner's mailbox-poll fiber and the deadline-sweep fiber are
+ * process-lifetime fibers; they need the launch-time supervisor `ServerLive`
+ * provides. The request side (registration action + Stripe webhook) is a
+ * SENDER into the SAME shared DB (see `senderLayer`).
+ *
+ * ## Composition
+ *
+ * Verified against `effect-encore/test/send-and-await.test.ts`'s
+ * `FastTerminationCluster`:
+ *
+ *   Sharding.layer
+ *     ⊕ Runners.layerNoop          // single-node: no remote runners
+ *     ⊕ <MessageStorage>           // SQL in prod, in-memory in single-graph tests
+ *     ⊕ RunnerStorage.layerMemory
+ *     ⊕ RunnerHealth.layerNoop
+ *     ⊕ ShardingConfig.layer({...})
+ *
+ * The `MessageStorage` is a PARAMETER: production wires `Order.MessageStorageLive`
+ * (G2, over the shared sqlite FILE), tests wire `Order.layerTest` (`:memory:`).
+ *
+ * ## Shard-parity invariant
+ *
+ * The runner's `ShardingConfig` MUST be the same `Order.ShardingConfigLive` the
+ * SENDER uses — `ActorAddressResolver.fromConfig` routes an entity to a shard
+ * computed from the shard count, so a divergent count makes the sender write a
+ * shard the runner never polls. Both `runnerLayer` and `senderLayer` build from
+ * the one `ShardingConfigLive` export, keeping the two runtimes byte-identical.
+ */
+export const runnerLayer = <R, E, RIn>(
+  messageStorage: Layer.Layer<R | MessageStorage.MessageStorage, E, RIn>,
+): Layer.Layer<Sharding.Sharding | R | MessageStorage.MessageStorage, E, RIn> =>
+  Sharding.layer.pipe(
+    Layer.provideMerge(Runners.layerNoop),
+    Layer.provideMerge(messageStorage),
+    Layer.provide([RunnerStorage.layerMemory, RunnerHealth.layerNoop]),
+    Layer.provide(ShardingConfigLive),
+  );
+
+/**
+ * The **sender** seam — the request/webhook side. In encore 0.14.0 the sender
+ * host is the deep `Client` transport (`ClientLayer.fromConfig`) plus the
+ * `ActorAddressResolver` the `peek`/`waitFor` loop reads directly, both over the
+ * SAME `MessageStorage` + `ShardingConfig` the runner uses. This is what makes
+ * the per-op `send` / `peek` / `waitFor` / `sendAndAwait` methods resolvable
+ * from a host that does NOT run the handlers (the `AppRuntime` request graph).
+ *
+ * It provides `Client | ActorAddressResolver` (+ the mailbox/snowflake the
+ * transport carries) and requires the SAME shared-DB `MessageStorage` — so a
+ * `send` from a route lands in the rows the `ServerLive` runner polls, and a
+ * `peek` from the webhook observes the reply the runner wrote, with ZERO bespoke
+ * adapter. The `MessageStorage` is a parameter for the identical reason as the
+ * runner: prod wires `Order.MessageStorageLive` (shared FILE), tests wire
+ * `Order.layerTest`.
+ */
+export const senderLayer = <R, E, RIn>(
+  messageStorage: Layer.Layer<R | MessageStorage.MessageStorage, E, RIn>,
+): Layer.Layer<
+  Client | ActorAddressResolver | R | MessageStorage.MessageStorage,
+  E,
+  RIn
+> =>
+  Layer.mergeAll(
+    ClientLayer.fromConfig,
+    ActorAddressResolverLayer.fromConfig,
+  ).pipe(
+    // `provideMerge` (not `provide`) so the storage's `MessageStorage` tag stays
+    // in the output: the per-op `send` / `peek` / `waitFor` / `sendAndAwait`
+    // methods require `Client | MessageStorage | ActorAddressResolver`, and the
+    // first two come from here while the resolver wraps the shard config.
+    Layer.provideMerge(Layer.mergeAll(messageStorage, ShardingConfigLive)),
+  );

--- a/app/lib/order/runner.server.ts
+++ b/app/lib/order/runner.server.ts
@@ -1,6 +1,6 @@
 export * as Order from './runner.server';
 
-import { Layer } from 'effect';
+import { Effect, Layer, Option } from 'effect';
 import {
   MessageStorage,
   RunnerHealth,
@@ -15,9 +15,18 @@ import {
   Client,
 } from 'effect-encore';
 
-import { ShardingConfigLive } from './storage.server';
+import { Env } from '../env.server';
+import {
+  ShardingConfigLive,
+  MessageStorageLive,
+  layerTest,
+} from './storage.server';
+import { handlers as orderHandlers, Order as OrderActorEntity } from './order.actor';
 
 export { MessageStorageLive, ShardingConfigLive, layerTest } from './storage.server';
+
+/** Re-export the Order entity so senders (`runtime.ts`, the webhook) dispatch ops through one handle. */
+export const Entity = OrderActorEntity;
 
 /**
  * The single-process in-process Sharding **runner** — the consumer side of the
@@ -102,3 +111,67 @@ export const senderLayer = <R, E, RIn>(
     // first two come from here while the resolver wraps the shard config.
     Layer.provideMerge(Layer.mergeAll(messageStorage, ShardingConfigLive)),
   );
+
+/**
+ * G6 — the FULLY-WIRED Order runner: the `arm` + `settle` (+ `cancel`/`refund`/
+ * `expire`) handler layer (`order.actor.ts` `handlers`) registered onto the
+ * single-process Sharding runner over a given `MessageStorage`. This is the
+ * layer `server.ts` adds to the long-lived `ServerLive` graph (gated on
+ * `Env.database` Some) so the runner's mailbox-poll fiber runs the handlers and
+ * writes their durable replies — the consumer side of the two-runtime topology.
+ *
+ * The handlers require `Submissions.Service` (the bucket-authority writes); the
+ * runner discharges `Sharding | MessageStorage`. So this leaves
+ * `Submissions.Service` plus the storage's `RIn` (`Env.Service` in prod) open,
+ * provided by `server.ts`. Production wires `Order.MessageStorageLive` (the
+ * shared sqlite FILE); the lifecycle tests wire `Order.layerTest` (`:memory:`).
+ */
+export const fullRunnerLayer = <R, E, RIn>(
+  messageStorage: Layer.Layer<R | MessageStorage.MessageStorage, E, RIn>,
+) =>
+  // `provideMerge` (not `provide`): keep the runner's client/storage/registry
+  // services (`Client | MessageStorage | ActorClientService | ActorAddressResolver
+  // | ActorStateRegistry`, which the handlers' `toLayer` output also carries) in
+  // the result, so a same-graph driver (the G6 lifecycle test, which `send`s ops
+  // and reads `getState` against this one runner) can resolve them. In prod this
+  // layer is merged into `ServerLive` where those extra outputs are harmless.
+  orderHandlers.pipe(Layer.provideMerge(runnerLayer(messageStorage)));
+
+/** The services the request/webhook sender contributes to `AppRuntime`. */
+export type SenderServices =
+  | Client
+  | ActorAddressResolver
+  | MessageStorage.MessageStorage;
+
+/**
+ * G6 — the SENDER seam threaded into `makeAppLayer` (the `AppRuntime` request
+ * graph), gated on `Env.database` Some exactly as `Storage`/`Payment` are
+ * optional there. The senders that USE it (the registration action's `arm`
+ * send, G7; the webhook's `settle` resolve, G8) are themselves `Env.database`-
+ * gated, so the DB-less branch never dispatches — but the service TYPES must be
+ * present unconditionally for `AppServices` to be stable, so the None branch
+ * wires the sender over an inert in-memory `layerTest` storage (a "disabled"
+ * instance no DB-less caller reaches, mirroring how `Storage.layerOptional`
+ * always produces `Storage.Service`). The Some branch wires the real
+ * `MessageStorageLive` — the SAME shared sqlite FILE the `ServerLive` runner
+ * polls — and the SAME `ShardingConfigLive` (the cross-runtime shard-parity
+ * invariant: a divergent shard count would route a `send` to a shard the runner
+ * never polls).
+ */
+export const appSenderLayer: Layer.Layer<
+  SenderServices,
+  never,
+  Env.Service
+> = Layer.unwrap(
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
+    return Option.isNone(env.database) ?
+        senderLayer(layerTest)
+        // In this branch `Env.database` IS Some, so `MessageStorageLive`'s
+        // `DatabaseUnconfigured` gate cannot fire — `orDie` reflects that
+        // impossibility (a build failure here would be a real defect) and keeps
+        // the sender's error channel `never`, so threading it into `makeAppLayer`
+        // does not widen `AppRuntime`'s `ConfigError`-only build-error channel.
+      : senderLayer(MessageStorageLive).pipe(Layer.orDie);
+  }),
+);

--- a/app/lib/order/runner.test.ts
+++ b/app/lib/order/runner.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Layer, Schema } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+
+import { Actor, makeExecId, isSuccess, fromSqlClient } from 'effect-encore';
+import { SqliteClient } from '@effect/sql-sqlite-bun';
+
+import { Order } from './runner.server';
+
+/**
+ * G3 — CONFIDENCE probe. A throwaway entity proving the new DB dependency + the
+ * SQL-backed in-process Sharding **runner** + the per-op send/await/ExecId
+ * resolution all work inside GYC's effect/bun toolchain, BEFORE any Order
+ * semantics exist. This establishes the production runner composition (which
+ * encore only ships in its own tests) — exactly why it is front-loaded.
+ *
+ * The probe wires the FULL `Order.runnerLayer` over the REAL SQL `MessageStorage`
+ * (`Order.layerTest`, `:memory:`) — NOT `TestRunner.layer` (which carries its own
+ * memory storage). The point is to prove the REAL SQL mailbox path: the runner
+ * consumes the SQL-backed mailbox, runs the handler, and writes the durable
+ * reply into `cluster_replies`.
+ */
+
+const OrderProbe = Actor.fromEntity('OrderProbe', {
+  Ping: {
+    payload: { key: Schema.String, extra: Schema.String },
+    success: Schema.String,
+    persisted: true,
+    // The Decision-4 id rule: a PURE STRING fn of ONE field (`key`), so
+    // `resolveId` sets entityId === primaryKey === key and the ExecId ignores
+    // every other payload field — the property the webhook relies on (it holds
+    // only `metadata.orderId`).
+    id: (p: { key: string }) => p.key,
+  },
+});
+
+const probeHandlers = Actor.toLayer(OrderProbe, {
+  Ping: ({ operation }) => Effect.succeed(`pong: ${operation.key}`),
+});
+
+/**
+ * A runner over a SQL `MessageStorage` that ALSO leaks `SqlClient` into context
+ * (via `provideMerge` of the SqliteClient) so the durability assertion can read
+ * the very same `:memory:` DB the runner persisted into — `Order.layerTest`
+ * consumes its SqliteClient internally, so a separate `SqlClient` build would be
+ * a DISJOINT in-memory DB.
+ */
+const storageLeakingSql = fromSqlClient().pipe(
+  Layer.provideMerge(SqliteClient.layer({ filename: ':memory:' })),
+);
+
+describe('Order runner (SQL-backed in-process Sharding runner)', () => {
+  it.scopedLive(
+    'sendAndAwait reaches Success, landing rows in cluster_messages/cluster_replies',
+    () =>
+      Effect.gen(function* () {
+        const value = yield* OrderProbe.Ping.sendAndAwait(
+          { key: 'alpha', extra: 'x' },
+          { timeout: '5 seconds' },
+        );
+        expect(value).toBe('pong: alpha');
+
+        // Durability proof: the runner persisted the request + reply through the
+        // REAL SQL MessageStorage (not an in-memory shortcut).
+        const sql = yield* SqlClient.SqlClient;
+        const messages = yield* sql<{ readonly n: number }>`
+          SELECT COUNT(*) AS n FROM cluster_messages
+        `;
+        const replies = yield* sql<{ readonly n: number }>`
+          SELECT COUNT(*) AS n FROM cluster_replies
+        `;
+        expect(Number(messages[0]?.n ?? 0)).toBeGreaterThan(0);
+        expect(Number(replies[0]?.n ?? 0)).toBeGreaterThan(0);
+      }).pipe(
+        Effect.provide(probeHandlers),
+        Effect.provide(Order.runnerLayer(storageLeakingSql)),
+      ),
+  );
+
+  it.scopedLive(
+    'the webhook-shaped ExecId path: executionId ignores the rest of the payload, waitFor sees the terminal reply',
+    () =>
+      Effect.gen(function* () {
+        const key = 'beta';
+
+        // Decision 4: the action side and the webhook side carry DIFFERENT
+        // non-key fields (the webhook reconstructs a payload from only
+        // `metadata.orderId` + the Stripe session, so its `extra` differs from
+        // the action's), yet both derive the SAME ExecId — because `id` is a
+        // pure fn of `key` and ignores every other field. Both also equal the
+        // manually formatted `entityId\x00tag\x00primaryKey` string.
+        const actionSide = yield* OrderProbe.Ping.executionId({
+          key,
+          extra: 'action-payload',
+        });
+        const webhookSide = yield* OrderProbe.Ping.executionId({
+          key,
+          extra: 'webhook-payload',
+        });
+        const manual = makeExecId(`${key}\x00Ping\x00${key}`);
+        expect(String(actionSide)).toBe(String(webhookSide));
+        expect(String(actionSide)).toBe(String(manual));
+
+        // Dispatch with the action-shaped payload ...
+        yield* OrderProbe.Ping.send({ key, extra: 'action-payload' });
+
+        // ... and resolve from the webhook-shaped payload (different `extra`),
+        // through the SAME SQL MessageStorage, with no bespoke adapter — the
+        // `{ key }`-derived ExecId lands on the runner's reply.
+        const result = yield* OrderProbe.Ping.waitFor(
+          { key, extra: 'webhook-payload' },
+          { filter: (r) => isSuccess(r) },
+        );
+        expect(result._tag).toBe('Success');
+        if (isSuccess(result)) {
+          expect(result.value).toBe('pong: beta');
+        }
+      }).pipe(
+        Effect.provide(probeHandlers),
+        Effect.provide(Order.runnerLayer(Order.layerTest)),
+      ),
+  );
+});

--- a/app/lib/order/storage.server.test.ts
+++ b/app/lib/order/storage.server.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'effect-bun-test';
+import {
+  ConfigProvider,
+  Effect,
+  Exit,
+  Layer,
+  Schema,
+} from 'effect';
+import { Snowflake } from 'effect/unstable/cluster';
+import { SqlClient } from 'effect/unstable/sql';
+
+import { fromSqlClient, EncoreMessageStorage } from 'effect-encore';
+import { SqliteClient } from '@effect/sql-sqlite-bun';
+
+import { Env } from '../env.server';
+import { Order } from './storage.server';
+
+/**
+ * A single in-memory SQL graph that exposes BOTH `SqlClient` (so the test can
+ * read `sqlite_master`) and encore's `MessageStorage` / `EncoreMessageStorage`
+ * over the same DB. `Order.layerTest` deliberately consumes its SqliteClient
+ * internally (the production shape), so for the table-inspection assertion we
+ * compose an equivalent graph that keeps `SqlClient` in context.
+ */
+const sqliteMemory = SqliteClient.layer({ filename: ':memory:' });
+const storageOverMemory = Layer.provideMerge(fromSqlClient(), sqliteMemory);
+
+/**
+ * G2 — proves encore's SQL `MessageStorage` adapter (`fromSqlClient`) boots and
+ * round-trips inside GYC's effect/bun toolchain. This is the core version-skew
+ * de-risk: the encore cluster storage is being stood up in GYC for the first
+ * time, against the bumped `effect@beta.75` + `@effect/sql-sqlite-bun`. The
+ * tables it creates (`cluster_messages` / `cluster_replies`) are the durable
+ * seam the two-runtime topology (runner ↔ senders) coordinates through.
+ */
+describe('Order.layerTest (encore SQL MessageStorage over :memory:)', () => {
+  it.effect('creates cluster_messages/cluster_replies tables on boot', () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql<{ readonly name: string }>`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name IN ('cluster_messages', 'cluster_replies')
+        ORDER BY name
+      `;
+      expect(rows.map((row) => row.name)).toEqual([
+        'cluster_messages',
+        'cluster_replies',
+      ]);
+    }).pipe(Effect.provide(storageOverMemory)));
+
+  it.effect("round-trips encore's deleteEnvelope against the real tables", () =>
+    Effect.gen(function* () {
+      const storage = yield* EncoreMessageStorage;
+      // deleteEnvelope wraps a two-statement transaction over both encore
+      // tables; running it (a no-op on an absent request id) proves the encore
+      // extension reaches the real SQL tables through GYC's toolchain without
+      // failing — the durability-path smoke check.
+      yield* storage.deleteEnvelope(Snowflake.Snowflake('1'));
+    }).pipe(Effect.provide(Order.layerTest)));
+});
+
+const envFrom = (env: Record<string, string>) =>
+  Layer.provide(Env.layer, ConfigProvider.layer(ConfigProvider.fromEnv({ env })));
+
+describe('Order.SqlClientLive', () => {
+  it.effect('fails with DatabaseUnconfigured when no DATABASE_URL is set', () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        SqlClient.SqlClient.pipe(
+          Effect.provide(
+            Order.SqlClientLive.pipe(
+              Layer.provide(envFrom({ NODE_ENV: 'development' })),
+            ),
+          ),
+        ),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const unconfigured = exit.cause.reasons.some(
+          (reason) =>
+            reason._tag === 'Fail' &&
+            Schema.is(Order.DatabaseUnconfigured)(reason.error),
+        );
+        expect(unconfigured).toBe(true);
+      }
+    }));
+
+  it.effect('builds a SqlClient when DATABASE_URL is configured', () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        SqlClient.SqlClient.pipe(
+          Effect.provide(
+            Order.SqlClientLive.pipe(
+              Layer.provide(
+                envFrom({
+                  NODE_ENV: 'development',
+                  DATABASE_URL: ':memory:',
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(Exit.isSuccess(exit)).toBe(true);
+    }));
+});

--- a/app/lib/order/storage.server.ts
+++ b/app/lib/order/storage.server.ts
@@ -98,11 +98,24 @@ export const SqlClientLive: Layer.Layer<
  * does NOT re-export `ShardingConfig` (so the runner storage uses the defaults),
  * but the SENDER side cannot borrow the storage's config — it must be provided
  * this layer independently (G6). Exporting the one definition here is what keeps
- * both sides in lockstep. Defaults today (no overrides) — the seam exists so a
- * future non-default shard count stays single-sourced.
+ * both sides in lockstep.
+ *
+ * ## Poll-interval tuning (Risk 3)
+ *
+ * The runner consumes the SQL mailbox by POLLING (`entityMessagePollInterval`),
+ * and encore's default is **10 seconds** — far too slow for the durable Order
+ * settlement, which is driven cross-runtime: the Stripe webhook (`AppRuntime`
+ * sender) `send`s `settle` and the long-lived runner (`ServerLive`) must consume
+ * it and write the `pending → paid` reply promptly (the webhook waits for the
+ * terminal reply within the request). A 10s mailbox poll would make every
+ * settlement lag up to ten seconds. We tighten `entityMessagePollInterval` to
+ * 250ms so the runner picks up a `send` within a couple hundred ms — the
+ * coordination is still durable (the SQL rows are the seam), just polled snappily.
+ * Single-sourced here so BOTH the runner and the sender share the identical
+ * config (the shard-parity invariant is unaffected — only the poll cadence moves).
  */
 export const ShardingConfigLive: Layer.Layer<ShardingConfig.ShardingConfig> =
-  ShardingConfig.layer();
+  ShardingConfig.layer({ entityMessagePollInterval: '250 millis' });
 
 /**
  * encore's SQL `MessageStorage` (`fromSqlClient` — provides BOTH the upstream

--- a/app/lib/order/storage.server.ts
+++ b/app/lib/order/storage.server.ts
@@ -1,0 +1,129 @@
+export * as Order from './storage.server';
+
+import { fromSqlClient } from 'effect-encore';
+import { Effect, Layer, Option, Redacted, Schema } from 'effect';
+import { ShardingConfig } from 'effect/unstable/cluster';
+import { SqlClient } from 'effect/unstable/sql';
+
+import { SqliteClient } from '@effect/sql-sqlite-bun';
+
+import { Env } from '../env.server';
+
+/**
+ * Durable Order workflow storage — encore's SQL `MessageStorage` stood up over
+ * the optional `DATABASE_URL` sqlite database. This is the first time GYC backs
+ * onto encore's cluster storage; everything here is gated on `Env.database`
+ * Some, mirroring the bucket/stripe None-gates (`env.server.ts`).
+ *
+ * House pattern: a module-level `export const layer` set, mirroring
+ * `storage.server.ts` (the bucket store) — `SqlClientLive` fails to *build* with
+ * `Order.DatabaseUnconfigured` when no DB is configured (the analogue of
+ * `Storage.StorageUnconfigured`), so callers that want the durable Order entity
+ * require it, and DB-less deploys simply never compose it (the bucket-only
+ * registration/webhook path is unaffected).
+ *
+ * ## The two-runtime topology (load-bearing)
+ *
+ * GYC has two independent runtime worlds that coordinate the Order lifecycle
+ * ONLY through this storage's backing DB:
+ *
+ * - the long-lived `ServerLive` graph hosts the in-process Sharding **runner**
+ *   (the consumer that runs handlers and writes replies);
+ * - the `AppRuntime` request-handler graph hosts the **senders** (the
+ *   registration action + Stripe webhook).
+ *
+ * These are SEPARATE layer graphs with SEPARATE `SqlClient` builds. They share
+ * the durable `cluster_messages` / `cluster_replies` rows **only if both point
+ * at the same sqlite FILE**. In production `DATABASE_URL` MUST therefore be a
+ * FILE path on a persistent volume — `':memory:'` gives the two graphs two
+ * disjoint in-memory DBs (a `send` from a route lands in a DB the runner never
+ * polls), which silently breaks the route → runner → webhook loop. `':memory:'`
+ * is for single-graph tests only (see `layerTest`).
+ *
+ * This is exactly the pattern the bucket `Storage` already uses: two separate
+ * `Storage` builds coordinate fine because the bucket is external shared state.
+ * Here the shared sqlite FILE is the seam.
+ */
+
+/**
+ * Fail-to-build error when the durable Order storage is required but no
+ * `DATABASE_URL` is configured — the analogue of `Storage.StorageUnconfigured`
+ * (`storage.server.ts`). Callers that need the Order entity require
+ * `SqlClient`; DB-less runtimes never compose this layer, so the error only
+ * surfaces if something requires the durable path without a DB.
+ */
+export class DatabaseUnconfigured extends Schema.TaggedErrorClass<DatabaseUnconfigured>()(
+  'Order.DatabaseUnconfigured',
+  {},
+) {}
+
+/**
+ * The single place the DB dependency is stood up: a `SqlClient` over the
+ * `DATABASE_URL` sqlite database, gated on `Env.database` Some. With no DB
+ * configured this fails to build with `Order.DatabaseUnconfigured` (mirroring
+ * `Storage.layer`'s `StorageUnconfigured` gate). The filename is the redacted
+ * connection string read straight off `Env` — a sqlite FILE path in
+ * production, `':memory:'` in single-graph tests.
+ *
+ * If the deploy target ever flips from a Railway persistent-volume sqlite file
+ * to Postgres, this is the ONE line that changes: swap `SqliteClient.layer` for
+ * `@effect/sql-pg`'s `PgClient.layer`. The DB choice is localized here.
+ */
+export const SqlClientLive: Layer.Layer<
+  SqlClient.SqlClient,
+  DatabaseUnconfigured,
+  Env.Service
+> = Layer.unwrap(
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
+
+    if (Option.isNone(env.database)) {
+      return yield* new DatabaseUnconfigured();
+    }
+
+    return SqliteClient.layer({
+      filename: Redacted.value(env.database.value.url),
+    });
+  }),
+);
+
+/**
+ * The shared `ShardingConfig` definition — ONE shard count both runtimes use.
+ * The sender (in `AppRuntime`) and the runner (in `ServerLive`) MUST build from
+ * the BYTE-IDENTICAL config: `ActorAddressResolverLayer.fromConfig` routes an
+ * entity to a shard computed from the shard count, so a divergent count makes
+ * the sender write a shard the runner never polls.
+ *
+ * `fromSqlClient` swallows its own `ShardingConfig.layerDefaults` internally and
+ * does NOT re-export `ShardingConfig` (so the runner storage uses the defaults),
+ * but the SENDER side cannot borrow the storage's config — it must be provided
+ * this layer independently (G6). Exporting the one definition here is what keeps
+ * both sides in lockstep. Defaults today (no overrides) — the seam exists so a
+ * future non-default shard count stays single-sourced.
+ */
+export const ShardingConfigLive: Layer.Layer<ShardingConfig.ShardingConfig> =
+  ShardingConfig.layer();
+
+/**
+ * encore's SQL `MessageStorage` (`fromSqlClient` — provides BOTH the upstream
+ * `MessageStorage` tag and encore's `EncoreMessageStorage` extension) composed
+ * onto `SqlClientLive`. This is the SINGLE place the DB dependency is stood up
+ * for the durable Order entity; it backs the runner in `ServerLive`.
+ *
+ * encore's `SqlMessageStorage` owns the `cluster_messages` / `cluster_replies`
+ * table creation (it runs its migrations at layer build), so there is no
+ * hand-written DDL here.
+ */
+export const MessageStorageLive = fromSqlClient().pipe(
+  Layer.provide(SqlClientLive),
+);
+
+/**
+ * In-memory SQL `MessageStorage` for the entity tests (G3+): `fromSqlClient`
+ * over a `':memory:'` SqliteClient. Valid ONLY for a single layer graph — the
+ * cross-runtime test (G3) uses a shared FILE precisely because `':memory:'`
+ * cannot exercise the two-graph seam.
+ */
+export const layerTest = fromSqlClient().pipe(
+  Layer.provide(SqliteClient.layer({ filename: ':memory:' })),
+);

--- a/app/lib/order/sweep.server.test.ts
+++ b/app/lib/order/sweep.server.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'effect-bun-test';
+import { Effect, Layer, Schema } from 'effect';
+
+import { Content } from '../content.server';
+import { defaultRegistrationForm } from '../content/pages/defaults';
+import { orderKey, submissionKey } from '../content/pages/registry';
+import { IsoDate, newListItemId, type ListItemId } from '../content/schema';
+import { RegistrationOrder } from '../forms/order';
+import { Payment } from '../payment.server';
+import { Cents, CurrencyCode } from '../forms/pricing';
+import { submissionSchema } from '../forms/submission';
+import { Submissions } from '../forms/submissions.server';
+import { layerTest as storageLayerTest } from '../storage.test-helper';
+import { isTerminal } from 'effect-encore';
+
+import { Order } from './runner.server';
+import { OrderActor } from './order.actor';
+import { OrderSweep } from './sweep.server';
+
+/**
+ * G9 — the deadline SWEEP, driven END-TO-END through the SQL-backed in-process
+ * runner (`Order.fullRunnerLayer` over `Order.layerTest`) against the REAL
+ * bucket-authority `Submissions`. The sweep lists the form's orders, filters to
+ * the pending-AND-past-deadline ones, and `send`s `Order.expire` to each — the
+ * runner consumes each send and flips the bucket `pending → expired`.
+ *
+ * The load-bearing assertion: a PAST-deadline PENDING order is swept to
+ * `expired`, while a FUTURE-deadline pending order AND a PAST-deadline PAID
+ * order are BOTH left untouched (the filter pre-screens; the `markOrderExpired`
+ * never-downgrade guard is the second line). A second sweep is a no-op.
+ *
+ * Deadlines are anchored to real far-past / far-future calendar dates so the
+ * LIVE clock (`scopedLive`) decides "due" deterministically without a TestClock.
+ */
+
+const REGISTRANT_IDS: readonly ListItemId[] = [newListItemId(), newListItemId()];
+
+const encodeOrder = Schema.encodeSync(Schema.fromJsonString(RegistrationOrder));
+
+/** A far-past deadline (always strictly before today) and a far-future one. */
+const PAST_DEADLINE = IsoDate.make('2020-01-01');
+const FUTURE_DEADLINE = IsoDate.make('2999-01-01');
+
+interface OrderSpec {
+  readonly orderId: string;
+  readonly status: RegistrationOrder['status'];
+  readonly deadline?: IsoDate;
+}
+
+/** Build a `RegistrationOrder` at a given status + optional deadline. */
+const makeOrder = (spec: OrderSpec): RegistrationOrder => ({
+  orderId: spec.orderId,
+  mode: 'group',
+  sessionId: `cs_${spec.orderId}`,
+  amount: Cents.make(15000),
+  currency: CurrencyCode.make('cad'),
+  receiptEmail: 'leader@example.com',
+  status: spec.status,
+  registrantIds: [...REGISTRANT_IDS],
+  ...(spec.deadline === undefined ? {} : { deadline: spec.deadline }),
+  ...(spec.status === 'paid' ? { paidAt: IsoDate.make('2026-06-20') } : {}),
+});
+
+/** A minimal valid (`payment`-less) exhibitor registrant submission JSON. */
+const registrantSubmissionJson = (id: ListItemId): string =>
+  Schema.encodeSync(
+    Schema.fromJsonString(submissionSchema(defaultRegistrationForm)),
+  )(
+    Schema.decodeUnknownSync(submissionSchema(defaultRegistrationForm))({
+      id,
+      form: 'registration',
+      submittedAt: '2026-06-17',
+      payload: {
+        name: 'Ada Co',
+        phone: '123-456-7890',
+        type: 'exhibitor',
+        synopsis: 'We sell books',
+        website: 'https://example.com',
+        company: 'Ada Books',
+      },
+    }),
+  );
+
+/** Seed each order under its `orderKey` ALONGSIDE the registrants it names. */
+const seed = (
+  orders: readonly RegistrationOrder[],
+): Parameters<typeof storageLayerTest>[0] => {
+  const objects: Parameters<typeof storageLayerTest>[0] = {};
+  for (const order of orders) {
+    objects[orderKey('registration', order.orderId)] = {
+      body: encodeOrder(order),
+      contentType: 'application/json',
+    };
+  }
+  // One shared set of registrant submissions (every order names the same ids;
+  // the flip re-stamps them idempotently).
+  for (const id of REGISTRANT_IDS) {
+    objects[submissionKey('registration', id)] = {
+      body: registrantSubmissionJson(id),
+      contentType: 'application/json',
+    };
+  }
+  return objects;
+};
+
+/** Read the on-bucket order status (the durable authority). */
+const bucketStatus = (orderId: string) =>
+  Effect.gen(function* () {
+    const submissions = yield* Submissions.Service;
+    return (yield* submissions.getOrder('registration', orderId)).status;
+  });
+
+/** Await the runner consuming the sweep's fire-and-forget `expire` send. */
+const awaitExpire = (orderId: string) =>
+  Order.Entity.expire
+    .waitFor({ orderId }, { filter: (result) => isTerminal(result) })
+    .pipe(Effect.timeout('5 seconds'), Effect.asVoid);
+
+/** The full G9 stack over ONE Map-backed bucket: SQL runner + bucket authority. */
+const provideStack = (orders: readonly RegistrationOrder[]) => {
+  const storage = storageLayerTest(seed(orders));
+  const submissions = Layer.provideMerge(
+    Submissions.layer,
+    Layer.provideMerge(Content.layer, storage),
+  );
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provide(Order.fullRunnerLayer(Order.layerTest)),
+      Effect.provide(submissions),
+      Effect.provide(Payment.testLayer()),
+    );
+};
+
+describe('Order deadline sweep (G9, SQL-backed runner over the bucket authority)', () => {
+  it.scopedLive(
+    'sweeps ONLY the past-deadline PENDING order; future-deadline + paid are untouched; second sweep is a no-op',
+    () => {
+      const pastPending = makeOrder({
+        orderId: 'ord-past-pending',
+        status: 'pending',
+        deadline: PAST_DEADLINE,
+      });
+      const futurePending = makeOrder({
+        orderId: 'ord-future-pending',
+        status: 'pending',
+        deadline: FUTURE_DEADLINE,
+      });
+      const pastPaid = makeOrder({
+        orderId: 'ord-past-paid',
+        status: 'paid',
+        deadline: PAST_DEADLINE,
+      });
+      const orders = [pastPending, futurePending, pastPaid];
+
+      return Effect.gen(function* () {
+        // (1) One sweep pass: it dispatches `expire` ONLY for the past-deadline
+        // pending order — the filter screens out the future-deadline pending one
+        // AND the past-deadline PAID one.
+        const dispatched = yield* OrderSweep.runOnce;
+        expect(dispatched).toEqual([pastPending.orderId]);
+
+        // Await the runner consuming the fire-and-forget send.
+        yield* awaitExpire(pastPending.orderId);
+
+        // (2) The past-deadline pending order flipped to `expired` (bucket + the
+        // derived State); the other two are untouched.
+        expect(yield* bucketStatus(pastPending.orderId)).toBe('expired');
+        expect(
+          (yield* OrderActor.readState(pastPending.orderId)).status,
+        ).toBe('expired');
+        expect(yield* bucketStatus(futurePending.orderId)).toBe('pending');
+        expect(yield* bucketStatus(pastPaid.orderId)).toBe('paid');
+
+        // (3) A SECOND sweep dispatches NOTHING (the only past-deadline order is
+        // now `expired`, no longer `pending`) — idempotent.
+        const second = yield* OrderSweep.runOnce;
+        expect(second).toEqual([]);
+        expect(yield* bucketStatus(pastPending.orderId)).toBe('expired');
+      }).pipe(provideStack(orders));
+    },
+  );
+
+  it.scopedLive(
+    'a deadline-less pending order is NEVER swept (no registrationDeadline configured)',
+    () => {
+      const noDeadline = makeOrder({
+        orderId: 'ord-no-deadline',
+        status: 'pending',
+      });
+      return Effect.gen(function* () {
+        const dispatched = yield* OrderSweep.runOnce;
+        expect(dispatched).toEqual([]);
+        expect(yield* bucketStatus(noDeadline.orderId)).toBe('pending');
+      }).pipe(provideStack([noDeadline]));
+    },
+  );
+});

--- a/app/lib/order/sweep.server.ts
+++ b/app/lib/order/sweep.server.ts
@@ -1,0 +1,178 @@
+export * as OrderSweep from './sweep.server';
+
+import { Clock, DateTime, Duration, Effect, Layer, Schedule } from 'effect';
+
+import { Submissions } from '../forms/submissions.server';
+import type { RegistrationOrder } from '../forms/order';
+import type { StorageError } from '../storage.server';
+
+import { Order } from './runner.server';
+
+/**
+ * G9 — the deadline SWEEP: an in-process scheduled fiber that lapses pending
+ * orders whose `deadline` has passed into `expired`.
+ *
+ * ## What it does
+ *
+ * It lists the form's frozen orders (`Submissions.listOrders` over
+ * `ordersPrefix('registration')` = `submissions/registration/orders/`) and, for
+ * each order that is BOTH `pending` AND past its `deadline`, `send`s the durable
+ * `Order.expire` op. The `expire` handler flips `pending → expired` through the
+ * never-downgrade `flipStatus` guard (`Submissions.markOrderExpired`, G5/G7), so
+ * a `paid`/`refunded`/`cancelled`/`failed`/already-`expired` order is left
+ * untouched even if it is somehow re-enumerated (make-impossible-states). The
+ * filter pre-screens to `pending`-with-a-passed-deadline so the sweep only
+ * dispatches where a transition is actually due; the handler's guard is the
+ * second line of defence against a race (an order paid between the list and the
+ * dispatch is never resurrected to `expired`).
+ *
+ * ## Where it lives (the load-bearing topology)
+ *
+ * It is launched in the long-lived `Layer.launch`-ed `ServerLive` graph
+ * (`server.ts`) — a sweep is a PROCESS-LIFETIME fiber (it polls forever on a
+ * schedule), so it needs the launch-time supervisor `ServerLive` provides, NOT
+ * the request-handler `makeAppLayer` graph (consumed once into the `AppRuntime`
+ * singleton, never `Layer.launch`-ed). It is a SENDER (`Order.expire.send`) into
+ * the SAME SQL MessageStorage the runner consumes — the two coordinate through
+ * the shared `DATABASE_URL` sqlite FILE, never an in-memory instance.
+ *
+ * ## Idempotency
+ *
+ * Re-sweeping is a no-op: a second pass re-`send`s `expire` for an order that the
+ * first pass already flipped `expired` (it is no longer `pending`, so the filter
+ * skips it) — and even a verbatim re-`send` dedups (encore primaryKey dedup) and
+ * the `markOrderExpired` flip is byte-identical on an already-`expired` order.
+ *
+ * ## Trigger model (Open Question 5)
+ *
+ * The default is an IN-PROCESS scheduled fiber, valid because the DB decision is
+ * a single always-on web instance (the same single-node assumption the runner
+ * makes). If GYC ever scales to MULTIPLE web processes against one DB, the sweep
+ * (like the runner) must move to a dedicated worker process / an external cron
+ * hitting the manual trigger route below, so N instances do not each sweep. The
+ * manual `/admin`-guarded trigger route (`app/routes/admin/orders.sweep.ts`)
+ * exposes the same sweep for an operator / an external scheduler without
+ * committing any infra.
+ */
+
+/** The form whose order lifecycle the sweep reconciles (the only paid form today). */
+const SWEEP_FORM = 'registration';
+
+/** How often the in-process fiber runs a sweep pass (a daily-deadline lifecycle
+ * does not need a tight loop; hourly catches a lapsed order well within a day). */
+const SWEEP_INTERVAL = Duration.hours(1);
+
+/** Format a UTC millisecond instant as a `YYYY-MM-DD` calendar-date string —
+ * the same shape `RegistrationOrder.deadline` (a branded `IsoDate`) carries, so a
+ * lexicographic compare IS a calendar compare (both are zero-padded `YYYY-MM-DD`). */
+const isoDateString = (millis: number): string =>
+  DateTime.formatIso(DateTime.makeUnsafe(millis)).slice(0, 10);
+
+/**
+ * `true` iff `order` is due to expire AS OF `today` (a `YYYY-MM-DD` string): it
+ * is `pending` AND carries a `deadline` that is STRICTLY before today. A
+ * deadline-less order never expires by the sweep (a registration with no
+ * registrationDeadline configured stays open); an order whose deadline IS today
+ * is still open through the end of that day (strict `<`, not `<=`).
+ */
+const isExpirable = (order: RegistrationOrder, today: string): boolean =>
+  order.status === 'pending' &&
+  order.deadline !== undefined &&
+  order.deadline < today;
+
+/**
+ * Run ONE sweep pass: enumerate the form's orders, dispatch `Order.expire` to
+ * each that is due. Returns the orderIds it dispatched (the manual trigger route
+ * reports the count; the in-process fiber ignores it). A `send` per due order is
+ * fire-and-forget — the sweep does NOT block on the runner consuming it (the
+ * durable `send` already landed in the SQL mailbox; the runner reconciles the
+ * flip off it), mirroring how the registration action `arm`s without awaiting.
+ *
+ * The error channel is `StorageError` (the `listOrders` bucket-list fault) — a
+ * genuinely-unreachable bucket fails the pass; the caller (the fiber's schedule /
+ * the trigger route) decides how to surface it. The per-order `send` is the
+ * durable seam, so a sweep that lists but cannot reach the runner still records
+ * the intent in the mailbox.
+ */
+export const runOnce: Effect.Effect<
+  readonly string[],
+  StorageError,
+  Submissions.Service | Order.SenderServices
+> = Effect.gen(function* () {
+  const submissions = yield* Submissions.Service;
+  const now = yield* Clock.currentTimeMillis;
+  const today = isoDateString(now);
+
+  const orders = yield* submissions.listOrders(SWEEP_FORM);
+  const due = orders.filter((order) => isExpirable(order, today));
+
+  yield* Effect.forEach(
+    due,
+    (order) =>
+      // The `expire` send is fire-and-forget into the SQL mailbox the runner
+      // consumes — the durable seam. A send-infra fault (mailbox full, a
+      // persistence blip, or a duplicate-in-flight `AlreadyProcessingMessage`)
+      // for ONE order must not abort the whole pass NOR widen the channel beyond
+      // the `listOrders` `StorageError`: it is logged + swallowed per order, so
+      // the remaining due orders still dispatch and the next sweep retries the
+      // failed one (a still-pending past-deadline order re-enters `due`).
+      Order.Entity.expire.send({ orderId: order.orderId }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logError(
+            `Order sweep failed to dispatch expire for ${order.orderId}`,
+            cause,
+          ),
+        ),
+      ),
+    { discard: true },
+  );
+
+  return due.map((order) => order.orderId);
+});
+
+/**
+ * The forever-looping sweep: run a pass, log + swallow any per-pass fault, then
+ * wait one interval and repeat. A bucket-list fault on one pass must NEVER kill
+ * the loop (the next interval retries), so the pass is wrapped in `catchCause` →
+ * log → continue. `Schedule.spaced(interval)` paces the loop AFTER each pass
+ * completes, so a slow pass never overlaps itself.
+ */
+const sweepForever = (
+  interval: Duration.Duration,
+): Effect.Effect<void, never, Submissions.Service | Order.SenderServices> =>
+  runOnce.pipe(
+    Effect.flatMap((expired) =>
+      expired.length === 0 ?
+        Effect.void
+      : Effect.logInfo(
+          `Order sweep expired ${expired.length} past-deadline order(s): ${expired.join(', ')}`,
+        ),
+    ),
+    Effect.catchCause((cause) =>
+      Effect.logError('Order sweep pass failed (will retry next interval)', cause),
+    ),
+    // `Schedule.spaced` recurs FOREVER, waiting `interval` between passes — so a
+    // pass never overlaps itself, and the loop only ends when the fiber is
+    // interrupted (the launch-scope teardown). The pass never fails (faults are
+    // caught above), so the loop never escapes.
+    Effect.repeat(Schedule.spaced(interval)),
+    Effect.asVoid,
+  );
+
+/**
+ * The in-process sweep fiber as a `Layer` — a `Layer.effectDiscard` that forks a
+ * fiber (running the sweep loop) into the LAYER's scope at build time.
+ * `server.ts` merges this into `ServerLive` (gated on `Env.database` Some), so
+ * `Layer.launch` supervises it: `forkScoped` ties the fiber to the launched
+ * layer scope (`effectDiscard` excludes `Scope` from the layer's requirements —
+ * the fork lives in the layer's own scope), so it is torn down with the server
+ * (never an orphan), and `interruptible` lets the teardown stop it cleanly. A
+ * sweep pass that faults is logged and the loop continues (see
+ * {@link sweepForever}).
+ */
+export const fiberLayer = (
+  interval: Duration.Duration = SWEEP_INTERVAL,
+): Layer.Layer<never, never, Submissions.Service | Order.SenderServices> =>
+  Layer.effectDiscard(
+    sweepForever(interval).pipe(Effect.interruptible, Effect.forkScoped),
+  );

--- a/app/lib/order/transitions.ts
+++ b/app/lib/order/transitions.ts
@@ -1,0 +1,66 @@
+import { Schema } from 'effect';
+
+/**
+ * The PURE Order lifecycle transition table — the SINGLE source of truth for
+ * which `status → status` flip is legal (Decision 5 / G4). Lifted into its own
+ * dependency-free module so BOTH the durable entity (`order.actor.ts`, which
+ * consults it in the `settle` paid guard) AND the bucket authority
+ * (`submissions.server.ts`, whose `markOrder*` `flipStatus` guards enforce it)
+ * read the SAME predicate without a circular import — `order.actor.ts` imports
+ * `Submissions`, so `submissions.server.ts` cannot import back from
+ * `order.actor.ts`. This module depends on nothing but `effect`'s `Schema`, so
+ * both sides import it freely and there is no second source of truth to drift.
+ *
+ * The five actor-visible lifecycle states. The persisted actor `OrderState`
+ * carries exactly these; it does NOT carry `failed` (a bucket-only terminal from
+ * `checkout.session.async_payment_failed`, mapped to a Failure reply, never an
+ * `OrderState` value).
+ */
+export const OrderStatus = Schema.Literals([
+  'pending',
+  'paid',
+  'cancelled',
+  'refunded',
+  'expired',
+]);
+export type OrderStatus = typeof OrderStatus.Type;
+
+/**
+ * The full bucket-status set the transition table reconciles over: the UNION of
+ * the actor's five visible states PLUS `failed` (bucket-only,
+ * `async_payment_failed`). Legality is a property of the bucket
+ * `RegistrationOrder.status` lifecycle, which carries this same closed 6-literal
+ * set (`order.ts`).
+ */
+export type BucketStatus = OrderStatus | 'failed';
+
+/**
+ * The pure transition table: which `status → status` flips are legal.
+ *
+ * Legal:
+ *   - `pending → { paid, cancelled, expired, failed }`
+ *   - `paid    → refunded`
+ *   - any `x → x` (idempotent re-flip to the same terminal is a no-op)
+ * Everything else is illegal.
+ *
+ * Terminal states (`cancelled`, `refunded`, `expired`, `failed`) have no legal
+ * onward transition except to themselves; `paid` may ONLY go to `refunded`.
+ */
+const LEGAL_TRANSITIONS: Readonly<
+  Record<BucketStatus, ReadonlySet<BucketStatus>>
+> = {
+  pending: new Set<BucketStatus>(['paid', 'cancelled', 'expired', 'failed']),
+  paid: new Set<BucketStatus>(['refunded']),
+  cancelled: new Set<BucketStatus>(),
+  refunded: new Set<BucketStatus>(),
+  expired: new Set<BucketStatus>(),
+  failed: new Set<BucketStatus>(),
+};
+
+/**
+ * `true` iff `from → to` is a legal Order lifecycle transition. An identity flip
+ * (`from === to`) is always legal (idempotent replay no-op); otherwise the
+ * target must be in `from`'s legal target set.
+ */
+export const canTransition = (from: BucketStatus, to: BucketStatus): boolean =>
+  from === to || LEGAL_TRANSITIONS[from].has(to);

--- a/app/lib/payment.server.test.ts
+++ b/app/lib/payment.server.test.ts
@@ -57,6 +57,22 @@ describe('Payment — Env.stripe None-gate', () => {
     }).pipe(Effect.provide(Layer.provide(Payment.layer, disabledEnv))),
   );
 
+  it.effect('createRefund fails PaymentDisabled when stripe is unconfigured', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        Effect.gen(function* () {
+          const payment = yield* Payment.Service;
+          yield* payment.createRefund({
+            sessionId: 'cs_test_1',
+            amount: Cents.make(5000),
+            idempotencyKey: 'registration:refund:order-1',
+          });
+        }),
+      );
+      expect(error).toBeInstanceOf(PaymentDisabled);
+    }).pipe(Effect.provide(Layer.provide(Payment.layer, disabledEnv))),
+  );
+
   it.effect('constructEvent fails PaymentDisabled when stripe is unconfigured', () =>
     Effect.gen(function* () {
       const error = yield* Effect.flip(
@@ -144,6 +160,49 @@ describe('Payment.testLayer — create-session double (no network)', () => {
       // Same idempotency key ⇒ same fake session (the no-second-checkout contract).
       expect(retry.sessionId).toBe(first.sessionId);
       expect(retry.url).toBe(first.url);
+    }).pipe(Effect.provide(Payment.testLayer())),
+  );
+
+  it.effect('createRefund records the call (session + frozen amount + idempotency key) and returns a fake refund', () => {
+    const refundCalls: Array<Payment.CreateRefundCall> = [];
+    return Effect.gen(function* () {
+      const payment = yield* Payment.Service;
+      const refund = yield* payment.createRefund({
+        sessionId: 'cs_test_order-42',
+        amount: Cents.make(15_000),
+        idempotencyKey: 'registration:refund:order-42',
+      });
+
+      // The fake refund's ids derive from the session + key (no network), and the
+      // resolved PaymentIntent is the session-derived stub (the production op
+      // resolves it from the session via GetCheckoutSessionsSession).
+      expect(refund.refundId).toBe('re_test_registration:refund:order-42');
+      expect(refund.paymentIntentId).toBe('pi_test_cs_test_order-42');
+
+      // The frozen amount + session + key threaded through verbatim.
+      expect(refundCalls).toHaveLength(1);
+      expect(refundCalls[0]?.sessionId).toBe('cs_test_order-42');
+      expect(refundCalls[0]?.amount).toBe(Cents.make(15_000));
+      expect(refundCalls[0]?.idempotencyKey).toBe(
+        'registration:refund:order-42',
+      );
+    }).pipe(Effect.provide(Payment.testLayer({ refundCalls })));
+  });
+
+  it.effect('createRefund replays the same fake refund for a verbatim retry (same idempotency key)', () =>
+    Effect.gen(function* () {
+      const payment = yield* Payment.Service;
+      const params = {
+        sessionId: 'cs_test_order-99',
+        amount: Cents.make(8000),
+        idempotencyKey: 'registration:refund:order-99',
+      };
+      const first = yield* payment.createRefund(params);
+      const retry = yield* payment.createRefund(params);
+      // Same key ⇒ same fake refund (the no-second-refund contract the durable
+      // `refund` op relies on).
+      expect(retry.refundId).toBe(first.refundId);
+      expect(retry.paymentIntentId).toBe(first.paymentIntentId);
     }).pipe(Effect.provide(Payment.testLayer())),
   );
 

--- a/app/lib/payment.server.ts
+++ b/app/lib/payment.server.ts
@@ -174,7 +174,7 @@ const credentialsLayer = Layer.effect(
   Credentials,
   // The `Credentials` service value IS an `Effect<Config>`, so map the `Env`
   // effect to that inner effect (the layer value is the inner `Effect<Config>`).
-  Effect.map(Env.Service.asEffect(), (env) =>
+  Effect.map(Env.Service, (env) =>
     Effect.succeed({
       apiKey: Option.isSome(env.stripe)
         ? env.stripe.value.apiKey

--- a/app/lib/payment.server.ts
+++ b/app/lib/payment.server.ts
@@ -15,7 +15,11 @@ import {
   DEFAULT_API_BASE_URL,
   Webhooks,
 } from '@distilled.cloud/stripe';
-import { PostCheckoutSessions } from '@distilled.cloud/stripe/Operations';
+import {
+  GetCheckoutSessionsSession,
+  PostCheckoutSessions,
+  PostRefunds,
+} from '@distilled.cloud/stripe/Operations';
 
 import type { Cents, CurrencyCode } from './forms/pricing';
 import { Env } from './env.server';
@@ -120,6 +124,19 @@ export interface CreatedSession {
   readonly url: string;
 }
 
+/**
+ * The issued refund — the `refundId` Stripe minted and the `paymentIntentId` it
+ * was issued against (resolved FROM the order's Checkout Session, since the
+ * frozen `RegistrationOrder` stores only `sessionId`). The durable Order
+ * `refund` op (G7) does not need the SDK's full refund object back; it freezes
+ * the order `refunded` off its OWN authority (the bucket transition), so the
+ * refund identifiers are all a caller needs for an audit trail.
+ */
+export interface CreatedRefund {
+  readonly refundId: string;
+  readonly paymentIntentId: string;
+}
+
 /** The verified, parsed webhook event (distilled's open `StripeEvent` shape). */
 export type StripeEvent = Webhooks.StripeEvent;
 
@@ -149,6 +166,24 @@ export class Service extends Context.Service<
       readonly metadata: Readonly<Record<string, string>>;
       readonly idempotencyKey: string;
     }) => Effect.Effect<CreatedSession, PaymentError | PaymentDisabled>;
+    /**
+     * Issue a refund for one frozen order against the Checkout Session it was
+     * minted from. `PostRefunds` refunds a `payment_intent`/`charge`, but the
+     * frozen `RegistrationOrder` stores only its `sessionId` (`order.ts`), so
+     * this resolves the PaymentIntent FROM the session FIRST
+     * (`GetCheckoutSessionsSession`) and then refunds `amount` (minor units —
+     * the order's FROZEN total, never re-derived) against it. `idempotencyKey`
+     * rides the `Idempotency-Key` HEADER (never the body), so a verbatim retry
+     * of the durable `refund` op replays the first refund rather than issuing a
+     * second. Fails `PaymentDisabled` when stripe is unconfigured; `PaymentError`
+     * on any SDK/transport failure (including a session that carries no resolvable
+     * PaymentIntent — an unpaid/expired session has nothing to refund).
+     */
+    readonly createRefund: (params: {
+      readonly sessionId: string;
+      readonly amount: Cents;
+      readonly idempotencyKey: string;
+    }) => Effect.Effect<CreatedRefund, PaymentError | PaymentDisabled>;
     /**
      * Verify `signature` against the RAW `rawBody` (HMAC-SHA256 over the exact
      * bytes Stripe sent — never reserialized JSON) and parse the event. Fails
@@ -198,15 +233,41 @@ export const layer = Layer.effect(
     // Capture the requirement-free operation handle once (yield-first): the
     // `Credentials` + `HttpClient` deps are satisfied by this layer's context.
     const postCheckoutSessions = yield* PostCheckoutSessions;
+    // The session-retrieve + refund handles, captured yield-first alongside
+    // `postCheckoutSessions` so the `Credentials` + `HttpClient` deps resolve at
+    // layer build, not per call (the same discipline as the create-session op).
+    const getCheckoutSession = yield* GetCheckoutSessionsSession;
+    const postRefunds = yield* PostRefunds;
 
     if (Option.isNone(env.stripe)) {
       return Service.of({
         createCheckoutSession: () => Effect.fail(new PaymentDisabled()),
+        createRefund: () => Effect.fail(new PaymentDisabled()),
         constructEvent: () => Effect.fail(new PaymentDisabled()),
       });
     }
 
     const config = env.stripe.value;
+
+    // The distilled operations declare an EMPTY typed-error channel (the SDK
+    // surfaces idempotency/invalid-request failures at runtime via the request
+    // cause, not in the static type), so every call catches the whole `Cause`
+    // and collapses it into ONE user-facing `PaymentError` — a server-frozen
+    // amount/order means any failure is an upstream/transport fault, not a user
+    // field. `Cause.squash` recovers the raw SDK error for logging.
+    const squashToPaymentError = (
+      cause: Cause.Cause<never>,
+    ): Effect.Effect<never, PaymentError> => {
+      const squashed = Cause.squash(cause);
+      const message =
+        typeof squashed === 'object' &&
+        squashed !== null &&
+        'message' in squashed &&
+        typeof (squashed as { readonly message?: unknown }).message === 'string'
+          ? (squashed as { readonly message: string }).message
+          : undefined;
+      return Effect.fail(new PaymentError({ message, cause: squashed }));
+    };
 
     const createCheckoutSession = Effect.fn('Payment.createCheckoutSession')(
       function* (params: {
@@ -249,25 +310,7 @@ export const layer = Layer.effect(
             metadata: { ...params.metadata },
           },
           { idempotencyKey: params.idempotencyKey },
-        ).pipe(
-          // The operation's static error channel is empty (the SDK reports
-          // idempotency/invalid-request failures at runtime, not in the type), so
-          // catch the whole `Cause` and squash it into ONE `PaymentError` — a
-          // server-frozen amount means any failure is an upstream/transport fault,
-          // not a user field. `Cause.squash` recovers the raw SDK error.
-          Effect.catchCause((cause) => {
-            const squashed = Cause.squash(cause);
-            const message =
-              typeof squashed === 'object' &&
-              squashed !== null &&
-              'message' in squashed &&
-              typeof (squashed as { readonly message?: unknown }).message ===
-                'string'
-                ? (squashed as { readonly message: string }).message
-                : undefined;
-            return Effect.fail(new PaymentError({ message, cause: squashed }));
-          }),
-        );
+        ).pipe(Effect.catchCause((cause) => squashToPaymentError(cause)));
 
         // A `mode: 'payment'` session ALWAYS carries a hosted `url` (the redirect
         // target); a `null` is an upstream Stripe contract violation, so it dies
@@ -287,6 +330,50 @@ export const layer = Layer.effect(
       },
     );
 
+    const createRefund = Effect.fn('Payment.createRefund')(function* (params: {
+      readonly sessionId: string;
+      readonly amount: Cents;
+      readonly idempotencyKey: string;
+    }) {
+      // (1) Resolve the PaymentIntent FROM the session — `PostRefunds` cannot
+      // take a `sessionId`, and the frozen order stores only that. A retrieve is
+      // a GET (no idempotency key needed; it is naturally idempotent).
+      const session = yield* getCheckoutSession({
+        session: params.sessionId,
+      }).pipe(Effect.catchCause((cause) => squashToPaymentError(cause)));
+
+      // The session's `payment_intent` is typed `unknown` (it may be a bare id
+      // string or — only when expanded, which we do NOT request — an object). For
+      // a settled `mode: 'payment'` session it is the PaymentIntent id string; a
+      // session with no resolvable PaymentIntent (unpaid/expired — nothing was
+      // ever charged) has nothing to refund, a `PaymentError` (the `refund`
+      // handler's `paid`-state guard already keeps this off the happy path, so
+      // reaching it is an upstream inconsistency, not a user field).
+      const paymentIntentId = session.payment_intent;
+      if (typeof paymentIntentId !== 'string' || paymentIntentId === '') {
+        return yield* new PaymentError({
+          message: `Checkout Session ${params.sessionId} carries no PaymentIntent to refund`,
+        });
+      }
+
+      // (2) Refund the FROZEN order amount (minor units) against the resolved
+      // PaymentIntent. `idempotencyKey` rides the HEADER so a verbatim retry of
+      // the durable `refund` op replays the first refund.
+      const refund = yield* postRefunds(
+        {
+          payment_intent: paymentIntentId,
+          amount: params.amount,
+          reason: 'requested_by_customer',
+        },
+        { idempotencyKey: params.idempotencyKey },
+      ).pipe(Effect.catchCause((cause) => squashToPaymentError(cause)));
+
+      return {
+        refundId: refund.id,
+        paymentIntentId,
+      } satisfies CreatedRefund;
+    });
+
     const constructEvent = Effect.fn('Payment.constructEvent')(function* (
       rawBody: string,
       signature: string | null | undefined,
@@ -303,7 +390,7 @@ export const layer = Layer.effect(
       );
     });
 
-    return Service.of({ createCheckoutSession, constructEvent });
+    return Service.of({ createCheckoutSession, createRefund, constructEvent });
   }),
 ).pipe(
   Layer.provide(FetchHttpClient.layer),
@@ -329,6 +416,13 @@ export interface CreateCheckoutSessionCall {
   readonly idempotencyKey: string;
 }
 
+/** The argument record `createRefund` was last called with — what a test asserts. */
+export interface CreateRefundCall {
+  readonly sessionId: string;
+  readonly amount: Cents;
+  readonly idempotencyKey: string;
+}
+
 /**
  * A network-free `Payment` test double (`Layer.succeed(Service, fake)`). The
  * registrar checkout tests (C7/C7.5) provide this to prove the create-session
@@ -344,6 +438,7 @@ export interface CreateCheckoutSessionCall {
  */
 export const testLayer = (options?: {
   readonly calls?: Array<CreateCheckoutSessionCall>;
+  readonly refundCalls?: Array<CreateRefundCall>;
   readonly event?: StripeEvent;
 }): Layer.Layer<Service> =>
   Layer.succeed(
@@ -364,6 +459,22 @@ export const testLayer = (options?: {
           return {
             sessionId: `cs_test_${params.idempotencyKey}`,
             url: `https://checkout.stripe.test/${params.idempotencyKey}`,
+          };
+        }),
+      // The refund double records each call and returns a deterministic refund
+      // whose id + resolved PaymentIntent derive from the session + idempotency
+      // key (so a retry with the same key yields the same fake refund — the
+      // idempotency contract is observable in tests, no network).
+      createRefund: (params) =>
+        Effect.sync(() => {
+          options?.refundCalls?.push({
+            sessionId: params.sessionId,
+            amount: params.amount,
+            idempotencyKey: params.idempotencyKey,
+          });
+          return {
+            refundId: `re_test_${params.idempotencyKey}`,
+            paymentIntentId: `pi_test_${params.sessionId}`,
           };
         }),
       constructEvent: () => Effect.succeed(options?.event ?? {}),

--- a/app/lib/services.test.ts
+++ b/app/lib/services.test.ts
@@ -71,7 +71,7 @@ describe('Env config', () => {
 
   it.effect('fails fast in production when a required mail var is missing', () =>
     Effect.gen(function* () {
-      const exit = yield* Env.Service.asEffect().pipe(
+      const exit = yield* Env.Service.pipe(
         provideEnv({ NODE_ENV: 'production', MAIL_HOST: 'only-host' }),
         Effect.exit,
       );
@@ -129,7 +129,7 @@ describe('Env config', () => {
 
   it.effect('fails fast when a configured stripe carries an unsupported currency', () =>
     Effect.gen(function* () {
-      const exit = yield* Env.Service.asEffect().pipe(
+      const exit = yield* Env.Service.pipe(
         provideEnv({
           NODE_ENV: 'development',
           STRIPE_API_KEY: 'sk_test_123',

--- a/app/lib/services.test.ts
+++ b/app/lib/services.test.ts
@@ -246,6 +246,58 @@ describe('Env config', () => {
         BUCKET_REGION: 'us-east-1',
       }),
     ));
+
+  it.effect('leaves the database absent everywhere when DATABASE_URL is unset', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      expect(Option.isNone(env.database)).toBe(true);
+    }).pipe(provideEnv({ NODE_ENV: 'development' })));
+
+  it.effect('leaves the database absent in production when DATABASE_URL is unset', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      expect(env.isProduction).toBe(true);
+      expect(Option.isNone(env.database)).toBe(true);
+    }).pipe(provideEnv(PROD_ENV)));
+
+  it.effect('resolves the database and redacts the connection URL', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      expect(Option.isSome(env.database)).toBe(true);
+      if (Option.isSome(env.database)) {
+        expect(Redacted.value(env.database.value.url)).toBe('/data/order.db');
+      }
+    }).pipe(
+      provideEnv({
+        NODE_ENV: 'development',
+        DATABASE_URL: '/data/order.db',
+      }),
+    ));
+
+  it.effect('treats a present-but-blank DATABASE_URL as absent (env.example placeholder)', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      // Mirrors a freshly-copied `.env.example`: DATABASE_URL is present but
+      // empty. It must collapse to `Option.none()` so the durable Order entity
+      // stays disabled, not a Some(...) of an empty string.
+      expect(Option.isNone(env.database)).toBe(true);
+    }).pipe(
+      provideEnv({
+        NODE_ENV: 'development',
+        DATABASE_URL: '',
+      }),
+    ));
+
+  it.effect('treats a whitespace-only DATABASE_URL as absent', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      expect(Option.isNone(env.database)).toBe(true);
+    }).pipe(
+      provideEnv({
+        NODE_ENV: 'development',
+        DATABASE_URL: '   \t',
+      }),
+    ));
 });
 
 describe('Mailer', () => {

--- a/app/lib/services.test.ts
+++ b/app/lib/services.test.ts
@@ -298,6 +298,77 @@ describe('Env config', () => {
         DATABASE_URL: '   \t',
       }),
     ));
+
+  it.effect("accepts DATABASE_URL=':memory:' in development (single-graph G3 path)", () =>
+    Effect.gen(function* () {
+      // The G3 `layerTest` / cross-runtime single-graph tests rely on the
+      // in-memory sqlite DB. The production guard must NOT regress that: dev/test
+      // keep `':memory:'` as a valid, resolvable connection string.
+      const env = yield* Env.Service;
+      expect(Option.isSome(env.database)).toBe(true);
+      if (Option.isSome(env.database)) {
+        expect(Redacted.value(env.database.value.url)).toBe(':memory:');
+      }
+    }).pipe(
+      provideEnv({
+        NODE_ENV: 'development',
+        DATABASE_URL: ':memory:',
+      }),
+    ));
+
+  it.effect("rejects DATABASE_URL=':memory:' in production (two-runtime coordination guard)", () =>
+    Effect.gen(function* () {
+      // The runner (`ServerLive`) and senders (`AppRuntime`) are separate layer
+      // graphs that coordinate ONLY through the shared sqlite FILE; `':memory:'`
+      // gives each its OWN private DB, silently breaking the route → runner →
+      // webhook loop (docs/order-workflow-plan.md:327). It must fail the env
+      // layer at boot with a typed `ConfigError` (NOT a thrown defect).
+      const exit = yield* Env.Service.pipe(
+        provideEnv({
+          ...PROD_ENV,
+          DATABASE_URL: ':memory:',
+        }),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const typedRejection = exit.cause.reasons.some(
+          (reason) =>
+            reason._tag === 'Fail' &&
+            typeof reason.error === 'object' &&
+            reason.error !== null &&
+            '_tag' in reason.error &&
+            reason.error._tag === 'ConfigError',
+        );
+        expect(typedRejection).toBe(true);
+      }
+    }));
+
+  it.effect("rejects a whitespace/case variant of ':memory:' in production", () =>
+    Effect.gen(function* () {
+      const exit = yield* Env.Service.pipe(
+        provideEnv({
+          ...PROD_ENV,
+          DATABASE_URL: '  :MEMORY:  ',
+        }),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    }));
+
+  it.effect('accepts a sqlite FILE path in production', () =>
+    Effect.gen(function* () {
+      const env = yield* Env.Service;
+      expect(Option.isSome(env.database)).toBe(true);
+      if (Option.isSome(env.database)) {
+        expect(Redacted.value(env.database.value.url)).toBe('/data/order.db');
+      }
+    }).pipe(
+      provideEnv({
+        ...PROD_ENV,
+        DATABASE_URL: '/data/order.db',
+      }),
+    ));
 });
 
 describe('Mailer', () => {

--- a/app/lib/storage.server.test.ts
+++ b/app/lib/storage.server.test.ts
@@ -123,7 +123,7 @@ describe('Storage.layer', () => {
   it.effect('fails with StorageUnconfigured when no bucket is configured', () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
-        Storage.Service.asEffect().pipe(
+        Storage.Service.pipe(
           Effect.provide(
             Storage.layer.pipe(
               Layer.provide(envFromBucketless({ NODE_ENV: 'development' })),
@@ -145,7 +145,7 @@ describe('Storage.layer', () => {
   it.effect('constructs a storage instance when the bucket is configured', () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(
-        Storage.Service.asEffect().pipe(
+        Storage.Service.pipe(
           Effect.provide(
             Storage.layer.pipe(
               Layer.provide(

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -50,6 +50,12 @@ export default [
   // middleware/loader runs ahead of it, so `request.text()` reads the RAW bytes
   // Stripe signed (HMAC verification fails on any reserialized body).
   route('api/stripe/webhook', 'routes/api.stripe-webhook.ts'),
+  // The manual deadline-sweep trigger (order-workflow G9) is a POST-only
+  // resource route OUTSIDE the `/admin` guard layout (a sibling of the webhook):
+  // it does its OWN cookie check + `Env.database` gate, so it never renders and
+  // never inherits the layout loader. An operator / external cron POSTs it to
+  // run one sweep pass on demand.
+  route('admin/orders/sweep', 'routes/admin/orders.sweep.ts'),
   layout('routes/admin/_layout.tsx', [
     route('admin', 'routes/admin/_index.tsx'),
     route('admin/content', 'routes/admin/content.tsx'),

--- a/app/routes/admin/orders.sweep.ts
+++ b/app/routes/admin/orders.sweep.ts
@@ -1,0 +1,54 @@
+import { Effect, Option } from 'effect';
+import { redirect } from 'react-router';
+
+import { Auth } from '~/lib/auth.server';
+import { Env } from '~/lib/env.server';
+import { ReactRouterContext } from '~/lib/effect/router-context';
+import { routeAction } from '~/lib/effect/route';
+import { OrderSweep } from '~/lib/order/sweep.server';
+
+/**
+ * The MANUAL deadline-sweep trigger (order-workflow G9, Open Question 5). A
+ * POST-only resource route an operator (or an external cron, if GYC ever scales
+ * past the single always-on instance the in-process sweep fiber assumes) hits to
+ * run ONE sweep pass on demand — lapsing every pending order past its `deadline`
+ * to `expired` via the durable `Order.expire` op, exactly as the in-process
+ * fiber (`sweep.server.ts`) does on its schedule.
+ *
+ * It sits OUTSIDE the `/admin` guard LAYOUT (it is a non-rendering POST endpoint,
+ * a sibling of the Stripe webhook), so it does its OWN cookie check rather than
+ * inheriting the layout loader's: an admin-disabled deploy (`ADMIN_PASSWORD`
+ * unset) 404s the endpoint (the sweep is not reachable without an admin), and a
+ * missing/invalid cookie redirects to `/admin/login` — the same redirect-vs-404
+ * policy the layout guard enforces. Gated additionally on `Env.database` Some:
+ * a DB-less deploy has no Order runner to consume the `expire` sends, so the
+ * trigger is a 404 (the durable lifecycle does not exist there).
+ *
+ * Returns the count of orders it dispatched `expire` for — JSON for an external
+ * caller, observable in the operator's network tab. The `expire` sends are
+ * fire-and-forget into the SAME SQL mailbox the `ServerLive` runner consumes
+ * (the durable seam); the runner reconciles each flip off the persisted send.
+ */
+export const action = routeAction(function* () {
+  const { request } = yield* ReactRouterContext;
+  const auth = yield* Auth.Service;
+  const env = yield* Env.Service;
+
+  // Gate (parity with the `/admin` layout guard): admin disabled ⇒ 404 the
+  // endpoint; no valid cookie ⇒ redirect to the login page. A DB-less deploy has
+  // no runner to consume the sweep's `expire` sends, so the durable lifecycle —
+  // and this trigger — does not exist: 404.
+  yield* auth.checkCookie(request.headers.get('cookie')).pipe(
+    Effect.catchTags({
+      'Auth.Disabled': () =>
+        Effect.fail(new Response('Not Found', { status: 404 })),
+      'Auth.Unauthorized': () => Effect.fail(redirect('/admin/login')),
+    }),
+  );
+  if (Option.isNone(env.database)) {
+    return yield* Effect.fail(new Response('Not Found', { status: 404 }));
+  }
+
+  const expired = yield* OrderSweep.runOnce;
+  return Response.json({ expired: expired.length, orderIds: expired });
+});

--- a/app/routes/api.stripe-webhook.ts
+++ b/app/routes/api.stripe-webhook.ts
@@ -98,23 +98,47 @@ export const action = routeAction(function* () {
   // the `ServerLive` runner consumes. The webhook holds only `metadata.orderId`,
   // and `settle`'s `id` is a pure fn of `orderId` (Decision 4), so the op
   // resolves WITHOUT reconstructing the full payload: `send` the settle, then
-  // `waitFor` a terminal reply keyed off the `{ orderId }`-derived ExecId. This
-  // is COMPLEMENTARY to the bucket flip (the receipt authority), so a settle
-  // infra fault — or the durable Failure the `async_payment_failed` path
-  // intentionally resolves to (`outcome: 'failed'` ⇒ a `SettleFailed` reply) — is
-  // logged + swallowed: the bucket order is ALREADY durably paid/failed and the
-  // runner reconciles the durable lifecycle off the persisted `send`, so the
-  // settle-drive NEVER changes the 200/400/503 the bucket flip earned (its error
-  // channel is collapsed to `never`). Gated on `Env.database` Some — a DB-less
-  // deploy has no runner, so it skips the drive and degrades to the bucket-only
-  // flip (backward compatible). `outcome` defaults to `'paid'` (the absent
-  // `checkout.session.completed` path); the `async_payment_failed` path passes
-  // `'failed'` so the durable reply mirrors the bucket `failed` flip (Decision 7).
+  // `waitFor` a terminal reply keyed off the `{ orderId }`-derived ExecId. Gated
+  // on `Env.database` Some — a DB-less deploy has no runner, so it skips the
+  // drive and degrades to the bucket-only flip (backward compatible). `outcome`
+  // defaults to `'paid'` (the absent `checkout.session.completed` path); the
+  // `async_payment_failed` path passes `'failed'` so the durable reply mirrors
+  // the bucket `failed` flip (Decision 7).
+  //
+  // (F3, --deep MAJOR) The `send` (persistence) and the `waitFor` (bounded
+  // observation) carry DIFFERENT failure semantics and so are NOT collapsed into
+  // one `catchCause`:
+  //
+  //   • `send` FAILING means the durable settle row never LANDED in MessageStorage
+  //     (a SQL/`PersistenceError`/`MailboxError` fault). Swallowing that would 200
+  //     Stripe with the bucket already flipped paid/failed but NO durable settle —
+  //     a lost-settle money hazard with no retry. So a `send` failure PROPAGATES,
+  //     failing the webhook response (non-2xx) so Stripe RETRIES. The retry is a
+  //     safe no-op on the bucket: `markOrderPaid`/`markOrderFailed` re-flip an
+  //     already-terminal order idempotently via `canTransition`'s identity case
+  //     (F1), so a retried `completed`/`async_payment_failed` re-runs only the
+  //     `send` until it lands. The error channel here is the `send` failure set;
+  //     it is mapped to a 502 by the `catchTags` below (Stripe retries on 5xx).
+  //
+  //   • The `waitFor` runs ONLY AFTER `send` has SUCCEEDED — the durable row is in
+  //     storage, the runner WILL reconcile it; the reply merely has not been
+  //     OBSERVED yet. A non-terminal/timeout wait is therefore safe to swallow:
+  //     the bound (`Effect.timeout('5 seconds')`) injects a `TimeoutException`
+  //     (`waitFor` polls FOREVER otherwise — a defected runner/sweep fiber in the
+  //     single-instance topology would hang the request fiber and never return),
+  //     and the post-send `catchCause` collapses it (and any `PersistenceError`
+  //     from the `peek` poll) to a logged no-op. The durable `send` already
+  //     landed; the runner/sweep converges it; the bucket authority is unaffected,
+  //     so the webhook 200s on the status the bucket flip earned.
   const settleOrder = (
     orderId: string,
     outcome: 'paid' | 'failed',
     sessionId: string,
-  ): Effect.Effect<void, never, Order.SenderServices> =>
+  ): Effect.Effect<
+    void,
+    Order.SettleSendError,
+    Order.SenderServices
+  > =>
     Option.isNone(env.database) ?
       Effect.void
     : Order.Entity.settle.send({
@@ -123,36 +147,25 @@ export const action = routeAction(function* () {
         sessionId,
         paymentIntentId: undefined,
       }).pipe(
-        // Wait for the op to reach a terminal reply (Success for `'paid'`, the
-        // durable `SettleFailed` Failure for `'failed'`) so the webhook observes
-        // the runner completed the continuation. A non-terminal/timeout is
-        // tolerated — the durable `send` already landed and the runner reconciles
-        // it; the bucket authority is unaffected either way.
+        // The durable row has LANDED. Wait for the op to reach a terminal reply
+        // (Success for `'paid'`, the durable `SettleFailed` Failure for
+        // `'failed'`) so the webhook observes the runner completed the
+        // continuation — but tolerate a non-terminal/timeout WAIT, since the
+        // `send` already persisted and the runner reconciles it. ONLY this
+        // post-send observation is swallowed; the `send` failure above is NOT.
         Effect.andThen(
           Order.Entity.settle.waitFor(
             { orderId, outcome, sessionId, paymentIntentId: undefined },
             { filter: (result) => isTerminal(result) },
-          ),
-        ),
-        Effect.asVoid,
-        // BOUND the wait: `waitFor` polls the persisted reply at 200ms FOREVER
-        // until the filter is true (no built-in timeout). That termination
-        // silently ASSUMES a live consumer — but in the single-instance topology
-        // the runner/sweep fiber can defect while the HTTP server keeps serving
-        // (a poll-fiber crash kills the consumer, not the web server). With a dead
-        // runner the reply never goes terminal, so an unbounded `waitFor` would
-        // hang the request fiber forever: Stripe times out and retries the
-        // already-paid event indefinitely, and the 200/400/503 the bucket flip
-        // earned is never returned. The bound injects a `TimeoutException` the
-        // `catchCause` below swallows (error channel stays `never`), degrading a
-        // non-replying runner to the swallow-and-200 path this drive already
-        // claims — the durable `send` already landed; the runner reconciles it on
-        // recovery; the bucket authority is unaffected.
-        Effect.timeout('5 seconds'),
-        Effect.catchCause((cause) =>
-          Effect.logError(
-            `Order.settle drive failed for ${orderId} (bucket order is the authority; runner reconciles the durable lifecycle)`,
-            cause,
+          ).pipe(
+            Effect.asVoid,
+            Effect.timeout('5 seconds'),
+            Effect.catchCause((cause) =>
+              Effect.logError(
+                `Order.settle wait timed out for ${orderId} (durable send landed; runner reconciles the durable lifecycle)`,
+                cause,
+              ),
+            ),
           ),
         ),
       );
@@ -228,6 +241,21 @@ export const action = routeAction(function* () {
       // The on-site path is unconfigured (`Env.stripe` None) ⇒ the endpoint is
       // inert: 503, so Stripe backs off until the gate flips.
       'Payment.Disabled': () => Effect.succeed(status(503)),
+      // (F3, --deep MAJOR) The durable `settle` `send` FAILED to persist — the
+      // SQL mailbox row never landed (a SQL/`PersistenceError`/`MailboxError`
+      // fault, a full mailbox, or a concurrent processing claim). The bucket may
+      // have already flipped paid/failed, but with NO durable settle the runner
+      // has nothing to reconcile, so this MUST NOT 200: a 502 lets Stripe RETRY
+      // until the `send` lands. The retry is a safe no-op on the already-flipped
+      // bucket (the `canTransition` identity case, F1), so it re-drives only the
+      // `send`. These four tags are `Entity.settle.send`'s declared error set
+      // (`Order.SettleSendError`); they reach this `catchTags` ONLY from the
+      // pre-observation `send`, never the swallowed post-send `waitFor`.
+      'effect-encore/actor-mailbox/MailboxError': () =>
+        Effect.succeed(status(502)),
+      PersistenceError: () => Effect.succeed(status(502)),
+      MailboxFull: () => Effect.succeed(status(502)),
+      AlreadyProcessingMessage: () => Effect.succeed(status(502)),
     }),
   );
 });

--- a/app/routes/api.stripe-webhook.ts
+++ b/app/routes/api.stripe-webhook.ts
@@ -1,8 +1,11 @@
-import { Effect, Schema } from 'effect';
+import { Effect, Option, Schema } from 'effect';
 
+import { Env } from '~/lib/env.server';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeAction } from '~/lib/effect/route';
 import { Submissions } from '~/lib/forms/submissions.server';
+import { Order } from '~/lib/order/runner.server';
+import { isTerminal } from 'effect-encore';
 import { Payment } from '~/lib/payment.server';
 import { Cents } from '~/lib/forms/pricing';
 
@@ -42,7 +45,23 @@ import { Cents } from '~/lib/forms/pricing';
  *      STAYS pending, **400**. Only a paid completion with an exact amount match
  *      flips the order to `paid`.
  *   6. Mark the order `paid` / `failed` (idempotent — replaying the same event is
- *      a no-op, mirroring the `c8c4abd` idempotency fix) and return **200**.
+ *      a no-op, mirroring the `c8c4abd` idempotency fix). The bucket flip is the
+ *      RECEIPT AUTHORITY and STAYS exactly as before.
+ *   7. (order-workflow G8) ADDITIONALLY drive the durable Order `settle` op
+ *      through the SAME SQL MessageStorage the `ServerLive` runner consumes, so
+ *      the durable lifecycle advances `pending → paid` (a `completed` paid event)
+ *      / resolves to a `SettleFailed` Failure (an `async_payment_failed` event).
+ *      The webhook holds only `metadata.orderId`, and `settle`'s `id` is a pure fn
+ *      of `orderId` (G4 / Decision 4), so it resolves the op WITHOUT
+ *      reconstructing the full payload — `send` then `waitFor({ orderId })`. This
+ *      is GATED on `Env.database` Some: a DB-less deploy has no runner and
+ *      degrades to the bucket-only flip (backward compatible). The settle-drive is
+ *      COMPLEMENTARY to the bucket authority, never a gate on it — a settle infra
+ *      fault is logged + swallowed (the bucket order is already durably paid/failed
+ *      and the runner reconciles the durable lifecycle off the persisted `send`),
+ *      so it never changes the 200/400/503 the bucket flip earned (Decision 1/7).
+ *      Idempotent: a replayed event re-resolves an already-terminal ExecId to a
+ *      no-op (encore dedup), `paidAt` byte-identical.
  *
  * The route returns plain `Response`s (Stripe reads the STATUS, not an HTML error
  * page): the verify/lookup failures are mapped to their codes via `catchTags` so
@@ -73,6 +92,70 @@ export const action = routeAction(function* () {
   const { request } = yield* ReactRouterContext;
   const payment = yield* Payment.Service;
   const submissions = yield* Submissions.Service;
+  const env = yield* Env.Service;
+
+  // (G8) Drive the durable Order `settle` op through the SAME SQL MessageStorage
+  // the `ServerLive` runner consumes. The webhook holds only `metadata.orderId`,
+  // and `settle`'s `id` is a pure fn of `orderId` (Decision 4), so the op
+  // resolves WITHOUT reconstructing the full payload: `send` the settle, then
+  // `waitFor` a terminal reply keyed off the `{ orderId }`-derived ExecId. This
+  // is COMPLEMENTARY to the bucket flip (the receipt authority), so a settle
+  // infra fault — or the durable Failure the `async_payment_failed` path
+  // intentionally resolves to (`outcome: 'failed'` ⇒ a `SettleFailed` reply) — is
+  // logged + swallowed: the bucket order is ALREADY durably paid/failed and the
+  // runner reconciles the durable lifecycle off the persisted `send`, so the
+  // settle-drive NEVER changes the 200/400/503 the bucket flip earned (its error
+  // channel is collapsed to `never`). Gated on `Env.database` Some — a DB-less
+  // deploy has no runner, so it skips the drive and degrades to the bucket-only
+  // flip (backward compatible). `outcome` defaults to `'paid'` (the absent
+  // `checkout.session.completed` path); the `async_payment_failed` path passes
+  // `'failed'` so the durable reply mirrors the bucket `failed` flip (Decision 7).
+  const settleOrder = (
+    orderId: string,
+    outcome: 'paid' | 'failed',
+    sessionId: string,
+  ): Effect.Effect<void, never, Order.SenderServices> =>
+    Option.isNone(env.database) ?
+      Effect.void
+    : Order.Entity.settle.send({
+        orderId,
+        outcome,
+        sessionId,
+        paymentIntentId: undefined,
+      }).pipe(
+        // Wait for the op to reach a terminal reply (Success for `'paid'`, the
+        // durable `SettleFailed` Failure for `'failed'`) so the webhook observes
+        // the runner completed the continuation. A non-terminal/timeout is
+        // tolerated — the durable `send` already landed and the runner reconciles
+        // it; the bucket authority is unaffected either way.
+        Effect.andThen(
+          Order.Entity.settle.waitFor(
+            { orderId, outcome, sessionId, paymentIntentId: undefined },
+            { filter: (result) => isTerminal(result) },
+          ),
+        ),
+        Effect.asVoid,
+        // BOUND the wait: `waitFor` polls the persisted reply at 200ms FOREVER
+        // until the filter is true (no built-in timeout). That termination
+        // silently ASSUMES a live consumer — but in the single-instance topology
+        // the runner/sweep fiber can defect while the HTTP server keeps serving
+        // (a poll-fiber crash kills the consumer, not the web server). With a dead
+        // runner the reply never goes terminal, so an unbounded `waitFor` would
+        // hang the request fiber forever: Stripe times out and retries the
+        // already-paid event indefinitely, and the 200/400/503 the bucket flip
+        // earned is never returned. The bound injects a `TimeoutException` the
+        // `catchCause` below swallows (error channel stays `never`), degrading a
+        // non-replying runner to the swallow-and-200 path this drive already
+        // claims — the durable `send` already landed; the runner reconciles it on
+        // recovery; the bucket authority is unaffected.
+        Effect.timeout('5 seconds'),
+        Effect.catchCause((cause) =>
+          Effect.logError(
+            `Order.settle drive failed for ${orderId} (bucket order is the authority; runner reconciles the durable lifecycle)`,
+            cause,
+          ),
+        ),
+      );
 
   return yield* Effect.gen(function* () {
     // (1) RAW body, read BEFORE any parse — the HMAC is over these exact bytes.
@@ -109,6 +192,11 @@ export const action = routeAction(function* () {
       // against a frozen amount); flip the order to `failed`. A `NotFound` (an
       // event for an order that has not landed) ⇒ 400 via the `catchTags`.
       yield* submissions.markOrderFailed('registration', orderId);
+      // (G8) ADDITIONALLY resolve the durable `settle` to a Failure (`outcome:
+      // 'failed'` ⇒ a `SettleFailed` reply) — preserving the bucket `failed`
+      // flip with NO regression (Decision 7). Gated + swallowed (the bucket is
+      // the authority).
+      yield* settleOrder(orderId, 'failed', session.value.id);
       return status(200);
     }
 
@@ -121,8 +209,15 @@ export const action = routeAction(function* () {
     const order = yield* submissions.getOrder('registration', orderId);
     if (order.amount !== amount_total) return status(400);
 
-    // (6) Paid + amounts match ⇒ flip to paid (idempotent on replay) and ack 200.
+    // (6) Paid + amounts match ⇒ flip to paid (idempotent on replay) — the
+    // bucket RECEIPT AUTHORITY, unchanged.
     yield* submissions.markOrderPaid('registration', orderId);
+    // (7, G8) ADDITIONALLY drive the durable Order `settle` (`outcome: 'paid'`)
+    // so the durable lifecycle advances `pending → paid` and the runner mirrors
+    // the bucket flip into actor State. Gated on `Env.database` Some + swallowed
+    // (the bucket flip already earned the 200). Idempotent on replay (encore
+    // dedup, `paidAt` byte-identical).
+    yield* settleOrder(orderId, 'paid', session.value.id);
     return status(200);
   }).pipe(
     Effect.catchTags({

--- a/app/routes/api.stripe-webhook.ts
+++ b/app/routes/api.stripe-webhook.ts
@@ -56,10 +56,13 @@ import { Cents } from '~/lib/forms/pricing';
  *      reconstructing the full payload — `send` then `waitFor({ orderId })`. This
  *      is GATED on `Env.database` Some: a DB-less deploy has no runner and
  *      degrades to the bucket-only flip (backward compatible). The settle-drive is
- *      COMPLEMENTARY to the bucket authority, never a gate on it — a settle infra
- *      fault is logged + swallowed (the bucket order is already durably paid/failed
- *      and the runner reconciles the durable lifecycle off the persisted `send`),
- *      so it never changes the 200/400/503 the bucket flip earned (Decision 1/7).
+ *      COMPLEMENTARY to the bucket authority, never a gate on it. Failure handling
+ *      is split (F3): a `settle.send`/persistence fault PROPAGATES — the durable row
+ *      never landed, so the route returns 502 for Stripe to retry. Only the
+ *      POST-send `waitFor` observation (the durable row already persisted; the
+ *      runner/sweep reconciles the lifecycle) is logged + swallowed, since the
+ *      bucket order is already durably paid/failed — so that swallowed wait never
+ *      changes the 200/400/503 the bucket flip earned (Decision 1/7).
  *      Idempotent: a replayed event re-resolves an already-terminal ExecId to a
  *      no-op (encore dedup), `paidAt` byte-identical.
  *

--- a/bun.lock
+++ b/bun.lock
@@ -9,14 +9,16 @@
         "@conform-to/dom": "^1.19.4",
         "@conform-to/react": "^1.19.4",
         "@distilled.cloud/stripe": "0.26.1",
-        "@effect/platform-bun": "4.0.0-beta.60",
+        "@effect/platform-bun": "4.0.0-beta.75",
+        "@effect/sql-sqlite-bun": "4.0.0-beta.75",
         "@epic-web/client-hints": "^1.3.2",
         "@react-router/node": "^7.15.0",
         "@sendgrid/client": "^8.1.6",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.11",
         "dedent": "^1.5.3",
-        "effect": "4.0.0-beta.60",
+        "effect": "4.0.0-beta.75",
+        "effect-encore": "^0.14.0",
         "framer-motion": "^11.2.13",
         "isbot": "^5.1.40",
         "lucide-react": "0.469.0",
@@ -49,7 +51,7 @@
     },
   },
   "overrides": {
-    "effect": "4.0.0-beta.60",
+    "effect": "4.0.0-beta.75",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -122,9 +124,11 @@
 
     "@distilled.cloud/stripe": ["@distilled.cloud/stripe@0.26.1", "", { "dependencies": { "@distilled.cloud/core": "0.26.1" }, "peerDependencies": { "effect": ">=4.0.0-beta.66 || >=4.0.0" } }, "sha512-+2trN/QRflYmhhkszDVMq3GY+U9sVoozd+lJ+PjDiy0NhyJeT1Rv6wexBi+ZJt2CW1aFXk9FzXsVA2hrCf3pPg=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.60", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.60" }, "peerDependencies": { "effect": "^4.0.0-beta.60" } }, "sha512-UHm4RyigOie5Rk3KvNqJZwNJ/mG/OlDt3Uz7hwAxD3KjgHZL4CouInwI0/VXDD31BMFwUSLgUECDFGk0nojwag=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.75", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.75" }, "peerDependencies": { "effect": "^4.0.0-beta.75" } }, "sha512-OIIi1kI/DFkzgIHPzy7kqLI1VVbRVpq3HkgH72LHPjVt9mIO3+YXvt8rnjSmTGpSpjEzzBsas8rZ4cnFbYKESA=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.78", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.78" } }, "sha512-mo0ddTPATyCMyqzQasYDL7+NI29vozoMplom+qu9f/onDTd4xG5hvEEfGxfL0Ljygui6keG/YE/E9OZVf2z5WA=="],
+
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.75", "", { "peerDependencies": { "effect": "^4.0.0-beta.75" } }, "sha512-3BsurtKS6AY6UtxGwQMG/Vwk6ZkTe1MNGJMj1+bh2r+DKTvB8Z/iGpTQEq1ah4mZn82APxNRWJzjpLYm3HPMWg=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.5.2", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.5.2", "@effect/tsgo-darwin-x64": "0.5.2", "@effect/tsgo-linux-arm": "0.5.2", "@effect/tsgo-linux-arm64": "0.5.2", "@effect/tsgo-linux-x64": "0.5.2", "@effect/tsgo-win32-arm64": "0.5.2", "@effect/tsgo-win32-x64": "0.5.2" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-LEKmx1rwP1j3l9mPW6Bx8VIdGKW+uEvvML89z4xiWnPC+h/uFm3y6FGHULop9Kl09Ybwn2TVuZzVPSZLj+ydmg=="],
 
@@ -516,9 +520,11 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "effect": ["effect@4.0.0-beta.60", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-OkrCKT+aBFIti4ryuxKfIozNx2SMxmFZ8uWB53gGzdjQzaJ7RVf0s6nJQ4JubJM//R24DtSYNOdmPRSK+qoRww=="],
+    "effect": ["effect@4.0.0-beta.75", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-KrDuecxuN8rC7dytVs5GFfUhtC+/D8pOyfVb1LNZGjJY7qigQG9xXJ4R1Bp+tBo7sKbZOXBswCfuQ3ombaEldQ=="],
 
     "effect-bun-test": ["effect-bun-test@0.3.0", "", { "peerDependencies": { "bun": "*", "effect": ">=3.19.0" } }, "sha512-P2xZ4HBZg4bFw2ePY4E5UB6EZ2d1L/HO13+KdoprTYFuc8B1uTpdn7V4UU6qyYiYsqTY9DZ1TFB94Ekx2YLA4g=="],
+
+    "effect-encore": ["effect-encore@0.14.0", "", { "peerDependencies": { "effect": ">=4.0.0-beta.66" } }, "sha512-t1N02K9wCR1TZg4V16ukb6iIRelTau+Me+2+K71QiXvH59+AprCI+zxx/xVTKoo1r33Y2bZuNlib6cpv/T2Amg=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.370", "", {}, "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g=="],
 
@@ -576,7 +582,7 @@
 
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
-    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "isbot": ["isbot@5.1.42", "", {}, "sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ=="],
 
@@ -634,7 +640,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
@@ -722,7 +728,7 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 

--- a/docs/order-workflow-plan.md
+++ b/docs/order-workflow-plan.md
@@ -1,0 +1,865 @@
+# GYC Order Workflow — durable Order actor for the registration-payment lifecycle
+
+> Authoritative, commit-broken implementation plan synthesized from PLAN A (infra-first)
+> + PLAN B (domain-first) + both adversarial cross-reviews. Every claim below is
+> verified against the real tree on branch **`feat/registrar`** (the registrar PR #35
+> base) and the **`effect-encore` HEAD (v0.12.8, `main`)** on disk at
+> `/Users/cvr/Developer/personal/effect-encore`. This plan will be `--deep` reviewed
+> then implemented commit-by-commit, so it is load-bearing: file:line citations are
+> the receipts.
+
+---
+
+## 1. Overview
+
+The registrar (PR #35, `feat/registrar`) already owns the **payment freeze discipline**:
+a `Payment` service that mints a Stripe Checkout Session
+(`app/lib/payment.server.ts:142` `createCheckoutSession`), a frozen `RegistrationOrder`
+receipt stored as a bucket object (`app/lib/forms/order.ts:40`), a `Submissions` service
+with `persistOrder` / `getOrder` / `markOrderPaid` / `markOrderFailed`
+(`app/lib/forms/submissions.server.ts:283,143,382,434`), and a Stripe webhook that
+reconciles `checkout.session.completed` / `async_payment_failed` against the frozen
+amount (`app/routes/api.stripe-webhook.ts:88-125`).
+
+This work adds a **durable encore Order ENTITY** that *orchestrates* that lifecycle — it
+does **not** replace the freeze. The entity:
+
+- backs onto **encore's SQL `MessageStorage`** stood up inside GYC for the first time
+  (GYC has no MessageStorage today — only the bucket store at `app/lib/storage.server.ts`);
+- exposes ops **`process` → `cancel` → `refund` → `expire`** over the state machine
+  `pending | paid | cancelled | refunded | expired`;
+- has its `process` op **suspend awaiting the Stripe webhook**, which resolves the op's
+  ExecId through the *same* SQL MessageStorage reply mechanism — no bespoke bucket adapter;
+- treats the **bucket `RegistrationOrder` as the durable source of truth** and the actor's
+  in-process State as a derived cache (because encore's durable per-entity State backing is
+  DEFERRED — `effect-encore/CONTEXT.md`, in-process `SubscriptionRef` today).
+
+### The decisive architecture fact both source plans got partly wrong
+
+Both source plans argued about whether GYC needs a Sharding "runner". The cross-reviews
+flagged the contradiction but neither source plan resolved it correctly. The tree settles it:
+
+- **PLAN A** wanted a runner but planned to add it to `makeAppLayer`
+  (`app/lib/effect/runtime.ts:94-115`). That is the **request-handler layer graph** — the one
+  every React Router loader/action runs against. It is **never `Layer.launch`-ed**, so it has
+  no process-lifetime supervisor for the mailbox-poll fiber or the deadline sweep. A durable
+  actor runner + sweep fiber **cannot** live there. (Note: `makeAppLayer` is NOT "rebuilt per
+  request" — it is consumed ONCE into the module-level singleton `AppRuntime`,
+  `runtime.ts:120` `const AppRuntime = ManagedRuntime.make(...)`. The disqualifier is the
+  never-`Layer.launch`-ed request-handler role, not per-request rebuild.)
+- **PLAN B** claimed "no runner — `Client.layer.fromConfig` is the dispatch seam." This is
+  **false against the tree**: `ActorMailboxLayer.fromConfig` only *enqueues* to storage
+  (`effect-encore/src/actor-mailbox.ts:88-120`, "the consumer's storage poll loop picks up
+  the envelope"). With **no runner consuming the mailbox, the `process` handler never runs**
+  — `createCheckoutSession` would never fire. Also `Client.layer`/`State<A>` are **not
+  exported** by encore HEAD (`effect-encore/src/index.ts` exports `registerState` +
+  read-only `ActorStateHandle` only — the #1/#2 reshape is unpublished).
+
+**The correct model (verified):** GYC hosts a **single-process in-process Sharding runner**
+in the **long-lived `ServerLive` layer** (`server.ts:263-269`, which IS `Layer.launch`-ed at
+`:269`) that registers the Order handlers (`Actor.toLayer`) AND consumes the SQL-backed
+mailbox. The runner belongs in the `Layer.launch`-ed graph because its mailbox-poll fiber and
+the deadline sweep are **process-lifetime fibers** — they need the launch-time supervisor
+`ServerLive` provides; the request-handler `makeAppLayer` graph never gets one. The exact
+runner composition is proven in `effect-encore/test/send-and-await.test.ts:63-68`
+(`FastTerminationCluster`):
+
+```
+Sharding.layer
+  ⊕ Runners.layerNoop            // single-node: no remote runners
+  ⊕ MessageStorage (SQL here)    // swap layerMemory → fromSqlClient
+  ⊕ RunnerStorage.layerMemory
+  ⊕ RunnerHealth.layerNoop
+  ⊕ ShardingConfig.layer({...})
+```
+
+The request side (route handlers, the webhook) is a **sender** into that same SQL storage:
+it uses the `OperationHandle` methods `send` / `peek` / `waitFor` / `sendAndAwait` (each a
+per-op method on the entity's operation handle, `effect-encore/src/actor.ts:557-639`), wired
+by `ActorSenderLayer.layer` which requires `MessageStorage | ShardingConfig`
+(`src/actor-sender.ts:42-46`), NOT a local runner.
+
+### The two-runtime topology — and why the shared seam is a DB FILE, not a layer instance
+
+GYC has **two independent runtime worlds**, and naming them is load-bearing because the
+central "webhook resolves the suspended op" invariant ONLY holds across them if they share
+durable backing:
+
+- **`ServerLive`** (`server.ts:263`, `Layer.launch`-ed at `:269`) — the long-lived process
+  graph. **This hosts the runner + `Order.MessageStorageLive`** (the consumer side that runs
+  handlers and writes replies) and the deadline-sweep fiber.
+- **`AppRuntime`** (`runtime.ts:120`, the **module-level singleton** built ONCE at import via
+  `ManagedRuntime.make(makeAppLayer(...))`, NOT per request) — the request-handler graph every
+  React Router loader/action runs against via `makeRequestRuntime()` (`server.ts:135`,
+  `runtime.ts:206-207`). **This hosts the SENDER side** (`ActorSenderLayer` threaded into
+  `makeAppLayer`). The registration action and the Stripe webhook (`api.stripe-webhook.ts:72`
+  `routeAction`) BOTH run here.
+
+These are **separate layer graphs with separate `SqlClient` builds.** They do NOT share an
+in-memory `MessageStorage` instance. They share durable state **only if both point at the
+same sqlite FILE** — the rows in `cluster_messages` / `cluster_replies` are the coordination
+point. This is **exactly the pattern `Storage` already uses today**: `server.ts:261`
+(`StorageLive = Storage.defaultLayer`) and `makeAppLayer`'s `Storage.layerOptional`
+(`runtime.ts:109`) are *two separate `Storage` builds* that coordinate fine because the bucket
+is **external shared state** (`runtime.ts:55-62` documents the "one Storage instance the whole
+app runtime shares … no second instance to coordinate" reasoning — the bucket IS the seam).
+
+**The hard consequence (see Risk 2, promoted to a pre-G0 BLOCKER):** `':memory:'` gives the
+two runtimes **two DISJOINT in-memory DBs** — a `send` from the `AppRuntime` sender lands in a
+DB the `ServerLive` runner never polls, and the webhook's `peek` sees nothing. The
+route→runner→webhook loop is **completely broken** under `':memory:'` in production. The only
+viable sqlite path is a **shared FILE on a persistent volume** (or `@effect/sql-pg`). A single
+in-memory layer graph in a test will pass while never exercising the real cross-runtime
+sharing — see the dedicated **G3 cross-runtime test** that builds BOTH graphs over ONE shared
+file DB.
+
+Because both the runner (in `ServerLive`) and the senders (in `AppRuntime`) point at **one
+SQL MessageStorage over one shared DB file**, a `send` from a route is consumed by the runner
+fiber, and a `peek`/ExecId resolution from the webhook observes the reply the runner wrote.
+This is the seam that makes "webhook resolves the suspended op" work with **zero bespoke
+adapter**.
+
+> **Cross-runtime `ShardingConfig` parity invariant.** `ActorSenderLayer.layer` uses
+> `ActorAddressResolverLayer.fromConfig`, which carries the shard-parity invariant
+> (`src/actor-address-resolver.ts`): the destination shard for an entity is computed from the
+> `ShardingConfig` shard count. The sender's `ShardingConfig` (in `AppRuntime`) and the
+> runner's `ShardingConfig` (in `ServerLive`) MUST be **byte-identical** (same shard count)
+> or routing diverges and the runner polls a different shard than the sender wrote to. Both
+> sides MUST be built from one shared `ShardingConfig.layer({...})` definition — see G6.
+
+> Note on latency: `fromConfig` mailbox delivery is bounded by `entityMessagePollInterval`,
+> not `notifyLocal` (`effect-encore/src/actor-mailbox.ts:30-33`). For an interactive
+> `process` (the visitor waits for the Checkout URL), we do NOT block the request on the
+> handler — see the **pre-suspend URL contract** in G6 (the action gets the URL synchronously,
+> the suspend/resume is the post-payment continuation).
+
+### Critical correction to the "process suspends, handler returns the URL" model
+
+The cross-reviews assumed the `process` handler creates the Checkout session AND returns the
+URL AND suspends — all in one op. Against the tree this is incoherent for an interactive
+redirect, because the runner consumes the mailbox asynchronously (poll-interval latency) and
+the request can't block on it. **Resolution (this plan's decision, see G5/G6):**
+
+- The **action** (request fiber) calls `Payment.createCheckoutSession` + `Submissions.persistOrder`
+  directly and synchronously (exactly as today, `registration-action.ts` checkout block) so it
+  has the `{sessionId, url}` to redirect/mail immediately. The freeze stays at the action
+  boundary.
+- The action then **`send`s the Order `arm` op** (a durable, fire-and-forget op that records
+  the entity into existence at `pending` with the frozen order linkage) — this is the durable
+  lifecycle anchor. It does NOT re-create the session.
+- The `process`/settlement continuation is driven by the **webhook resolving the op**, not by a
+  blocking handler. The op the webhook resolves is the durable one whose ExecId is reconstructable
+  from `metadata.orderId`.
+
+This keeps the interactive redirect synchronous (no regression), makes the durable lifecycle a
+true wrapper, and sidesteps the "handler must return the URL before suspending" foot-gun that
+both cross-reviews flagged (PLAN B risk 6).
+
+---
+
+## 2. Architecture decisions this plan honors
+
+1. **Bucket `RegistrationOrder` is the durable source of truth; actor State is a derived
+   in-process cache.** encore's durable per-entity State backing is DEFERRED
+   (`effect-encore/CONTEXT.md`; in-process `SubscriptionRef`). A process restart between
+   `send` and webhook-resolve must NOT lose the lifecycle — it rebuilds from the bucket order +
+   the durable SQL reply log. Every op writes the **bucket transition** (`flipStatus`,
+   `submissions.server.ts:346`) as the authority; State mirrors it. (cross-review-A mustFix #1,
+   cross-review-B strength #2.)
+
+2. **Single-process in-process Sharding runner in the long-lived `ServerLive` layer**
+   (`server.ts:263-269`, the `Layer.launch`-ed graph), NOT in the request-handler
+   `makeAppLayer` graph (consumed once into the `AppRuntime` singleton, `runtime.ts:120`). The
+   disqualifier for `makeAppLayer` is that it is **never `Layer.launch`-ed** — it has no
+   process-lifetime supervisor for the runner's mailbox-poll fiber or the deadline sweep — NOT
+   that it is "rebuilt per request" (it is a module-level singleton). The runner hosts
+   `Actor.toLayer` handlers + the deadline-sweep fiber; the request side (in `AppRuntime`) is a
+   sender into the **same shared DB**. Composition template: `send-and-await.test.ts:63-68`.
+   The two graphs share durable state via a **shared sqlite FILE** (the `cluster_messages` /
+   `cluster_replies` rows), never an in-memory instance — see the two-runtime topology in §1.
+   (cross-review-A mustFix #2, cross-review-B mustFix #1.)
+
+3. **Consume the encore HEAD as-published** — `effect-encore/src/index.ts` exports
+   `fromSqlClient`, `fromSqlClientWithShardingConfig` (`:70-71`), `entityIdCodec` (`:76`),
+   `makeExecId` + `PeekResult` (`:51-53`), `ActorSenderLayer` (`:82`), `ActorMailbox` +
+   `ActorMailboxLayer` (`:80`). The `sendAndAwait` / `waitFor` / `peek` / `executionId`
+   operations are **per-op METHODS on each operation's `OperationHandle`** (`src/actor.ts:586`,
+   `:604`, `:607`, `:622`) — NOT standalone `Op.*` exports; you reach them as
+   `Order.settle.sendAndAwait(...)`, `Order.settle.waitFor(...)`, etc. The index does **NOT**
+   export `Client`/`State<A>` (the #1/#2 reshape is unpublished). **This plan does NOT depend
+   on the unpublished reshape** — it uses the shipped sender + SQL-storage + per-op
+   `sendAndAwait`/`waitFor` seams, which are sufficient. This removes the publish-ordering
+   blocker both cross-reviews raised: **no new encore publish is strictly required** to start
+   (confirm the version GYC pins; HEAD `0.12.8` already has the `sendAndAwait` method).
+
+4. **ExecId resolvable from `metadata.orderId` alone — via the op's own `waitFor`/`peek`,
+   NOT via `entityIdCodec`/`makeExecId` string-surgery.** The webhook only has
+   `metadata.orderId` (`api.stripe-webhook.ts:105`). The mechanism (verified against
+   `actor.ts:114-128,1380-1386`):
+   - The op's `id` fn MUST be a **pure function of `orderId`** returning a **string**:
+     `id: (p) => p.orderId`. When `id` returns a string, `resolveId` sets
+     `entityId === primaryKey === orderId` (`actor.ts:124-125`), and the per-op `execId`
+     closure produces `makeExecId(\`${orderId}\x00settle\x00${orderId}\`)`
+     (`actor.ts:1383-1385`).
+   - The webhook reconstructs by calling the op's own method with a payload that carries only
+     `orderId`: **`Order.settle.waitFor({ orderId })`** (or `.peek({ orderId })`). This works
+     because `id` ignores every other payload field — `resolveId` runs `id(payload)` and reads
+     only `p.orderId`, so the rest of the `settle` payload is irrelevant to the execId
+     (`actor.ts:1380-1382`). The webhook does NOT need to reconstruct the full payload.
+   - **Do NOT** build the execId via `entityIdCodec` + `makeExecId`: `entityIdCodec`
+     (`entity-id-codec.ts:38`) encodes an entityId TUPLE joined by `:`, not the
+     `entityId\x00tag\x00primaryKey` execId format; `makeExecId` (`receipt.ts:14`) ONLY brands
+     a string and joins nothing. Neither produces the execId format — that is the per-op
+     `execId` closure alone (`actor.ts:1383-1385`). The fallback, if a raw string is ever
+     needed, is to format `\`${orderId}\x00settle\x00${orderId}\`` directly and
+     `makeExecId(...)`-brand it — but the supported path is `Order.settle.waitFor({ orderId })`.
+   - **Round-trip assertion (G3/G8):** assert the action-side `Order.settle.executionId(fullPayload)`
+     equals the webhook-side `Order.settle.executionId({ orderId })` (and equals the manually
+     formatted string), proving the `id`-ignores-the-rest property holds.
+
+   Terminal replay is a no-op (encore dedup — a terminal persisted reply returns immediately,
+   `actor.ts:574-576`), preserving `paidAt` byte-identical (`order.ts:62-71`, idempotency
+   contract `c8c4abd`). (Both cross-reviews mustFix.)
+
+5. **Status-set reconciliation: actor State is the sole authority for the two NEW states
+   (`cancelled`, `refunded`); the bucket schema is widened ONLY where a transition must be
+   durable.** The bucket `RegistrationOrder.status` is today `['pending','paid','failed','expired']`
+   (`order.ts:56`). The actor adds `cancelled` (≈ `failed`, operator/abandon) and `refunded`
+   (genuinely new). **Decision:** widen the bucket literal to
+   `['pending','paid','failed','expired','cancelled','refunded']` (superset, additive) with a
+   read-boundary tolerance so legacy paid orders still decode — this is the published-doc
+   backfill hazard from MEMORY (`cms-published-doc-backfill-hazard.md`): the widen is on a
+   **closed `Schema.Literals`**, and any read that pattern-matches status must handle the two
+   new arms. `failed` and `cancelled` stay **distinct** (`failed` = Stripe async-payment-failed;
+   `cancelled` = operator/abandon). (cross-review-A mustFix #6, cross-review-B gap.)
+
+6. **The Order WRAPS the freeze; the action keeps the synchronous URL handoff.** Move NOTHING
+   that must be synchronous into an async handler. The action computes the frozen
+   `amount`/`receiptEmail` under the shared `now` (Decision 6, `registration-action.ts:249-258`),
+   calls `createCheckoutSession` + `persistOrder` synchronously, redirects (group) / mails
+   (perRegistrant), and `send`s the durable Order op. (Resolves PLAN B risk 6 + cross-review-A
+   mustFix #4 without breaking the redirect.)
+
+7. **`async_payment_failed` is NOT regressed.** The webhook already flips to `failed`
+   (`api.stripe-webhook.ts:107-112` `markOrderFailed`). The new actor-resolution path resolves
+   the op to a Failure (→ State `failed`) ADDITIVELY, preserving the existing bucket flip.
+   (Both cross-reviews mustFix.)
+
+8. **Everything is gated `Env.database` Some**, mirroring the bucket/stripe None-gate
+   (`env.server.ts:98-175`). DB-less deploys keep working exactly as today (bucket-only
+   webhook flip, no Order entity). (PLAN A G2/G6/G8/G9, retained.)
+
+---
+
+## 3. Dependency / version facts (verified)
+
+- GYC pins `effect@4.0.0-beta.60` + `@effect/platform-bun@4.0.0-beta.60` + `overrides.effect`
+  (`package.json:38,28,73-75`).
+- encore HEAD `package.json`: `effect@4.0.0-beta.75`, `@effect/sql-sqlite-bun@4.0.0-beta.75`,
+  peerDep `effect >=4.0.0-beta.66`.
+- `@effect/sql` ships **inside** `effect` under `effect/unstable/{sql,cluster}` (confirmed —
+  encore imports `effect/unstable/cluster` and `effect/unstable/sql`; `send-and-await.test.ts:5`
+  imports `MessageStorage, Runners, Sharding, ShardingConfig, RunnerStorage, RunnerHealth` from
+  `effect/unstable/cluster`). So GYC adds only the **sqlite-bun driver**, NOT a separate
+  `@effect/sql`/`@effect/cluster` dep. (cross-review-A correctly faults PLAN B G0 for adding
+  `@effect/sql` separately.)
+  - **Stale-peerDep caveat (G0 gate):** encore's `package.json` lists `@effect/cluster`,
+    `@effect/rpc`, `@effect/sql`, `@effect/workflow` as peerDeps (with dev pins), but `src`
+    actually imports them from `effect/unstable/*` (the versions bundled into `effect`). Those
+    peerDeps are **stale/unused for the unstable paths** — GYC must NOT add them. `bun install`
+    may surface an `EBADPEER`-style note for these unused peers; the G0 gate-green check should
+    **tolerate/expect** those stale-peer notices and must still resolve the genuinely-required
+    peer (`effect >=beta.66`, satisfied by beta.75).
+- distilled refund operation is `PostRefunds` (`node_modules/@distilled.cloud/stripe/lib/operations/PostRefunds.*`),
+  imported from `@distilled.cloud/stripe/Operations` like `PostCheckoutSessions`
+  (`payment.server.ts:18`). **Caveat (G7 risk):** `PostRefunds` refunds a `payment_intent` or
+  `charge`, but the bucket order stores only `sessionId` (`order.ts:50`) — the refund op must
+  resolve the PaymentIntent from the session first (see G7).
+
+---
+
+## 4. Commits
+
+> Branch: stack ON TOP of `feat/registrar` (current branch) as a child branch
+> `feat/order-workflow`. Every commit: `bun run typecheck` (= `react-router typegen && tsgo
+> --noEmit`) + `bun run lint` (oxlint) + `bun test` green. Each commit compiles and passes gate
+> in isolation. High-blast-radius commits (G0, G6) are sub-committable per the global
+> sub-commit guidance if the diff balloons.
+
+---
+
+### G0 — `build(deps): bump effect to beta.75 + add encore + sqlite-bun driver`
+
+**Files:** `package.json`, `bun.lock`, plus any existing-app fallout files surfaced by the
+post-bump typecheck.
+
+**Scope:**
+- Bump `effect` `4.0.0-beta.60 → 4.0.0-beta.75`, `@effect/platform-bun` `4.0.0-beta.60 →
+  4.0.0-beta.75`, and the `overrides.effect` pin (`package.json:73-75`) — all in lockstep
+  (these betas are co-released; the `overrides` pin makes the app's effect the single instance
+  encore peers against).
+- Add `effect-encore` at the published version that ships the per-op `sendAndAwait`/`waitFor`
+  methods on `OperationHandle` (`actor.ts:586,622`) + `fromSqlClient` + `ActorSenderLayer` (HEAD
+  is `0.12.8`; confirm the exact published tag — see Open Question 1).
+- Add `@effect/sql-sqlite-bun@4.0.0-beta.75` (encore's tested SQL driver,
+  `send-and-await`/`sql-storage` tests; the GYC MessageStorage backing).
+- Add the DB env knob to `.env.example` (`DATABASE_URL` or `DATABASE_PATH` — a sqlite file path
+  or `:memory:`).
+- Run `bun install`; then `bun run typecheck` to surface beta.60→beta.75 API drift in existing
+  files (Schema, Layer, Config, `effect/unstable/*` import paths). **Fix all fallout in THIS
+  commit** so the bump is atomic and green (the No-Bail-Outs rule — no `any`, no commented-out
+  code). Likely hot spots to check: `Schema.TaggedErrorClass` usages (`payment.server.ts:85,108`),
+  `Config` gates (`env.server.ts`), `Layer.provideMerge` (`runtime.ts:109-114`),
+  `ManagedRuntime.make` (`runtime.ts:120`).
+
+**Gate green:** `bun install` resolves the **required** peer (encore's `effect >=beta.66` is
+satisfied by beta.75); the only acceptable `EBADPEER` notices are encore's **stale/unused**
+`@effect/cluster|rpc|sql|workflow` peerDeps (see §3 — encore imports those from
+`effect/unstable/*`, so the peerDep is informational and does NOT require GYC to add the dep);
+any OTHER `EBADPEER` is a real failure to fix. `bun run typecheck` passes on the existing suite
+with the bumped effect; `bun run lint` clean; `bun test` green (no source logic changed beyond
+drift fixes).
+
+**Deps:** none EXCEPT the pre-G0 BLOCKER below (DB target / Open Question 2 must be resolved
+first — it determines G2's adapter and the whole cross-runtime sharing story). encore must be
+published — out-of-repo prerequisite; HEAD already has the required surface.
+
+> **Pre-G0 BLOCKER — resolve Open Question 2 BEFORE this commit.** Because the runner
+> (`ServerLive`) and the senders (`AppRuntime`) are two separate layer graphs that can ONLY
+> share durable state through a backing DB, `':memory:'` is **impossible in production** (two
+> disjoint in-memory DBs — see §1 two-runtime topology). The choice is **sqlite FILE on a
+> persistent volume** vs **`@effect/sql-pg` + Railway Postgres**, and it gates the whole
+> architecture (not just G2's adapter line). Decide first. If Railway can't mount a volume, the
+> plan flips to `@effect/sql-pg`: add that dep here in G0 (with a connection-pool note),
+> localized to `Order.SqlClientLive` (G2) but architecture-gating.
+
+---
+
+### G1 — `feat(order): optional Database (DATABASE_URL) env gate`
+
+**Files:** `app/lib/env.server.ts`, `app/lib/env.server.test.ts` (if it asserts the `Service`
+shape).
+
+**Scope:**
+- Add a `DatabaseConfig` `Config.Config<Option.Option<DatabaseConfig>>` following the EXACT
+  blank-collapse None-gate the bucket/stripe configs use (`env.server.ts:98-175`): a
+  `Config.withDefault('')` read trimmed, collapsing to `Option.none()` unless non-blank. Do
+  NOT use `Config.option` (the documented rationale at `env.server.ts:131-140`: a present-but-
+  empty env var is a successful empty parse, not missing data).
+- Shape: `{ readonly url: Redacted.Redacted<string> }` (redacted so the connection string never
+  logs, mirroring `bucket.accessKeyId`). For a sqlite file path the redaction is harmless; for a
+  future Postgres URL it matters.
+- Add `database: Option.Option<DatabaseConfig>` to the `Env.Service` shape — note the env
+  service is a `Context.Service` class (`env.server.ts:177`, NOT `Effect.Service`) — and thread
+  it through BOTH the production and dev branches of `layer` (`env.server.ts:207-219`), exactly
+  as `stripe`/`bucket` are threaded. `defaultLayer` unchanged (`env.server.ts:223`).
+
+**Decision:** Database is optional everywhere — the app boots without a DB; the Order entity is
+gated off it and the rest (CMS, forms, the existing bucket-backed order persist + webhook) is
+untouched.
+
+**Gate green:** `bun run typecheck` (the `Env.Service` shape change propagates cleanly — no
+consumer requires `database` yet); `bun test` green incl. the env config test; lint clean.
+
+**Deps:** G0.
+
+---
+
+### G2 — `feat(order): SQL MessageStorage layer over DATABASE_URL (no entity yet)`
+
+**Files:** NEW `app/lib/order/storage.server.ts`, NEW `app/lib/order/storage.server.test.ts`.
+
+**Scope:**
+- A house-pattern module (module-level `export const layer`, mirroring `storage.server.ts:137`
+  / opencode convention) exposing:
+  - `Order.SqlClientLive`: `Layer<SqlClient.SqlClient, never, Env.Service>` gated on
+    `Env.database` Some. None ⇒ a `DatabaseUnconfigured` tagged-error fail-to-build (mirroring
+    `StorageUnconfigured`, `storage.server.ts:71-74,161-168`). Uses `SqliteClient.layer({
+    filename })` from `@effect/sql-sqlite-bun` keyed off `DATABASE_URL` — encore's tested
+    adapter (`effect-encore/test/sql-storage.test.ts`; `send-and-await` uses memory, sqlite is
+    the file analog). **In production `DATABASE_URL` MUST be a FILE path on a persistent volume,
+    never `':memory:'`** — `':memory:'` gives `ServerLive` (runner) and `AppRuntime` (sender)
+    two disjoint DBs and breaks the cross-runtime loop (§1 two-runtime topology / Risk 2,
+    pre-G0 BLOCKER). `':memory:'` is for single-graph tests only. If the pre-G0 decision flips
+    to Postgres, swap this for `@effect/sql-pg` (`PgClient.layer`) — localized here. NOT a
+    network DB by default (Railway mounts a volume for the sqlite file).
+  - `Order.MessageStorageLive` = encore's `fromSqlClient()`
+    (`effect-encore/src/index.ts:70`, `src/storage.ts:142-145`, returns `Layer<MessageStorage |
+    EncoreMessageStorage, never, SqlClient.SqlClient>` with `ShardingConfig.layerDefaults`
+    already provided internally) composed onto `SqlClientLive`, yielding `Layer<MessageStorage |
+    EncoreMessageStorage, never, Env.Service>`. **This is the SINGLE place the DB dependency is
+    stood up** (it backs the runner in `ServerLive`).
+  - `Order.ShardingConfigLive` = ONE shared `ShardingConfig.layer({...})` definition (the SAME
+    shard count both runtimes use). Export it from this module so the runner (G6, `ServerLive`)
+    AND the sender (G6, `AppRuntime`) build from the identical config — the cross-runtime
+    shard-parity invariant (§1). NOTE: `fromSqlClient` swallows its own
+    `ShardingConfig.layerDefaults` and does NOT re-export `ShardingConfig`
+    (`src/storage.ts:145`), so the **sender side cannot borrow the storage's config** — it must
+    be provided `Order.ShardingConfigLive` independently (G6). If a future need arises to make
+    the runner storage use the shared (non-default) config too, swap `fromSqlClient` for
+    `fromSqlClientWithShardingConfig` (`src/storage.ts:108`, leaves `ShardingConfig` open) and
+    provide `Order.ShardingConfigLive`.
+- NEW `app/lib/order/storage.test-helper.ts` (or inline in the test): `Order.layerTest` =
+  `fromSqlClient().pipe(Layer.provide(SqliteClient.layer({ filename: ':memory:' })))` — the
+  in-memory backing for the entity tests in G3+.
+- NO hand-written DDL: encore's `SqlMessageStorage` owns `cluster_messages` / `cluster_replies`
+  creation (`effect-encore/src/storage.ts:108-141`; table names prefixed `cluster`).
+
+**Gate green:** `bun run typecheck` (composes encore's exported layers with no requirement leak
+beyond `Env`); `storage.server.test.ts` boots `Order.layerTest` against `:memory:` and asserts
+(a) `cluster_messages`/`cluster_replies` exist after boot, (b) a raw
+`EncoreMessageStorage.deleteEnvelope` (or a `saveRequest`→`repliesFor`) round-trips — porting
+`effect-encore/test/sql-storage.test.ts` into GYC's harness, **proving the encore SQL adapter
+works inside GYC's effect/bun toolchain (the core version-skew de-risk)**; lint clean.
+
+**Deps:** G1.
+
+---
+
+### G3 — `feat(order): in-process Sharding runner + durable probe entity round-trips end-to-end`
+
+**Files:** NEW `app/lib/order/runner.server.ts`, NEW `app/lib/order/runner.test.ts`
+(test-only probe), NEW `app/lib/order/cross-runtime.test.ts` (the two-graph shared-file test).
+
+**Scope:**
+- `app/lib/order/runner.server.ts`: a `Order.runnerLayer(messageStorage)` that composes the
+  **single-process Sharding runner** over a given MessageStorage, per the verified template
+  `effect-encore/test/send-and-await.test.ts:63-68`:
+  `Sharding.layer ⊕ Runners.layerNoop ⊕ <MessageStorage> ⊕ RunnerStorage.layerMemory ⊕
+  RunnerHealth.layerNoop ⊕ ShardingConfig.layer({...})`. Production wires
+  `Order.MessageStorageLive` (G2) in; tests wire `Order.layerTest`. **The runner's
+  `ShardingConfig` MUST be `Order.ShardingConfigLive` (G2)** — the same instance the sender
+  uses — so the shard-parity invariant holds across runtimes (§1). Also re-export the
+  `ActorSenderLayer` bundle (`effect-encore/src/actor-sender.ts:64`), provided
+  `Order.MessageStorageLive` + `Order.ShardingConfigLive`, for the request/webhook sender side
+  — both runner and sender over the SAME storage AND the SAME shard config.
+- `app/lib/order/runner.test.ts` (throwaway probe — deleted/folded when G8 lands the real
+  lifecycle test, OR kept as a permanent SQL-storage smoke test; lean keep-as-smoke): define a
+  minimal `Actor.fromEntity('OrderProbe', { Ping: { payload, success, persisted: true, id } })`
+  with `id: (p) => p.key` (a pure-fn-of-one-field id, mirroring Decision 4) + `Actor.toLayer`
+  handler, wire the FULL runner over `Order.layerTest` SQL MessageStorage (NOT `TestRunner.layer`
+  — the point is to prove the REAL SQL path), and assert:
+  1. `Ping.sendAndAwait({...}, { timeout })` — the per-op METHOD (`actor.ts:586`), called as
+     `OrderProbe.Ping.sendAndAwait` — reaches `Success` with the row landing in
+     `cluster_messages`/`cluster_replies` — the durability proof that the runner consumes the
+     SQL mailbox and writes the reply;
+  2. **the webhook-shaped ExecId path (Decision 4):** assert
+     `Ping.executionId({ key, extra: 'a' })` === `Ping.executionId({ key })` === the manually
+     formatted `makeExecId(\`${key}\x00Ping\x00${key}\`)` — proving `id` ignores the rest of the
+     payload — then `Ping.waitFor({ key })` (the orderId-only payload the webhook holds) observes
+     the reply terminal through the SAME SQL MessageStorage with no bespoke adapter. Do NOT use
+     `entityIdCodec`+`makeExecId` to build the execId — see Decision 4.
+- **`app/lib/order/cross-runtime.test.ts` (the BLOCKER test — cross-review mustFix #1):** the
+  ONLY test that exercises the real two-runtime topology. Build BOTH layer graphs over **ONE
+  shared sqlite FILE** (`SqliteClient.layer({ filename: <tmpfile> })`, NOT `':memory:'`):
+  - a **runner graph** = `Order.runnerLayer(Order.MessageStorageLive)` + the probe
+    `Actor.toLayer` handler (the `ServerLive` analog);
+  - a **sender graph** = `ActorSenderLayer.layer` provided `Order.MessageStorageLive` +
+    `Order.ShardingConfigLive` over the SAME file (the `AppRuntime` analog), built as a
+    SEPARATE `ManagedRuntime`/layer build (distinct `SqlClient`).
+  Assert: a `Ping.send({ key })` from the **sender graph** is consumed by the **runner graph**'s
+  handler, and a `Ping.peek({ key })` from a **second independent sender build** over the same
+  file sees it terminal. Then assert the **negative control**: repeat with `':memory:'` on each
+  graph and show the send is NOT observed cross-graph (the two-disjoint-DBs failure mode — kept
+  as a guard so a future `':memory:'` regression is caught). This is the test the G8/G9
+  single-graph `':memory:'` tests CANNOT provide — it proves the production seam.
+
+**Deliverable: CONFIDENCE.** The new DB dependency + the SQL-backed in-process runner + the
+sender/ExecId resolution + **the cross-runtime shared-file seam** all work in GYC before any
+Order semantics exist. This commit ESTABLISHES the production runner composition (which encore
+only ships in tests) — exactly why it is front-loaded (PLAN A G3/G4 de-risk, sharpened with the
+now-verified runner wiring + the two-runtime topology).
+
+**Gate green:** `bun test` runs the probe green — a persisted entity `sendAndAwait` reaches
+Success backed by GYC's SQL MessageStorage, the ExecId round-trip holds
+(`executionId({key,extra})===executionId({key})`), AND the **cross-runtime shared-file test**
+proves a sender-graph `send` is consumed by the runner-graph handler and a second sender's
+`peek` sees it terminal (with the `':memory:'` negative control failing as expected); typecheck
++ lint clean.
+
+**Deps:** G2.
+
+---
+
+### G4 — `feat(order): Order entity schema + state machine (no Stripe calls)`
+
+**Files:** NEW `app/lib/order/order.actor.ts` (definition + transition table only),
+NEW `app/lib/order/order.actor.test.ts`.
+
+**Scope:**
+- `Actor.fromEntity('Order', {...})` (`effect-encore/src/actor.ts` `fromEntity`). Ops:
+  - **`arm`** (the durable lifecycle anchor, `persisted: true`): payload = the frozen order
+    linkage `{ orderId, mode, amount, currency, receiptEmail, sessionId, registrantIds,
+    deadline? }`. `id: (p) => p.orderId` — returns the **string** `orderId`, so `resolveId`
+    sets `entityId === primaryKey === orderId` (`actor.ts:124-125`) and `id` IGNORES every
+    other payload field (Decision 4 — the webhook, which has only `metadata.orderId`,
+    resolves the ExecId by calling the op with `{ orderId }`). Records the entity into
+    existence at `pending`.
+  - **`settle`** (`persisted: true`): the op the webhook resolves on
+    `checkout.session.completed`. `id: (p) => p.orderId` (string, same pure-fn-of-`orderId`
+    rule as `arm`) — so the webhook resolves it via `Order.settle.waitFor({ orderId })` /
+    `.peek({ orderId })` (Decision 4). Its success drives `pending → paid`.
+  - **`cancel`** / **`refund`** / **`expire`** (`persisted: true`): `id: (p) => p.orderId`
+    (string), keyed on `orderId`.
+- Persisted state schema `OrderState`: `{ status:
+  Schema.Literals(['pending','paid','cancelled','refunded','expired']), sessionId, paidAt? }`
+  (NOTE: the actor state literal need not carry `failed` — `failed` is a bucket-only terminal
+  from `async_payment_failed`; the actor maps an async-failed settlement to a Failure reply,
+  see G6). Reuse the brands `Cents`/`CurrencyCode`/`BillingMode`/`ListItemId`/`IsoDate`
+  (`order.ts:1-6`, `pricing.ts`) — derive-don't-sync, do NOT redeclare.
+- **No handler bodies that touch Stripe yet.** This commit ships the actor DEFINITION + a pure
+  **transition-table predicate** (which `status → status` is legal: `pending→{paid,cancelled,
+  expired,failed}`, `paid→refunded`; everything else illegal/no-op), unit-tested in isolation,
+  WITHOUT a runtime.
+- **State-vs-bucket contract:** document that every op handler (G6/G7) writes the **bucket
+  transition** (the authority, via `Submissions` `flipStatus`, `submissions.server.ts:346`) AND
+  the actor State atomically within the handler; the actor State is a derived cache (Decision 1).
+
+**Gate green:** `bun run typecheck` (the Order actor compiles against bumped encore —
+`Actor.fromEntity` types resolve); `order.actor.test.ts` unit-tests the transition table
+(legal/illegal) + a schema round-trip (encode→JSON→decode) WITHOUT a runtime; lint clean.
+
+**Deps:** G3.
+
+---
+
+### G5 — `feat(order): widen bucket order status + markOrderCancelled/Refunded/Expired transitions`
+
+**Files:** `app/lib/forms/order.ts`, `app/lib/forms/submissions.server.ts`,
+`app/lib/forms/order.test.ts`, `app/lib/forms/submissions.server.test.ts`. Plus any read site
+that pattern-matches `RegistrationOrder.status` (grep `status` over `app/` admin/read paths —
+the backfill-hazard sweep).
+
+**Scope:**
+- Widen `RegistrationOrder.status` literal from `['pending','paid','failed','expired']` to
+  `['pending','paid','failed','expired','cancelled','refunded']` (`order.ts:56`) — additive
+  superset (Decision 5). Closed `Schema.Literals`, so a present-but-unknown token still fails
+  decode; legacy paid/failed/expired orders decode unchanged.
+- Add `markOrderCancelled` / `markOrderRefunded` / `markOrderExpired` transition helpers to
+  `Submissions`, each built on the existing `flipStatus` guard discipline
+  (`submissions.server.ts:346-465`, the same never-downgrade-a-terminal-state guard as
+  `markOrderPaid`/`markOrderFailed`). `markOrderExpired`/`markOrderCancelled`: only from
+  `pending`. `markOrderRefunded`: only from `paid`. Mirror `markOrderPaid`'s idempotency (a
+  re-flip to the same terminal is a no-op).
+- **Backfill-hazard sweep (MEMORY `cms-published-doc-backfill-hazard.md`):** find every read
+  that switches on `status` (admin order views, any receipt/summary read on BOTH public and
+  `/admin` draft reads) and ensure the two new arms are handled, not dropped. Cite each touched
+  read in the commit body.
+
+**Gate green:** `bun run typecheck`; `order.test.ts` round-trips an order at each new status;
+`submissions.server.test.ts` covers each new transition + its guard (illegal source rejected,
+terminal re-flip is a no-op); lint + full suite green.
+
+**Deps:** G4. (Independent of G3's runtime — can land in parallel conceptually, but ordered
+after G4 so the actor's status set and the bucket's are reconciled in one reviewable arc.)
+
+---
+
+### G6 — `feat(order): arm + settle handlers — wire the Order runner into server.ts`
+
+**Files:** `app/lib/order/order.actor.ts` (handler layer), `app/lib/order/runner.server.ts`
+(register handlers), `server.ts`, `app/lib/order/order.actor.test.ts`.
+
+**Scope:**
+- **`arm` handler:** record the entity at `pending` and persist/refresh the actor State from the
+  frozen linkage. Re-assert (read-back) the bucket order exists at `pending` via
+  `Submissions.getOrder` (`submissions.server.ts:143`) — the bucket is the authority; `arm`
+  does NOT re-create the session (the action already did, G7). Idempotent: a duplicate `arm`
+  send for the same `orderId` dedups (encore primaryKey dedup, `actor.ts:574-576`).
+- **`settle` handler:** the post-payment continuation. On success ⇒ `pending → paid`: call
+  `Submissions.markOrderPaid` (`submissions.server.ts:382`, the byte-identical `paidAt` freeze,
+  `order.ts:62-71`) AND set State `paid`. On the async-payment-failed path the webhook resolves
+  `settle` to a Failure ⇒ the handler/continuation flips bucket `failed`
+  (`Submissions.markOrderFailed`) — **preserving the existing webhook behavior, no regression**
+  (Decision 7). Read the FROZEN amount/receiptEmail back from the bucket — NEVER re-derive
+  (Decision 6 freeze discipline).
+- **`server.ts` (the `ServerLive` / runner side):** add the Order runner
+  (`Order.runnerLayer(Order.MessageStorageLive)` provided `Order.ShardingConfigLive` + the
+  registered `Actor.toLayer` handler layer) to the **long-lived `ServerLive`** composition
+  (`server.ts:263-269`, the `HttpRouter.serve` layer that is `Layer.launch`-ed at `:269`,
+  giving the runner's poll fiber a process-lifetime supervisor) — NOT the request-handler
+  `makeAppLayer` graph (consumed once into the `AppRuntime` singleton, `runtime.ts:120`, never
+  `Layer.launch`-ed). Gate the whole Order runner on `Env.database` Some so a DB-less deploy is
+  unaffected and `Layer.launch(ServerLive)` still exits non-zero on missing REQUIRED config (the
+  `StartupCheck` contract, `server.ts:249-252`). (cross-review-A mustFix #2 / cross-review-B
+  mustFix #1.)
+- **`runtime.ts` (the `AppRuntime` / sender side):** thread the **sender**
+  (`ActorSenderLayer.layer`, `src/actor-sender.ts:42-46`) into `makeAppLayer` so routes/webhook
+  can `send`/`peek`/`waitFor` — gated `Env.database` Some, exactly as `Storage`/`Payment` are
+  optional in `makeAppLayer` (`runtime.ts:103-114`). **`ActorSenderLayer.layer` requires
+  `MessageStorage | ShardingConfig` and provides NEITHER** (`src/actor-sender.ts:42-46`); and
+  `fromSqlClient` consumes its own `ShardingConfig.layerDefaults` internally and does NOT
+  re-export it (`src/storage.ts:145`) — so the sender side MUST be provided BOTH
+  `Order.MessageStorageLive` (its `SqlClient` build, over the SAME shared DB file as the runner)
+  **AND `Order.ShardingConfigLive` explicitly** (the SAME shared shard config the runner uses).
+  This is the sender-requirement-leak fix (cross-review mustFix).
+  - **Cross-runtime shard-parity invariant (gate-green check):** the sender's `ShardingConfig`
+    (in `AppRuntime`) and the runner's `ShardingConfig` (in `ServerLive`) MUST be the identical
+    `Order.ShardingConfigLive` (same shard count) — `ActorAddressResolverLayer.fromConfig`
+    routes by shard count (`src/actor-address-resolver.ts`), so a divergent count makes the
+    sender write a shard the runner never polls. Both sides import the one `Order.ShardingConfigLive`.
+  - Add the Order sender handle to `AppServices` (`runtime.ts:29-39`) and any new error to
+    `AppError` (`runtime.ts:40-53`).
+
+**Gate green:** `bun run typecheck` (`AppServices`/`makeAppLayer` + `ServerLive` extension
+typecheck, the runner composes; the sender layer has NO unsatisfied `ShardingConfig`/`MessageStorage`
+requirement; `bun run build` succeeds); a test asserts the sender's and runner's
+`ShardingConfig` are the same instance/shard-count (shard-parity); `order.actor.test.ts` drives
+`arm` then resolves `settle` to Success against `Order.layerTest` + a fake `Submissions` —
+asserts the bucket order is marked paid with a frozen `paidAt` and State is `paid`; resolving
+`settle` to Failure marks bucket `failed`; lint + existing tests green. DB-less build still
+launches.
+
+**Deps:** G5.
+
+---
+
+### G7 — `refactor(registration): action sends Order.arm; refund op + cancel/expire handlers`
+
+**Files:** `app/lib/forms/registration-action.ts`, `app/lib/order/order.actor.ts`,
+`app/lib/payment.server.ts`, `app/lib/forms/registration-action.test.ts`,
+`app/lib/payment.server.test.ts`, `app/lib/order/order.actor.test.ts`.
+
+> This is high-blast-radius; sub-commit (G7.1 action wiring / G7.2 refund op / G7.3
+> cancel+expire) per the global sub-commit guidance if the diff balloons. Each sub-commit
+> compiles + passes gate.
+
+**Scope:**
+- **`registration-action.ts` (G7.1):** after the existing synchronous `createCheckoutSession` +
+  `persistOrder` (the checkout block, `registration-action.ts:249-340` group + perRegistrant
+  arms — UNCHANGED, the freeze + redirect/mail stays), **`send` the Order `arm` op** for each
+  minted order (group: ONE keyed `requestFingerprint`, `registration-action.ts:168`;
+  perRegistrant: N keyed `<fingerprint>:<index>`, `:177`). The action keeps the
+  `groupSessionUrl` redirect (`:242`) / perRegistrant mail fan-out — `arm` is durable
+  fire-and-forget, it does NOT block the redirect. Idempotency STRENGTHENS: a verbatim retry
+  re-`send`s `arm` with the same `orderId` ⇒ encore dedups (no second entity), complementing the
+  existing bucket-overwrite idempotency (`registration-action.ts` persist). Gate the `arm` send
+  on `Env.database` Some (DB-less ⇒ skip the send, the bucket path is unchanged).
+- **`payment.server.ts` (G7.2):** add a third op `createRefund` (mirror `createCheckoutSession`
+  structure, `payment.server.ts:211-306`): import `PostRefunds` from
+  `@distilled.cloud/stripe/Operations`, yield-first captured op handle, `idempotencyKey` on the
+  HEADER (`payment.server.ts:251`), fail `PaymentDisabled` when `Env.stripe` None
+  (`:202-205`), squash the SDK `Cause` into one `PaymentError` (`:255-268`). **Caveat:**
+  `PostRefunds` refunds a `payment_intent`/`charge`, not a session — so `createRefund` takes a
+  `paymentIntentId` (or resolves it from `sessionId` via a session-retrieve op first; the
+  simplest correct path is to persist the PaymentIntent id on the order at `settle` time from the
+  webhook's session object — note as a sub-task). Extend `testLayer` (`payment.server.ts:345`) +
+  a `CreateRefundCall` capture so refund wiring is network-free testable.
+- **`refund` handler (G7.2):** guard current State `paid` (refunding a pending/cancelled order
+  is a typed `RefundNotAllowed` domain error — make-impossible-states); yield
+  `Payment.createRefund` against the FROZEN `RegistrationOrder.amount` read back via
+  `Submissions.getOrder` (`submissions.server.ts:143` — never re-derive); set State `refunded` +
+  `Submissions.markOrderRefunded` (G5).
+- **`cancel` + `expire` handlers (G7.3):** `cancel` ⇒ `pending → cancelled`
+  (`Submissions.markOrderCancelled` + State; no Stripe call needed beyond optionally expiring the
+  Checkout session). `expire` ⇒ `pending → expired` (`Submissions.markOrderExpired` + State),
+  reading the order's frozen `deadline` (`order.ts:61`). Each enforces the G4 transition table
+  (illegal transitions are typed no-ops, the `flipStatus` never-downgrade discipline).
+- **Webhook 200-ignore for `charge.refunded` (G7.2):** narrow `charge.refunded` to a 200-ignore
+  in the webhook type-narrow (`api.stripe-webhook.ts:88-89`) so a Stripe-side refund doesn't
+  400. (refund is operator-initiated, not Stripe-push — no new event handler needed.)
+
+**Gate green:** `bun run typecheck`; the existing registration-action checkout test now also
+asserts each minted order `send`s `arm` (group one, perRegistrant N, zero-amount none, verbatim
+retry dedups to no second entity) over `Order.layerTest` + `Payment.testLayer`;
+`order.actor.test.ts` drives a paid Order → `refund` (asserts `createRefund` called with the
+frozen amount, State `refunded`, bucket `refunded`) and `refund`-while-pending →
+`RefundNotAllowed`; `cancel`/`expire` legal+illegal transitions; `payment.server.test.ts` covers
+`createRefund` disabled-gate + idempotency-key; lint + full suite green.
+
+**Deps:** G6.
+
+---
+
+### G8 — `feat(order): webhook resolves the settle ExecId via SQL MessageStorage`
+
+**Files:** `app/routes/api.stripe-webhook.ts`, `app/routes/api.stripe-webhook` test (extend the
+existing `app/lib/forms/webhook.server.test.ts`).
+
+**Scope:**
+- Keep the verify → type-narrow → decode → `payment_status==='paid'` → amount-check spine
+  UNCHANGED (`api.stripe-webhook.ts:78-122` — the verified-amount guard at `:122` is the freeze
+  check and STAYS, returning 400 on mismatch with the order left pending).
+- On a matched paid `checkout.session.completed`, **in addition to** the existing
+  `submissions.markOrderPaid` flip (`:125`), drive the Order `settle` op through the SAME SQL
+  MessageStorage. The webhook holds only `metadata.orderId` (`:105`), and `settle`'s `id` is a
+  pure fn of `orderId` (G4), so the webhook resolves the op WITHOUT reconstructing the full
+  payload: **`send` the `settle` op with `{ orderId, ...sessionFields }` then
+  `Order.settle.waitFor({ orderId })`** (or `sendAndAwait({ orderId, ... }, { timeout })`) — the
+  runner consumes the `settle` send, runs the `pending → paid` continuation + State `paid`, and
+  writes the reply; `waitFor`/`peek` (keyed by the `{ orderId }`-derived ExecId,
+  `actor.ts:1383-1385`) observe it terminal Success. **Do NOT build the ExecId via
+  `entityIdCodec` + `makeExecId`** — `entityIdCodec` encodes the entityId TUPLE (`:`-joined) and
+  `makeExecId` only brands a string; neither produces the `entityId\x00tag\x00primaryKey` execId
+  format (Decision 4, `entity-id-codec.ts:38`, `receipt.ts:14`, `actor.ts:1383-1385`). The
+  op-method path (`waitFor`/`peek`/`sendAndAwait` on `Order.settle`) IS the execId reconstruction
+  — it runs the same per-op `execId` closure internally. The bucket `markOrderPaid` remains the
+  receipt authority; the actor mirrors it.
+- On `checkout.session.async_payment_failed` (`:107-112`): keep the existing
+  `markOrderFailed`, AND resolve `settle` to a Failure (or `send` `Order.cancel`) → State/bucket
+  `failed`. **No regression** (Decision 7, cross-review mustFix).
+- Idempotency: a replayed `checkout.session.completed` re-resolving an already-terminal ExecId
+  is a no-op (encore dedup, `actor.ts:574-576`), `paidAt` byte-identical (`order.ts:62-71`,
+  `c8c4abd`).
+- Gate the actor-resolution on `Env.database` Some — DB-less ⇒ the webhook degrades to the
+  existing bucket-only flip (backward compatible). Map any new failure into the route's
+  `catchTags` (`api.stripe-webhook.ts:128-136`) preserving the 200/400/503 contract Stripe reads.
+
+**Gate green:** `bun run typecheck`; the webhook test drives the full loop against
+`Order.layerTest` + the in-process runner: `arm` an order → forge a signed
+`checkout.session.completed` with matching amount → assert the `settle` op resolves Success, the
+Order State `paid`, the bucket order `paid` with a frozen `paidAt`, AND a verbatim REPLAY POST
+is a 200 no-op leaving `paidAt` byte-identical; an amount-mismatch POST leaves the op unresolved
++ order pending + 400; the no-DB path still 200s on the bucket flip; an `async_payment_failed`
+flips `failed` on both. **ExecId round-trip assertion (Decision 4):** assert the action-side
+`Order.settle.executionId(armPayload)` === the webhook-side `Order.settle.executionId({ orderId })`
+=== the manually formatted `makeExecId(\`${orderId}\x00settle\x00${orderId}\`)`, so the webhook's
+`{ orderId }`-only resolution lands on the exact ExecId the runner replied to. Lint + full suite
+green.
+
+**Deps:** G7.
+
+---
+
+### G9 — `feat(order): deadline-sweep fiber + durable-lifecycle integration capstone`
+
+**Files:** NEW `app/lib/order/sweep.server.ts`, `server.ts`, NEW
+`app/lib/order/lifecycle.test.ts`, NEW `app/lib/order/sweep.server.test.ts`.
+
+**Scope:**
+- **Deadline sweep (`sweep.server.ts`):** an in-process scheduled Effect fiber (no external cron
+  dep — self-contained, mirroring how the app stays self-wired) launched in `ServerLive`
+  (`server.ts:263-269`, the long-lived layer — a sweep needs a process-lifetime fiber, NOT
+  per-request). It lists pending orders past `deadline` (read the bucket orders under
+  `submissions/registration/orders/*.json`, OR `listStateEntityIds` over the Order entity,
+  `effect-encore/src/index.ts:5`) and `send`s `Order.expire` to each (`pending → expired` only;
+  a `paid`/`refunded`/`cancelled` order is untouched — the `expire` handler's State guard,
+  make-impossible-states). Idempotent: re-sweeping an already-expired/paid order is a no-op.
+  Gate on `Env.database` Some. Also expose a manual `/admin`-guarded trigger route
+  (`auth.server.ts` gate) and document the optional external cron hook without committing infra.
+- **Late-payment-on-expired race:** a `checkout.session.completed` arriving AFTER `expire` →
+  `expired` must NOT silently resurrect to `paid` — `expire → expired` is terminal for the op,
+  so a late paid reply on an expired entity is rejected/logged. The product decision (honor vs
+  auto-refund) is an Open Question; the code defaults to reject-and-log, surfacing it.
+- **Lifecycle capstone (`lifecycle.test.ts`)** — PLAN B G7, the strongest single artifact in
+  either source plan. End-to-end over the REAL `Order.MessageStorageLive` (SQLite `:memory:`) +
+  the in-process runner + a network-free `Payment.testLayer`, exercising every edge as one
+  durable narrative: `pending → paid` (arm → webhook resolve), `pending → cancelled` (cancel),
+  `paid → refunded` (refund), `pending → expired` (sweep), AND the ILLEGAL transitions
+  (refund-while-pending, expire-while-paid, cancel-while-paid) all rejected by State guards.
+  Assert the cross-cutting invariants:
+  1. the `settle` ExecId is stable across a webhook REPLAY so `paidAt` is byte-identical
+     (`order.ts:62-71`, `c8c4abd`);
+  2. the frozen amount/receiptEmail are never re-derived by any op (read back from the bucket,
+     compare to the create-time freeze — `registration-action.ts:258`);
+  3. the actor State and the bucket `RegistrationOrder.status` never diverge (every transition
+     writes both within the handler).
+
+**Gate green:** `bun run typecheck` && `bun run build` (`server.ts` composes the sweep fiber);
+`sweep.server.test.ts` seeds two pending (one past-deadline, one future) + one paid past-deadline,
+runs the sweep, asserts ONLY the past-deadline pending one → expired (State + bucket), the others
+untouched, a second sweep is a no-op; `lifecycle.test.ts` covers all 5 states + 3 illegal-
+transition rejections + the 3 invariants against the durable SQLite-backed Order; DB-less build
+still launches; lint + full suite green.
+
+**Deps:** G8.
+
+---
+
+## 5. Divergences from both source plans
+
+| Topic | PLAN A | PLAN B | This plan (and why) |
+|---|---|---|---|
+| **Runner model** | Runner in the request-handler `makeAppLayer` graph (G6) then "must be long-lived" (G9) — self-contradictory | "No runner — `Client.layer.fromConfig`" (false: `Client` unexported; `fromConfig` mailbox doesn't run handlers) | **In-process Sharding runner in the long-lived `Layer.launch`-ed `ServerLive`** (`server.ts:263-269`); the request side (`AppRuntime` singleton, `runtime.ts:120`) is a sender. The two graphs share one sqlite FILE (`cluster_messages`/`cluster_replies` rows), NEVER `':memory:'`. Verified template `send-and-await.test.ts:63-68`. Resolves both cross-reviews' #1/#2 mustFix. |
+| **encore publish dependency** | Assumes a new publish; flags it as prereq | Assumes the unpublished `Client`/`State<A>` reshape (BLOCKED) | **No dependency on the unpublished reshape** — uses shipped `fromSqlClient` + the per-op `sendAndAwait`/`waitFor`/`peek` methods + `ActorSenderLayer`. HEAD `0.12.8` already suffices. Removes the blocker. |
+| **process op shape** | One `process` op creates session + suspends | One `process` op creates session + returns URL + suspends (incoherent for async runner) | **Split:** action creates session synchronously (keeps redirect), then `send`s a durable `arm` op; the webhook resolves a `settle` op. No "handler returns URL before suspend" foot-gun. |
+| **registration-action integration** | Never touched (dual-write hazard, named but unfixed) | `Order.process` dispatch replaces inline checkout | **Action keeps the synchronous checkout** (no redirect regression) and ADDS an `arm` send. Wraps, not replaces. |
+| **`@effect/sql` dep** | Correctly inside `effect/unstable` (no separate dep) | Adds `@effect/sql` separately (wrong vs tree) | **Inside `effect/unstable`** — only the sqlite-bun driver is added. |
+| **Status set** | Actor superset, reconciliation deferred to G5 | Actor-only authority, bucket unchanged | **Widen the bucket** to the superset with a read-boundary backfill sweep; `failed` and `cancelled` stay distinct. |
+| **`async_payment_failed`** | Unhandled (regression) | Resolves to Failure / cancel | **Preserved + additively resolves `settle` to Failure.** |
+| **Capstone test** | Scattered per-commit gates | Single durable-lifecycle narrative (G7) | **Adopted as G9** — strongest artifact, all 5 states + 3 illegal transitions + 3 invariants. |
+
+---
+
+## 6. Risks
+
+1. **Effect version skew (highest, front-loaded into G0).** beta.60 → beta.75 spans real
+   Schema/Layer/Config API drift across the existing app (`payment.server.ts`,
+   `runtime.ts`, `env.server.ts`, every Schema usage). G0 is its own commit; ALL fallout fixed
+   there before anything depends on it. If it balloons, sub-commit by subsystem.
+2. **DB backing — a PRE-G0 BLOCKER, not a "confirm before G2".** Because the runner
+   (`ServerLive`) and the senders (`AppRuntime`) are TWO SEPARATE layer graphs that can ONLY
+   coordinate through durable backing (§1 two-runtime topology), `':memory:'` is **impossible in
+   production** — it gives the two graphs two disjoint in-memory DBs and the
+   route→runner→webhook loop never closes. The choice is **sqlite FILE on a Railway persistent
+   volume** vs **`@effect/sql-pg` + Railway Postgres**, and it gates the WHOLE architecture (G2's
+   adapter AND the cross-runtime sharing story), so it MUST be resolved **before G0** (Open
+   Question 2). A persistent volume is also required for durability: an ephemeral FS loses
+   `cluster_messages`/`cluster_replies` between deploys, breaking in-flight (suspended `settle`)
+   orders. If no volume is mountable, the plan flips to `@effect/sql-pg` + Railway Postgres (add
+   the dep in G0, connection-pool note, localized to `Order.SqlClientLive` in G2). The G3
+   cross-runtime test (shared FILE, with a `':memory:'` negative control) is the guard that
+   proves the seam.
+3. **Runner consumes mailbox at `entityMessagePollInterval` latency, not instantly**
+   (`actor-mailbox.ts:30-33`). Fine for the durable lifecycle (the webhook resolve is async
+   anyway), but the `arm`→entity-exists window is poll-bounded. The interactive redirect does NOT
+   depend on it (the action has the URL synchronously). Tune `ShardingConfig` poll interval if a
+   sweep/settle feels laggy.
+4. **PaymentIntent vs sessionId for refund (G7).** `PostRefunds` refunds a
+   `payment_intent`/`charge`, but the order stores only `sessionId` (`order.ts:50`). G7 must
+   persist the PaymentIntent id (available on the webhook's session object at `settle` time) or
+   add a session-retrieve op. Note as a G7 sub-task; do not stub.
+5. **Dual source-of-truth coherence.** The actor State + the bucket `RegistrationOrder` both
+   model the payment lifecycle. Mitigated by Decision 1 (bucket = authority, State = derived
+   cache; every handler writes both within one handler; restart rebuilds from bucket + reply
+   log) and asserted by G9 invariant 3. Still a coherence hazard if a handler writes one and not
+   the other — the handler MUST write both atomically.
+6. **Per-registrant cardinality fan-out.** `perRegistrant` mints N orders keyed
+   `<fingerprint>:<index>` (`order.ts:18-21`, `registration-action.ts:177`). The Order entity's
+   `id`-fn (one entity per `orderId`) handles this since each gets its own `orderId`, but the
+   action `send`s N `arm` ops and the sweep handles N entities per request — G7/G9 must cover the
+   N-per-request case, not just the group 1-per-request case.
+7. **Late-payment-on-expired (G9).** A `checkout.session.completed` after `expire → expired` is a
+   real money/support hazard. Code defaults to reject-and-log; the honor-vs-auto-refund policy is
+   an Open Question to settle before launch.
+8. **ExecId resolution (G8) hinges on the `id`-fn purity (Decision 4).** The webhook resolves the
+   `settle` op by calling `Order.settle.waitFor({ orderId })` — which works ONLY because
+   `id: (p) => p.orderId` ignores every other payload field (so the `{ orderId }`-only payload
+   derives the same ExecId as the action-side full payload, `actor.ts:1380-1385`). If G4's
+   `id`-fn derives the key from anything beyond `orderId` (e.g. a payload hash), the webhook
+   (which has only `metadata.orderId`) lands on a DIFFERENT ExecId and never sees the reply. G4
+   MUST make `id` a pure string fn of `orderId`; the G3/G8 round-trip test
+   (`executionId({orderId,...}) === executionId({orderId})`) is the guard. Do NOT attempt to
+   rebuild the ExecId via `entityIdCodec`/`makeExecId` (neither produces the execId format —
+   Decision 4).
+
+---
+
+## 7. Open questions
+
+1. **Exact encore version to pin in G0.** HEAD is `0.12.8` and already ships the per-op
+   `sendAndAwait`/`waitFor`/`peek` methods (`actor.ts:586,604,607,622`) + `fromSqlClient` +
+   `fromSqlClientWithShardingConfig` + `entityIdCodec` + `ActorSenderLayer`. Confirm `0.12.8` is
+   published to the registry GYC pulls from (or publish it via the changeset flow first). This
+   plan does NOT require the `Client`/`State<A>` reshape, so no further encore work blocks the
+   start — confirm the publish state.
+2. **DB target — RESOLVE BEFORE G0 (pre-G0 BLOCKER, Risk 2): sqlite FILE on a Railway persistent
+   volume vs Railway Postgres + `@effect/sql-pg`?** Because the two runtimes share state only via
+   durable backing, `':memory:'` is impossible in production; this choice settles G2's adapter,
+   whether G0 adds `@effect/sql-pg`, and the whole cross-runtime sharing story. NOT deferrable to
+   G2.
+3. **Refund trigger surface (G7).** Operator action via `/admin` route (`auth.server.ts` gate),
+   CLI, or Stripe-dashboard-initiated (`charge.refunded` → `Order.refund`)? The plan builds the
+   op + a manual `/admin` entrypoint; the operator UX is unspecified.
+4. **Late-payment-on-expired policy (G9).** Honor the payment (resurrect → paid + ship) or
+   auto-refund via the G7 refund path? Product/money decision.
+5. **Sweep trigger (G9).** In-process scheduled fiber (plan default, self-contained) vs external
+   cron hitting the `/admin` route? Depends on whether Railway runs a single always-on instance
+   (in-process fine) or scales/sleeps (needs external trigger). Single-process is also the
+   runner assumption (Risk 3 / single-node) — if GYC ever scales to multiple web processes
+   against one DB, the runner must move to a dedicated worker process (the
+   `Client.layer.fromSharding` path) — flag the flip-trigger.
+6. **Branch base.** This plan stacks `feat/order-workflow` ON TOP of `feat/registrar` (PR #35),
+   which already has `Payment`/`RegistrationOrder`/webhook/`Submissions`. Confirm #35 lands first
+   (or this stays a child branch) so G7's `payment.server.ts` `createRefund` addition doesn't
+   conflict with an in-flight registrar change.

--- a/package.json
+++ b/package.json
@@ -19,14 +19,16 @@
     "@conform-to/dom": "^1.19.4",
     "@conform-to/react": "^1.19.4",
     "@distilled.cloud/stripe": "0.26.1",
-    "@effect/platform-bun": "4.0.0-beta.60",
+    "@effect/platform-bun": "4.0.0-beta.75",
+    "@effect/sql-sqlite-bun": "4.0.0-beta.75",
     "@epic-web/client-hints": "^1.3.2",
     "@sendgrid/client": "^8.1.6",
     "@react-router/node": "^7.15.0",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.11",
     "dedent": "^1.5.3",
-    "effect": "4.0.0-beta.60",
+    "effect": "4.0.0-beta.75",
+    "effect-encore": "^0.14.0",
     "framer-motion": "^11.2.13",
     "isbot": "^5.1.40",
     "lucide-react": "0.469.0",
@@ -57,6 +59,6 @@
     "vite": "^8.0.10"
   },
   "overrides": {
-    "effect": "4.0.0-beta.60"
+    "effect": "4.0.0-beta.75"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,7 @@ import {
 import { imageKeyFromPath } from './app/lib/images.server.ts';
 import { Storage } from './app/lib/storage.server.ts';
 import { Submissions } from './app/lib/forms/submissions.server.ts';
+import { Payment } from './app/lib/payment.server.ts';
 import { Order } from './app/lib/order/runner.server.ts';
 
 declare module 'react-router' {
@@ -286,7 +287,14 @@ const OrderRunnerLive = Layer.unwrap(
     // impossibility (a build failure here is a real defect) and keeps the
     // runner's build-error channel clean.
     return Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
+      // The runner's bucket-authority writes come from `Submissions`; the
+      // `refund` handler (G7) ALSO issues the Stripe refund, so `Payment` is
+      // provided here too (self-contained `defaultLayer`s — both gate on their
+      // own `Env` reads). When `Env.stripe` is None `Payment` is inert and a
+      // `refund` op would die `PaymentDisabled`, but no sender reaches `refund`
+      // without a configured Stripe, so the runner still builds cleanly.
       Layer.provide(Submissions.defaultLayer),
+      Layer.provide(Payment.defaultLayer),
       Layer.orDie,
     );
   }),

--- a/server.ts
+++ b/server.ts
@@ -248,7 +248,7 @@ const RoutesLive = isDev ? DevRoutes : ProdRoutes;
 // (ADR 0004:38-40). Providing `Env.layer` discharges the requirement, so a
 // missing secret fails `Layer.launch` and `BunRuntime.runMain` exits non-zero.
 // In dev / test the env vars are optional, so this is a cheap no-op.
-const StartupCheck = Layer.effectDiscard(Env.Service.asEffect()).pipe(
+const StartupCheck = Layer.effectDiscard(Env.Service).pipe(
   Layer.provide(Env.layer),
 );
 

--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ import { Storage } from './app/lib/storage.server.ts';
 import { Submissions } from './app/lib/forms/submissions.server.ts';
 import { Payment } from './app/lib/payment.server.ts';
 import { Order } from './app/lib/order/runner.server.ts';
+import { OrderSweep } from './app/lib/order/sweep.server.ts';
 
 declare module 'react-router' {
   interface RouterContextProvider {
@@ -286,13 +287,31 @@ const OrderRunnerLive = Layer.unwrap(
     // `DatabaseUnconfigured` gate cannot fire; `orDie` reflects the
     // impossibility (a build failure here is a real defect) and keeps the
     // runner's build-error channel clean.
-    return Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
-      // The runner's bucket-authority writes come from `Submissions`; the
-      // `refund` handler (G7) ALSO issues the Stripe refund, so `Payment` is
-      // provided here too (self-contained `defaultLayer`s — both gate on their
-      // own `Env` reads). When `Env.stripe` is None `Payment` is inert and a
-      // `refund` op would die `PaymentDisabled`, but no sender reaches `refund`
-      // without a configured Stripe, so the runner still builds cleanly.
+    // The runner (consumer) AND the deadline-sweep fiber (a SENDER of
+    // `Order.expire`), both in this long-lived `Layer.launch`-ed graph. The
+    // sweep needs `Order.SenderServices` (`Client | ActorAddressResolver |
+    // MessageStorage`) — which `fullRunnerLayer` already carries in its output
+    // (the handlers' `toLayer` keeps the client/storage services) — so
+    // `provideMerge` wires the sweep's sender requirement from the same runner
+    // build, over the SAME shared sqlite FILE the runner polls. A `send` from
+    // the sweep lands in the rows the runner consumes; the two never coordinate
+    // through anything but the durable DB (the two-runtime topology).
+    // `provideMerge` (not `merge`): the sweep fiber REQUIRES the runner's sender
+    // output (`Client | ActorAddressResolver | MessageStorage`), so the runner
+    // must PROVIDE it to the fiber — `merge` would leave the fiber's requirement
+    // unsatisfied. `provideMerge` feeds `fullRunnerLayer`'s output into the
+    // fiber AND keeps the runner's services in the result (so `Layer.launch`
+    // builds the runner too). Both end up needing `Submissions` (the fiber's
+    // `listOrders` + the handlers' bucket writes), discharged once below.
+    return OrderSweep.fiberLayer().pipe(
+      Layer.provideMerge(Order.fullRunnerLayer(Order.MessageStorageLive)),
+      // The runner's bucket-authority writes come from `Submissions`; the sweep
+      // ALSO reads orders through `Submissions` (`listOrders`). The `refund`
+      // handler (G7) ALSO issues the Stripe refund, so `Payment` is provided
+      // here too (self-contained `defaultLayer`s — both gate on their own `Env`
+      // reads). When `Env.stripe` is None `Payment` is inert and a `refund` op
+      // would die `PaymentDisabled`, but no sender reaches `refund` without a
+      // configured Stripe, so the runner still builds cleanly.
       Layer.provide(Submissions.defaultLayer),
       Layer.provide(Payment.defaultLayer),
       Layer.orDie,

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 import { BunHttpServer, BunRuntime } from '@effect/platform-bun';
-import { Data, Effect, Layer } from 'effect';
+import { Data, Effect, Layer, Option } from 'effect';
 import {
   HttpRouter,
   HttpServerRequest,
@@ -15,6 +15,8 @@ import {
 } from './app/lib/effect/runtime.ts';
 import { imageKeyFromPath } from './app/lib/images.server.ts';
 import { Storage } from './app/lib/storage.server.ts';
+import { Submissions } from './app/lib/forms/submissions.server.ts';
+import { Order } from './app/lib/order/runner.server.ts';
 
 declare module 'react-router' {
   interface RouterContextProvider {
@@ -260,10 +262,46 @@ const StartupCheck = Layer.effectDiscard(Env.Service).pipe(
 // storage layer is self-contained.
 const StorageLive = Storage.defaultLayer;
 
+// The durable Order workflow's CONSUMER side: the in-process Sharding runner +
+// the `arm`/`settle`/… handlers, hosted in this long-lived `Layer.launch`-ed
+// `ServerLive` graph (G6, order-workflow-plan §1) — NOT the request-handler
+// `makeAppLayer` graph, which is consumed once into the `AppRuntime` singleton
+// and never `Layer.launch`-ed, so it has no process-lifetime supervisor for the
+// runner's mailbox-poll fiber. The runner consumes the SQL mailbox the
+// registration action + Stripe webhook (SENDERS in `AppRuntime`) write to; the
+// two graphs coordinate ONLY through the shared `DATABASE_URL` sqlite FILE.
+//
+// Gated on `Env.database` Some: a DB-less deploy composes `Layer.empty`, so the
+// bucket-only registration/webhook path is byte-identically unaffected and
+// `Layer.launch` still exits non-zero on a missing REQUIRED config (the
+// `StartupCheck` contract). The runner's bucket-authority writes come from
+// `Submissions.defaultLayer` (self-contained); `Env.layer` discharges the
+// `MessageStorageLive` SqlClient gate and the `Env`-read in the gate itself.
+const OrderRunnerLive = Layer.unwrap(
+  Effect.gen(function* () {
+    const env = yield* Env.Service;
+    if (Option.isNone(env.database)) return Layer.empty;
+    // In this branch `Env.database` IS Some, so `MessageStorageLive`'s
+    // `DatabaseUnconfigured` gate cannot fire; `orDie` reflects the
+    // impossibility (a build failure here is a real defect) and keeps the
+    // runner's build-error channel clean.
+    return Order.fullRunnerLayer(Order.MessageStorageLive).pipe(
+      Layer.provide(Submissions.defaultLayer),
+      Layer.orDie,
+    );
+  }),
+).pipe(Layer.provide(Env.layer));
+
 const ServerLive = HttpRouter.serve(RoutesLive).pipe(
   Layer.provide(StorageLive),
   Layer.provide(StartupCheck),
   Layer.provide(BunHttpServer.layer({ port: PORT })),
+  // `merge` (not `provide`): nothing in the HTTP graph CONSUMES the runner's
+  // output services, so `Layer.provide` would never build it (provide only
+  // builds a dependency something requires). Merging makes the runner part of
+  // `ServerLive`'s own composition, so `Layer.launch` builds it and supervises
+  // its mailbox-poll fiber for the process lifetime.
+  Layer.merge(OrderRunnerLive),
 );
 
 BunRuntime.runMain(Layer.launch(ServerLive));


### PR DESCRIPTION
**Stacked on #35 (feat/registrar).** Adds a durable encore `Order` entity modelling a registration payment's full lifecycle, backed by SQL `MessageStorage`. Consumes the just-published `effect-encore@^0.14.0`.

## What it does
The Stripe Checkout payment confirmation becomes a **durable, crash-recoverable workflow**: the registration action sends `Order.arm`; the `process` op suspends awaiting the reply token; the Stripe webhook (`checkout.session.completed`) resolves the suspended `settle` ExecId via SQL `MessageStorage`. Plus `cancel` / `refund` / `expire` and a deadline-sweep.

## Architecture (the load-bearing decisions)
- **Two-runtime split:** the durable RUNNER + deadline-sweep fiber + `MessageStorage` live in the long-lived `Layer.launch`-ed `ServerLive`; the registration action + webhook are SENDERS against the `AppRuntime` request graph. Two `SqlClient` builds share the **same sqlite FILE** (`DATABASE_URL`, never `:memory:` — prod rejects it).
- **State machine** (`app/lib/order/transitions.ts`, one source of truth): `pending | paid | cancelled | refunded | expired`. Terminals are sinks; every bucket mutation (webhook, create, actor) routes through `canTransition`.
- **ExecId** = `{orderId}` (entityId===primaryKey===orderId), so the webhook resolves the reply from `{orderId}` alone.
- **Refund** resolves the PaymentIntent from the Checkout session first, refunds the frozen order amount.

## Commits
G0 dep bump (effect beta.75 + encore@^0.14.0 + sqlite-bun) · G1 `DATABASE_URL` gate · G2 SQL MessageStorage · G3 in-process runner + cross-runtime shared-file test · G4 Order entity + state machine · G5 bucket status widening · G6 runner→server.ts (two-runtime) · G7 action sends arm + refund/cancel/expire · G8 webhook resolves settle ExecId · G9 deadline-sweep + capstone. Plus 6 fix commits across 4 `--deep` rounds + a doc fix.

## Confirmed product behavior
- Late-payment-on-expired: **reject-and-log** (no resurrection).
- Sweep: in-process fiber + manual `/admin` POST trigger (multi-instance flip).
- Resubmit: paid → `?checkout=success` (no re-charge); pending → reuse session; non-paid terminal → fresh order; conflict → explicit error.

## Review
19 commits, each per-commit Codex-gated. **5 rounds of `--deep`** to convergence — the terminal-state-resurrection bug class had three distinct entry points (webhook guard, create-path `put`, the alreadyPaid race inside the fix), each caught in a different round. Final round: 0 BLOCKER / 0 MAJOR / 0 MINOR. Gate green: typecheck, lint, 759 tests.

## Deploy prerequisite
Railway: a **persistent volume** for the sqlite file + `DATABASE_URL` = that file path. Single always-on web instance (the runner's single-node assumption). If GYC ever scales to multiple web processes, the runner moves to a dedicated worker (the `Client.layer.fromSharding` path).

> Merge #35 first, then this.