### PR TITLE
Refine conference pages and CMS integration

### DIFF
--- a/app/lib/admin-headers.test.ts
+++ b/app/lib/admin-headers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { adminFlashStatus, adminRedirectWithStatus } from './admin-headers';
+
+describe('admin flash status helpers', () => {
+  test('reads the status query param from the request URL', () => {
+    const request = new Request(
+      'http://localhost/admin/content?status=Published.%20Live%20on%20the%20next%20page%20load.',
+    );
+    expect(adminFlashStatus(request)).toBe(
+      'Published. Live on the next page load.',
+    );
+  });
+
+  test('builds a redirect carrying an encoded status message', () => {
+    const response = adminRedirectWithStatus(
+      '/admin/content',
+      'Published. Live on the next page load.',
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe(
+      '/admin/content?status=Published.%20Live%20on%20the%20next%20page%20load.',
+    );
+  });
+});

--- a/app/lib/admin-headers.ts
+++ b/app/lib/admin-headers.ts
@@ -10,6 +10,8 @@
  *   - `X-Frame-Options: DENY` / `Referrer-Policy: same-origin` are standard
  *     hardening for an authenticated surface.
  */
+import { redirect } from 'react-router';
+
 export const adminSecurityHeaders = (): Record<string, string> => ({
   'Cache-Control': 'private, no-store, max-age=0',
   'X-Frame-Options': 'DENY',
@@ -20,3 +22,11 @@ export const adminSecurityHeaders = (): Record<string, string> => ({
 export const adminMeta = () => [
   { name: 'robots', content: 'noindex, nofollow' },
 ];
+
+/** Read the one-shot flash `?status=` query param from an admin request URL. */
+export const adminFlashStatus = (request: Request): string | null =>
+  new URL(request.url).searchParams.get('status');
+
+/** Redirect to an admin path with a flash status message in the query string. */
+export const adminRedirectWithStatus = (pathname: string, message: string) =>
+  redirect(`${pathname}?status=${encodeURIComponent(message)}`);

--- a/app/lib/content.server.test.ts
+++ b/app/lib/content.server.test.ts
@@ -196,75 +196,66 @@ describe('Content boundary conversion (decode → legacy shape)', () => {
 });
 
 describe('Content optional detail-page projection (Option → string|undefined)', () => {
-  /**
-   * The Conference document models its detail-page fields as `Option`
-   * (`OptionFromOptionalKey` for the URLs, an empty-able list for `hotels`,
-   * registration-launch Branch 3.1). `toConference` projects each to the boundary
-   * shape React renders: `string | undefined` for the URLs, a plain `{name,
-   * note?}[]` for hotels — so a component never sees an `Option<string>` and
-   * Branch 4's section-skip gates on `undefined` / `[]` (`boundary-discipline`).
-   * These tests pin that projection against the defaults: 2024 carries every
-   * field, 2026 only `registrationUrl` (the RegFox live channel, settled #9),
-   * 2025 (cancelled) none.
-   */
-  it.effect('projects 2024 — every optional field present', () =>
+  it.effect('projects 2024 — URLs and enabled sections present', () =>
     Effect.gen(function* () {
       const content = yield* Content.Service;
       const conference = yield* content.getConference('en', 2024);
 
-      // The brand-validated https strings cross the boundary verbatim (no Option).
       expect(conference.registrationUrl).toBe(
         'https://gyccanada.regfox.com/gyc-canada-2024-while-it-is-day',
       );
       expect(conference.scheduleUrl).toBe(
         'https://docs.google.com/document/d/1gNAOfdW2Yhgg7FABjUqQt2k2mXV_AdhARWUOyiVL9dA/pub',
       );
-      expect(conference.mapEmbedUrl).toBeDefined();
-      expect(conference.mapEmbedUrl?.startsWith('https://www.google.com/maps/embed')).toBe(
-        true,
+      expect(conference.travel.enabled).toBe(true);
+      expect(conference.travel.mapEmbedUrl?.startsWith(
+        'https://www.google.com/maps/embed',
+      )).toBe(true);
+      expect(conference.accommodations.enabled).toBe(true);
+      expect(conference.accommodations.hotels).toHaveLength(5);
+      expect(conference.accommodations.hotels[0]?.name).toBe(
+        'Super 8 by Wyndham Kelowna BC',
       );
-
-      // Hotels project to this locale's strings; the optional `note` is present
-      // only on the items that carry one.
-      expect(conference.hotels).toHaveLength(5);
-      expect(conference.hotels[0]?.name).toBe('Super 8 by Wyndham Kelowna BC');
-      expect(conference.hotels[0]?.note).toBeUndefined();
-      expect(conference.hotels[1]?.name).toBe('Fairfield Inn & Suites Kelowna');
-      expect(conference.hotels[1]?.note).toContain('Holiday Inn Express');
+      expect(conference.accommodations.hotels[1]?.description).toContain(
+        'Holiday Inn Express',
+      );
+      expect(conference.registrationCopy.enabled).toBe(true);
+      expect(conference.faqCopy.enabled).toBe(true);
     }).pipe(provideSeeded(defaultContent)));
 
-  it.effect('projects 2024 hotel notes per-locale (fr)', () =>
+  it.effect('projects 2024 hotel descriptions per-locale (fr)', () =>
     Effect.gen(function* () {
       const content = yield* Content.Service;
       const conference = yield* content.getConference('fr', 2024);
-      // The bilingual `note` `Text` collapses to the requested locale.
-      expect(conference.hotels[1]?.note).toContain('code de groupe');
+      expect(conference.accommodations.hotels[1]?.description).toContain(
+        'code de groupe',
+      );
     }).pipe(provideSeeded(defaultContent)));
 
-  it.effect('projects 2026 — only registrationUrl present, the rest skippable', () =>
+  it.effect('projects 2026 — registrationUrl and copy sections enabled', () =>
     Effect.gen(function* () {
       const content = yield* Content.Service;
       const conference = yield* content.getConference('en', 2026);
-      // 2026 carries ONLY its RegFox registration URL (settled #9).
       expect(conference.registrationUrl).toBe(
         'https://gyccanada.regfox.com/gyc-canada-2026-speak',
       );
-      // Schedule / map / hotels are TBD → the section-skip discriminators.
       expect(conference.scheduleUrl).toBeUndefined();
-      expect(conference.mapEmbedUrl).toBeUndefined();
-      expect(conference.hotels).toEqual([]);
+      expect(conference.travel.enabled).toBe(false);
+      expect(conference.accommodations.enabled).toBe(false);
+      expect(conference.registrationCopy.enabled).toBe(true);
+      expect(conference.faqCopy.enabled).toBe(true);
     }).pipe(provideSeeded(defaultContent)));
 
-  it.effect('projects 2025 — cancelled year, every optional field absent', () =>
+  it.effect('projects 2025 — cancelled year, optional URLs absent', () =>
     Effect.gen(function* () {
       const content = yield* Content.Service;
       const conference = yield* content.getConference('en', 2025);
-      // Cancelled year: no registration channel, no schedule/map, no hotels —
-      // Branch 4 renders it as hero + FAQ only.
       expect(conference.registrationUrl).toBeUndefined();
       expect(conference.scheduleUrl).toBeUndefined();
-      expect(conference.mapEmbedUrl).toBeUndefined();
-      expect(conference.hotels).toEqual([]);
+      expect(conference.travel.enabled).toBe(false);
+      expect(conference.accommodations.enabled).toBe(false);
+      expect(conference.registrationCopy.enabled).toBe(false);
+      expect(conference.faqCopy.enabled).toBe(true);
     }).pipe(provideSeeded(defaultContent)));
 });
 

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -109,11 +109,21 @@ export interface Seminar {
   readonly description: string;
 }
 
+export interface ConferenceAirportTransitOption {
+  readonly description: string;
+}
+
+export interface ConferenceAirport {
+  readonly name: string;
+  readonly transitOptions: readonly ConferenceAirportTransitOption[];
+}
+
 export interface ConferenceTravelSection {
   readonly enabled: boolean;
   readonly headerCopy: string;
-  readonly bodyCopy: string;
+  readonly bodyCopy: string | undefined;
   readonly mapEmbedUrl: string | undefined;
+  readonly airport: ConferenceAirport | undefined;
 }
 
 export interface ConferenceParkingOption {
@@ -126,6 +136,7 @@ export interface ConferenceParkingOption {
 export interface ConferenceParkingSection {
   readonly enabled: boolean;
   readonly headerCopy: string;
+  readonly bodyCopy: string | undefined;
   readonly options: readonly ConferenceParkingOption[];
 }
 
@@ -305,12 +316,28 @@ const toConference = (
   travel: {
     enabled: conference.travel.enabled,
     headerCopy: conference.travel.headerCopy[locale],
-    bodyCopy: conference.travel.bodyCopy[locale],
+    bodyCopy:
+      conference.travel.bodyCopy === undefined
+        ? undefined
+        : conference.travel.bodyCopy[locale],
     mapEmbedUrl: Option.getOrUndefined(conference.travel.mapEmbedUrl),
+    airport:
+      conference.travel.airport === undefined
+        ? undefined
+        : {
+            name: conference.travel.airport.name[locale],
+            transitOptions: conference.travel.airport.transitOptions.map(
+              (opt) => ({ description: opt.description[locale] }),
+            ),
+          },
   },
   parking: {
     enabled: conference.parking.enabled,
     headerCopy: conference.parking.headerCopy[locale],
+    bodyCopy:
+      conference.parking.bodyCopy === undefined
+        ? undefined
+        : conference.parking.bodyCopy[locale],
     options: conference.parking.options.map((option) => ({
       title: option.title[locale],
       link: Option.getOrUndefined(option.link),

--- a/app/lib/content.server.ts
+++ b/app/lib/content.server.ts
@@ -109,6 +109,63 @@ export interface Seminar {
   readonly description: string;
 }
 
+export interface ConferenceTravelSection {
+  readonly enabled: boolean;
+  readonly headerCopy: string;
+  readonly bodyCopy: string;
+  readonly mapEmbedUrl: string | undefined;
+}
+
+export interface ConferenceParkingOption {
+  readonly title: string;
+  readonly link: string | undefined;
+  readonly address: string | undefined;
+  readonly description: string | undefined;
+}
+
+export interface ConferenceParkingSection {
+  readonly enabled: boolean;
+  readonly headerCopy: string;
+  readonly options: readonly ConferenceParkingOption[];
+}
+
+export interface ConferenceAccommodationHotel {
+  readonly name: string;
+  readonly address: string;
+  readonly checkIn: string | undefined;
+  readonly checkOut: string | undefined;
+  readonly roomRates: readonly { readonly description: string }[];
+  readonly description: string | undefined;
+  readonly navigateUrl: string | undefined;
+  readonly reservationUrl: string | undefined;
+}
+
+export interface ConferenceAccommodationsSection {
+  readonly enabled: boolean;
+  readonly headerCopy: string;
+  readonly hotels: readonly ConferenceAccommodationHotel[];
+}
+
+export interface ConferenceMealsSection {
+  readonly enabled: boolean;
+  readonly headerCopy: string;
+  readonly bodyCopy: string | undefined;
+  readonly items: readonly { readonly label: string; readonly price: string }[];
+}
+
+export interface ConferenceRegistrationCopySection {
+  readonly enabled: boolean;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly buttonLabel: string;
+}
+
+export interface ConferenceFaqCopySection {
+  readonly enabled: boolean;
+  readonly title: string;
+  readonly subtitle: string;
+}
+
 export interface Conference {
   readonly slug: string;
   readonly title: string;
@@ -141,25 +198,15 @@ export interface Conference {
    * document field is the correctly-named `accentColor` (CMS decision D5).
    */
   readonly theme: string;
-  /**
-   * The optional detail-page data the forked `/YYYY` pages hard-coded
-   * (registration-launch Branch 3, settled #4). The document models each as
-   * `Option` (`OptionFromOptionalKey` / empty list); this boundary projects them
-   * to `string | undefined` and a plain object array so React never sees an
-   * `Option<string>` (`boundary-discipline`). An absent field is `undefined`, an
-   * absent list is `[]` — that is the section-presence discriminator Branch 4's
-   * section-skip gates on (`registrationUrl !== undefined`,
-   * `mapEmbedUrl !== undefined`, `hotels.length > 0`). Each URL crossed the
-   * `ExternalHttpsUrl` / `GoogleMapsEmbedUrl` brand on decode, so the rendered
-   * `href` / iframe `src` is already an XSS-safe https string.
-   */
   readonly registrationUrl: string | undefined;
   readonly scheduleUrl: string | undefined;
-  readonly mapEmbedUrl: string | undefined;
-  readonly hotels: readonly {
-    readonly name: string;
-    readonly note?: string;
-  }[];
+  readonly learnMoreEnabled: boolean;
+  readonly travel: ConferenceTravelSection;
+  readonly parking: ConferenceParkingSection;
+  readonly accommodations: ConferenceAccommodationsSection;
+  readonly meals: ConferenceMealsSection;
+  readonly registrationCopy: ConferenceRegistrationCopySection;
+  readonly faqCopy: ConferenceFaqCopySection;
 }
 
 /**
@@ -218,21 +265,6 @@ const toSeminar = (seminar: DocSeminar, locale: Locale): Seminar => ({
   description: seminar.description[locale],
 });
 
-/**
- * Project a document `Hotel` to the boundary shape: the bilingual `name`/`note`
- * `Text`s collapse to this locale's string, and the optional `note` becomes a
- * `string | undefined` (omitted when the document carries no note). The `id`
- * (list identity, ADR 0006) is not part of the read boundary the detail page
- * renders, so it is dropped here.
- */
-const toHotel = (
-  hotel: DocConference['hotels'][number],
-  locale: Locale,
-): Conference['hotels'][number] => ({
-  name: hotel.name[locale],
-  ...(hotel.note === undefined ? {} : { note: hotel.note[locale] }),
-});
-
 const toConference = (
   conference: DocConference,
   locale: Locale,
@@ -241,8 +273,6 @@ const toConference = (
   title: conference.themeName[locale],
   theme: conference.accentColor,
   hero: {
-    // Hero art is per-locale on disk; select this locale's key for each crop
-    // and resolve it to the served URL so the rendered `src` is unchanged.
     image: {
       desktop: assetUrl(conference.hero.desktop.key[locale]),
       mobile: assetUrl(conference.hero.mobile.key[locale]),
@@ -269,16 +299,71 @@ const toConference = (
   speakers: conference.speakers.map((speaker) => toSpeaker(speaker, locale)),
   seminars: conference.seminars.map((seminar) => toSeminar(seminar, locale)),
   promos: [...conference.promos],
-  // The optional detail-page fields: each document `Option` projects to
-  // `string | undefined` via `Option.getOrUndefined` (the convention for ALL
-  // new optional Conference fields — `Option` at the document layer, plain
-  // `string | undefined` at the boundary so React never sees an `Option`,
-  // matching the `registration` `Option.isSome` gate above). `hotels` projects
-  // each item to this locale's strings; an empty document list stays `[]`.
   registrationUrl: Option.getOrUndefined(conference.registrationUrl),
   scheduleUrl: Option.getOrUndefined(conference.scheduleUrl),
-  mapEmbedUrl: Option.getOrUndefined(conference.mapEmbedUrl),
-  hotels: conference.hotels.map((hotel) => toHotel(hotel, locale)),
+  learnMoreEnabled: conference.learnMoreEnabled,
+  travel: {
+    enabled: conference.travel.enabled,
+    headerCopy: conference.travel.headerCopy[locale],
+    bodyCopy: conference.travel.bodyCopy[locale],
+    mapEmbedUrl: Option.getOrUndefined(conference.travel.mapEmbedUrl),
+  },
+  parking: {
+    enabled: conference.parking.enabled,
+    headerCopy: conference.parking.headerCopy[locale],
+    options: conference.parking.options.map((option) => ({
+      title: option.title[locale],
+      link: Option.getOrUndefined(option.link),
+      address:
+        option.address === undefined ? undefined : option.address[locale],
+      description:
+        option.description === undefined
+          ? undefined
+          : option.description[locale],
+    })),
+  },
+  accommodations: {
+    enabled: conference.accommodations.enabled,
+    headerCopy: conference.accommodations.headerCopy[locale],
+    hotels: conference.accommodations.hotels.map((hotel) => ({
+      name: hotel.name[locale],
+      address: hotel.address[locale],
+      checkIn:
+        hotel.checkIn === undefined ? undefined : hotel.checkIn[locale],
+      checkOut:
+        hotel.checkOut === undefined ? undefined : hotel.checkOut[locale],
+      roomRates: hotel.roomRates.map((rate) => ({
+        description: rate.description[locale],
+      })),
+      description:
+        hotel.description === undefined ? undefined : hotel.description[locale],
+      navigateUrl: Option.getOrUndefined(hotel.navigateUrl),
+      reservationUrl: Option.getOrUndefined(hotel.reservationUrl),
+    })),
+  },
+  meals: {
+    enabled: conference.meals.enabled,
+    headerCopy: conference.meals.headerCopy[locale],
+    bodyCopy:
+      conference.meals.bodyCopy === undefined
+        ? undefined
+        : conference.meals.bodyCopy[locale],
+    items: conference.meals.items.map((item) => ({
+      label: item.label[locale],
+      price: item.price[locale],
+    })),
+  },
+  registrationCopy: {
+    enabled: conference.registrationCopy.enabled,
+    title: conference.registrationCopy.title[locale],
+    subtitle: conference.registrationCopy.subtitle[locale],
+    buttonLabel: conference.registrationCopy.buttonLabel[locale],
+  },
+  faqCopy: {
+    enabled: conference.faqCopy.enabled,
+    title: conference.faqCopy.title[locale],
+    subtitle: conference.faqCopy.subtitle[locale],
+  },
 });
 
 const toTeamMember = (member: DocTeamMember): TeamMember => ({

--- a/app/lib/content/admin-form.test.ts
+++ b/app/lib/content/admin-form.test.ts
@@ -8,13 +8,16 @@ import {
   imageUploadTarget,
   isAcceptedImageType,
   normalizeFaqAnswers,
+  normalizeMergedSiteContent,
   pruneKeylessImageOverrides,
   setAtPath,
+  stripEmptyBilingualLeaves,
+  stripEmptyOptionalUrlLeaves,
   uploadedImageKey,
   type Json,
 } from './admin-form';
-import { defaultContent } from './defaults';
-import { SiteContent, newListItemId } from './schema';
+import { defaultContent, defaultDraftContent } from './defaults';
+import { DraftSiteContent, SiteContent, newListItemId } from './schema';
 import {
   DraftFaqPage,
   DraftTeamPage,
@@ -31,6 +34,8 @@ import {
 
 const encode = Schema.encodeUnknownEffect(SiteContent);
 const decode = Schema.decodeUnknownEffect(SiteContent);
+const encodeDraft = Schema.encodeUnknownEffect(DraftSiteContent);
+const decodeDraft = Schema.decodeUnknownEffect(DraftSiteContent);
 
 const entries = (
   record: Record<string, string>,
@@ -84,6 +89,48 @@ describe('assembleOverrides', () => {
       enabled: unknown;
     };
     expect(unchecked.enabled).toBe(false);
+  });
+
+  test('coerces `learnMoreEnabled` to a real boolean', () => {
+    const checked = assembleOverrides([
+      ['conferences./2024.learnMoreEnabled', 'false'],
+      ['conferences./2024.learnMoreEnabled', 'true'],
+    ]) as { conferences: { '/2024': { learnMoreEnabled: unknown } } };
+    expect(checked.conferences['/2024']?.learnMoreEnabled).toBe(true);
+
+    const unchecked = assembleOverrides([
+      ['conferences./2024.learnMoreEnabled', 'false'],
+    ]) as { conferences: { '/2024': { learnMoreEnabled: unknown } } };
+    expect(unchecked.conferences['/2024']?.learnMoreEnabled).toBe(false);
+  });
+});
+
+describe('stripEmptyOptionalUrlLeaves', () => {
+  test('drops empty optional URL leaves but keeps non-empty values', () => {
+    const input = {
+      registrationUrl: '',
+      scheduleUrl: 'https://example.com/schedule',
+      travel: { mapEmbedUrl: '   ', bodyCopy: { en: 'x', fr: 'y' } },
+    } satisfies Json;
+    expect(stripEmptyOptionalUrlLeaves(input)).toEqual({
+      scheduleUrl: 'https://example.com/schedule',
+      travel: { bodyCopy: { en: 'x', fr: 'y' } },
+    });
+  });
+});
+
+describe('stripEmptyBilingualLeaves', () => {
+  test('drops bilingual leaves with both locales empty but keeps half-filled and complete values', () => {
+    const input = {
+      checkIn: { en: '', fr: '' },
+      checkOut: { en: '3 PM', fr: '' },
+      description: { en: 'Note', fr: 'Note' },
+      name: { en: '', fr: '' },
+    } satisfies Json;
+    expect(stripEmptyBilingualLeaves(input)).toEqual({
+      checkOut: { en: '3 PM', fr: '' },
+      description: { en: 'Note', fr: 'Note' },
+    });
   });
 });
 
@@ -461,6 +508,47 @@ describe('merge-onto-current-document round-trip', () => {
       );
       const exit = yield* Effect.exit(decode(merged));
       expect(exit._tag).toBe('Failure');
+    }));
+
+  it.effect('conference checkbox and cleared URL fields decode as draft and publish', () =>
+    Effect.gen(function* () {
+      const base = (yield* encodeDraft(defaultDraftContent)) as Json;
+      const overrides = assembleOverrides(
+        entries({
+          'conferences./2024.learnMoreEnabled': 'false',
+          'conferences./2024.registrationUrl': '',
+          'conferences./2024.travel.mapEmbedUrl': '',
+        }),
+      );
+      const merged = normalizeMergedSiteContent(deepMerge(base, overrides));
+      const draftExit = yield* Effect.exit(decodeDraft(merged));
+      expect(draftExit._tag).toBe('Success');
+      if (draftExit._tag === 'Success') {
+        expect(draftExit.value.conferences[0]?.learnMoreEnabled).toBe(false);
+      }
+      const publishExit = yield* Effect.exit(decode(merged));
+      expect(publishExit._tag).toBe('Success');
+    }));
+
+  it.effect('untouched optional hotel bilingual fields do not block publish', () =>
+    Effect.gen(function* () {
+      const base = (yield* encodeDraft(defaultDraftContent)) as Json;
+      const hotelId = defaultDraftContent.conferences[0]?.accommodations.hotels[0]?.id;
+      const overrides = assembleOverrides(
+        entries({
+          [`conferences./2024.accommodations.hotels.${String(hotelId)}.checkIn.en`]:
+            '',
+          [`conferences./2024.accommodations.hotels.${String(hotelId)}.checkIn.fr`]:
+            '',
+          [`conferences./2024.accommodations.hotels.${String(hotelId)}.checkOut.en`]:
+            '',
+          [`conferences./2024.accommodations.hotels.${String(hotelId)}.checkOut.fr`]:
+            '',
+        }),
+      );
+      const merged = normalizeMergedSiteContent(deepMerge(base, overrides));
+      const publishExit = yield* Effect.exit(decode(merged));
+      expect(publishExit._tag).toBe('Success');
     }));
 });
 

--- a/app/lib/content/admin-form.ts
+++ b/app/lib/content/admin-form.ts
@@ -117,6 +117,22 @@ export const translationFieldName = (locale: 'en' | 'fr', key: string): string =
 const isTranslationField = (name: string): boolean =>
   name.startsWith(TRANSLATION_FIELD_PREFIX);
 
+/** FormData checkbox leaves that must decode as real booleans (Codex #5/#12). */
+const BOOLEAN_LEAVES = new Set(['enabled', 'learnMoreEnabled']);
+
+/**
+ * Optional URL fields the editor clears by posting an empty string. Absent keys
+ * decode as `Option.none()` / omitted optional fields; a present `""` does not.
+ */
+const OPTIONAL_URL_LEAVES = new Set([
+  'registrationUrl',
+  'scheduleUrl',
+  'mapEmbedUrl',
+  'link',
+  'navigateUrl',
+  'reservationUrl',
+]);
+
 /**
  * Collect every `t:<locale>:<key>` form field into the bilingual translations
  * override, e.g. `t:en:main.newsletter.title` → `{ en: { 'main.newsletter.title':
@@ -208,20 +224,88 @@ export const assembleOverrides = (
     const path = name.split('.');
     const leaf = path[path.length - 1];
     // Leaf-name coercion so the form's string FormData decodes at the typed schema
-    // boundary: `chapter`/`verse` are numbers; `enabled` (the per-page visibility
-    // checkbox, Feature C) is a real boolean — a bare `"true"`/`"false"` string
-    // would NOT decode as `Schema.Boolean` (Codex #5/#12). The hidden-companion +
-    // checkbox always post an `enabled` value, so this coercion is deterministic.
+    // boundary: `chapter`/`verse` are numbers; checkbox leaves are real booleans —
+    // a bare `"true"`/`"false"` string would NOT decode as `Schema.Boolean`
+    // (Codex #5/#12). The hidden-companion + checkbox always post a value, so this
+    // coercion is deterministic.
     const coerced: Json =
       (leaf === 'chapter' || leaf === 'verse') && value.trim() !== ''
         ? Number(value)
-        : leaf === 'enabled'
+        : leaf !== undefined && BOOLEAN_LEAVES.has(leaf)
           ? value === 'true'
           : value;
     setPath(root, path, coerced);
   }
   return root;
 };
+
+/**
+ * Drop optional URL leaves whose merged value is an empty/whitespace string so
+ * clearing a URL field in the editor removes the key instead of posting `""`,
+ * which strict URL brands reject.
+ */
+export const stripEmptyOptionalUrlLeaves = (node: Json): Json => {
+  if (Array.isArray(node)) {
+    return node.map(stripEmptyOptionalUrlLeaves);
+  }
+  if (isPlainObject(node)) {
+    const result: MutableJsonObject = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        OPTIONAL_URL_LEAVES.has(key) &&
+        typeof value === 'string' &&
+        value.trim() === ''
+      ) {
+        continue;
+      }
+      result[key] = stripEmptyOptionalUrlLeaves(value);
+    }
+    return result;
+  }
+  return node;
+};
+
+const isBilingualLeaf = (
+  value: Json,
+): value is { readonly en?: Json; readonly fr?: Json } => {
+  if (!isPlainObject(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => key === 'en' || key === 'fr');
+};
+
+const isBothLocalesEmpty = (value: {
+  readonly en?: Json;
+  readonly fr?: Json;
+}): boolean => {
+  const empty = (leaf: Json | undefined) =>
+    leaf === undefined || (typeof leaf === 'string' && leaf.trim() === '');
+  return empty(value.en) && empty(value.fr);
+};
+
+/**
+ * Drop `{ en, fr }` leaves whose both locales are empty/whitespace. Optional
+ * bilingual fields (`checkIn`, `description`, …) render as blank inputs in the
+ * editor and post `""` for each locale; absent keys decode as omitted optional
+ * fields, but a present `{ en: "", fr: "" }` fails strict `Text`.
+ */
+export const stripEmptyBilingualLeaves = (node: Json): Json => {
+  if (Array.isArray(node)) {
+    return node.map(stripEmptyBilingualLeaves);
+  }
+  if (isPlainObject(node)) {
+    const result: MutableJsonObject = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (isBilingualLeaf(value) && isBothLocalesEmpty(value)) continue;
+      result[key] = stripEmptyBilingualLeaves(value);
+    }
+    return result;
+  }
+  return node;
+};
+
+/** Normalize a merged site-content document before draft/publish decode. */
+export const normalizeMergedSiteContent = (node: Json): Json =>
+  stripEmptyBilingualLeaves(stripEmptyOptionalUrlLeaves(node));
 
 /**
  * Rewrite a FAQ-answer override leaf from the editor's plain-text bilingual input

--- a/app/lib/content/cms-e2e.test.ts
+++ b/app/lib/content/cms-e2e.test.ts
@@ -270,6 +270,46 @@ describe('CMS list-op (add / remove / reorder) via DraftEditor.applyListOps', ()
     );
   });
 
+  it('add parking / hotel / meal reopens from draft even without a clock advance (same-second reload)', async () => {
+    const seed = await seedBody();
+    const parkingId = newListItemId();
+    const hotelId = newListItemId();
+    const mealId = newListItemId();
+
+    const result = await run(
+      Effect.gen(function* () {
+        const editor = yield* DraftEditor.Service;
+
+        // NO TestClock.adjust — the draft is written in the same second as the
+        // epoch-seeded published document (second-granular S3/MinIO behaviour).
+        yield* editor.applyListOps(siteScope, [
+          addOp('conferences./2024.parking.options', parkingId),
+          addOp('conferences./2024.accommodations.hotels', hotelId),
+          addOp('conferences./2024.meals.items', mealId),
+        ]);
+
+        const draft = yield* editor.load(siteScope);
+        const conf = draft.content.conferences.find((c) => c.slug === '/2024');
+        return {
+          source: draft.source,
+          parkingIds: (conf?.parking.options ?? []).map((item) => String(item.id)),
+          hotelIds: (conf?.accommodations.hotels ?? []).map((item) => String(item.id)),
+          mealIds: (conf?.meals.items ?? []).map((item) => String(item.id)),
+          addedHotelRoomRates: conf?.accommodations.hotels.find(
+            (item) => String(item.id) === String(hotelId),
+          )?.roomRates,
+        };
+      }),
+      { [SITE_CONTENT_KEY]: { body: seed } },
+    );
+
+    expect(result.source).toBe('draft');
+    expect(result.parkingIds).toContain(String(parkingId));
+    expect(result.hotelIds).toContain(String(hotelId));
+    expect(result.mealIds).toContain(String(mealId));
+    expect(result.addedHotelRoomRates).toEqual([]);
+  });
+
   it('add → untouched Save draft succeeds (an incomplete item blocks publish, not save)', async () => {
     const seed = await seedBody();
     const newId = newListItemId();

--- a/app/lib/content/conference-section-defaults.ts
+++ b/app/lib/content/conference-section-defaults.ts
@@ -9,7 +9,6 @@ const placeholder = { en: '—', fr: '—' } as const;
 export const disabledTravelSection = {
   enabled: false,
   headerCopy: { en: 'Travel', fr: 'Voyage' },
-  bodyCopy: placeholder,
 } as const;
 
 export const disabledParkingSection = {

--- a/app/lib/content/conference-section-defaults.ts
+++ b/app/lib/content/conference-section-defaults.ts
@@ -1,0 +1,51 @@
+/**
+ * Disabled-by-default conference section shapes for backfill and bundled defaults.
+ * Placeholder copy satisfies strict `Text` (both locales non-empty) while sections
+ * remain invisible until `enabled: true` in CMS.
+ */
+
+const placeholder = { en: '—', fr: '—' } as const;
+
+export const disabledTravelSection = {
+  enabled: false,
+  headerCopy: { en: 'Travel', fr: 'Voyage' },
+  bodyCopy: placeholder,
+} as const;
+
+export const disabledParkingSection = {
+  enabled: false,
+  headerCopy: { en: 'Parking', fr: 'Stationnement' },
+  options: [],
+} as const;
+
+export const disabledAccommodationsSection = {
+  enabled: false,
+  headerCopy: { en: 'Accommodations', fr: 'Hébergement' },
+  hotels: [],
+} as const;
+
+export const disabledMealsSection = {
+  enabled: false,
+  headerCopy: { en: 'Meals', fr: 'Repas' },
+  bodyCopy: placeholder,
+  items: [],
+} as const;
+
+export const disabledRegistrationCopySection = {
+  enabled: false,
+  title: { en: 'Register Now!', fr: 'Inscrivez-vous!' },
+  subtitle: {
+    en: 'Registration is now open. Secure your spot today!',
+    fr: 'Les inscriptions sont ouvertes. Réservez votre place dès aujourd’hui!',
+  },
+  buttonLabel: { en: 'Register Now', fr: "S'inscrire" },
+} as const;
+
+export const disabledFaqCopySection = {
+  enabled: false,
+  title: { en: 'Got Questions?', fr: 'Des questions?' },
+  subtitle: {
+    en: 'We are here to help. Reach out or browse our FAQ.',
+    fr: 'Nous sommes là pour vous aider. Contactez-nous ou consultez notre FAQ.',
+  },
+} as const;

--- a/app/lib/content/defaults.ts
+++ b/app/lib/content/defaults.ts
@@ -1,6 +1,14 @@
 import { Schema } from "effect";
 
 import { root } from "../localization/translations";
+import {
+  disabledAccommodationsSection,
+  disabledFaqCopySection,
+  disabledMealsSection,
+  disabledParkingSection,
+  disabledRegistrationCopySection,
+  disabledTravelSection,
+} from "./conference-section-defaults";
 import { deterministicListItemId, SiteContent } from "./schema";
 
 /**
@@ -93,46 +101,106 @@ export const defaultContent: SiteContent = Schema.decodeUnknownSync(
         "https://gyccanada.regfox.com/gyc-canada-2024-while-it-is-day",
       scheduleUrl:
         "https://docs.google.com/document/d/1gNAOfdW2Yhgg7FABjUqQt2k2mXV_AdhARWUOyiVL9dA/pub",
-      mapEmbedUrl:
-        "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2570.54720532797!2d-119.4124495876084!3d49.888529227544645!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x537d8d28862f4bfd%3A0xd41402dfff0455f4!2s130%20Gerstmar%20Rd%2C%20Kelowna%2C%20BC%20V1X%204A7!5e0!3m2!1sen!2sca!4v1720988332743!5m2!1sen!2sca",
-      hotels: [
-        {
-          id: "hQ1c8mZrT0vK4nXpL9aWd",
-          name: {
-            en: "Super 8 by Wyndham Kelowna BC",
-            fr: "Super 8 by Wyndham Kelowna BC",
-          },
+      learnMoreEnabled: false,
+      travel: {
+        enabled: true,
+        headerCopy: { en: "Travel", fr: "Voyage" },
+        bodyCopy: {
+          en: "The conference will be at 130 Gerstmar Rd, Kelowna, BC V1X 4A7.",
+          fr: "La conférence aura lieu au 130 Gerstmar Rd, Kelowna, BC V1X 4A7.",
         },
-        {
-          id: "rB7yN2eJ5sU0wG3kP8xQv",
-          name: {
-            en: "Fairfield Inn & Suites Kelowna",
-            fr: "Fairfield Inn & Suites Kelowna",
-          },
-          note: {
-            en: 'Holiday Inn Express & Suites Kelowna — "GYC Canada" or Group Code: "GYC" (call 778-484-2999 for discount)',
-            fr: 'Holiday Inn Express & Suites Kelowna — « GYC Canada » ou code de groupe : « GYC » (appelez le 778-484-2999 pour le rabais)',
-          },
+        mapEmbedUrl:
+          "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2570.54720532797!2d-119.4124495876084!3d49.888529227544645!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x537d8d28862f4bfd%3A0xd41402dfff0455f4!2s130%20Gerstmar%20Rd%2C%20Kelowna%2C%20BC%20V1X%204A7!5e0!3m2!1sen!2sca!4v1720988332743!5m2!1sen!2sca",
+      },
+      parking: { ...disabledParkingSection },
+      accommodations: {
+        enabled: true,
+        headerCopy: {
+          en: "There are quite a few hotels in Kelowna, BC. We've listed the closest hotels to the venue below.",
+          fr: "Il y a plusieurs hôtels à Kelowna, en Colombie-Britannique. Nous avons répertorié les hôtels les plus proches du lieu ci-dessous.",
         },
-        {
-          id: "tF9pX4kW6mD1cR8vN3sLb",
-          name: {
-            en: "Microtel Inn & Suites by Wyndham Kelowna",
-            fr: "Microtel Inn & Suites by Wyndham Kelowna",
+        hotels: [
+          {
+            id: "hQ1c8mZrT0vK4nXpL9aWd",
+            name: {
+              en: "Super 8 by Wyndham Kelowna BC",
+              fr: "Super 8 by Wyndham Kelowna BC",
+            },
+            address: {
+              en: "Kelowna, BC",
+              fr: "Kelowna, BC",
+            },
+            roomRates: [],
           },
-        },
-        {
-          id: "yK2nV7bH5jQ0dT8wM4xPc",
-          name: { en: "Comfort Suites", fr: "Comfort Suites" },
-        },
-        {
-          id: "zL6mC3gR9pW1kN7vX5sQt",
-          name: {
-            en: "Kelowna Days Inn by Wyndham Kelowna",
-            fr: "Kelowna Days Inn by Wyndham Kelowna",
+          {
+            id: "rB7yN2eJ5sU0wG3kP8xQv",
+            name: {
+              en: "Fairfield Inn & Suites Kelowna",
+              fr: "Fairfield Inn & Suites Kelowna",
+            },
+            address: {
+              en: "Kelowna, BC",
+              fr: "Kelowna, BC",
+            },
+            description: {
+              en: 'Holiday Inn Express & Suites Kelowna — "GYC Canada" or Group Code: "GYC" (call 778-484-2999 for discount)',
+              fr: 'Holiday Inn Express & Suites Kelowna — « GYC Canada » ou code de groupe : « GYC » (appelez le 778-484-2999 pour le rabais)',
+            },
+            roomRates: [],
           },
+          {
+            id: "tF9pX4kW6mD1cR8vN3sLb",
+            name: {
+              en: "Microtel Inn & Suites by Wyndham Kelowna",
+              fr: "Microtel Inn & Suites by Wyndham Kelowna",
+            },
+            address: {
+              en: "Kelowna, BC",
+              fr: "Kelowna, BC",
+            },
+            roomRates: [],
+          },
+          {
+            id: "yK2nV7bH5jQ0dT8wM4xPc",
+            name: { en: "Comfort Suites", fr: "Comfort Suites" },
+            address: {
+              en: "Kelowna, BC",
+              fr: "Kelowna, BC",
+            },
+            roomRates: [],
+          },
+          {
+            id: "zL6mC3gR9pW1kN7vX5sQt",
+            name: {
+              en: "Kelowna Days Inn by Wyndham Kelowna",
+              fr: "Kelowna Days Inn by Wyndham Kelowna",
+            },
+            address: {
+              en: "Kelowna, BC",
+              fr: "Kelowna, BC",
+            },
+            roomRates: [],
+          },
+        ],
+      },
+      meals: { ...disabledMealsSection },
+      registrationCopy: {
+        enabled: true,
+        title: { en: "Register Now!", fr: "Inscrivez-vous!" },
+        subtitle: {
+          en: "Registration is now open. Secure your spot today!",
+          fr: "Les inscriptions sont ouvertes. Réservez votre place dès aujourd’hui!",
         },
-      ],
+        buttonLabel: { en: "Register Now", fr: "S'inscrire" },
+      },
+      faqCopy: {
+        enabled: true,
+        title: { en: "Got Questions?", fr: "Des questions?" },
+        subtitle: {
+          en: "We are here to help. Reach out or browse our FAQ.",
+          fr: "Nous sommes là pour vous aider. Contactez-nous ou consultez notre FAQ.",
+        },
+      },
       location: {
         en: "130 Gerstmar Rd, Kelowna, BC V1X 4A7",
         fr: "130 Gerstmar Rd, Kelowna, BC V1X 4A7",
@@ -301,11 +369,20 @@ lives in Michigan with his wife and daughter where he works as a pastor.
         },
       },
       dates: { start: "2025-08-20", end: "2025-08-24" },
-      // No pricing for 2025 — omit `registration` (decodes to `Option.none()`).
-      // Cancelled year: omit every optional detail field (registrationUrl /
-      // scheduleUrl / mapEmbedUrl decode to `Option.none()`) and carry no hotels,
-      // so Branch 4's section-skip renders 2025 as hero + FAQ only.
-      hotels: [],
+      learnMoreEnabled: false,
+      travel: { ...disabledTravelSection },
+      parking: { ...disabledParkingSection },
+      accommodations: { ...disabledAccommodationsSection },
+      meals: { ...disabledMealsSection },
+      registrationCopy: { ...disabledRegistrationCopySection },
+      faqCopy: {
+        enabled: true,
+        title: { en: "Got Questions?", fr: "Des questions?" },
+        subtitle: {
+          en: "We are here to help. Reach out or browse our FAQ.",
+          fr: "Nous sommes là pour vous aider. Contactez-nous ou consultez notre FAQ.",
+        },
+      },
       location: { en: "Montreal, QC", fr: "Montréal, QC" },
       tagline: {
         en: '"And after the earthquake a fire, but the Lord was not in the fire; and after the fire a still small voice."',
@@ -361,7 +438,28 @@ lives in Michigan with his wife and daughter where he works as a pastor.
       // TBD, so those optional fields are omitted and `hotels` is empty. This sets
       // up Branch 4's skip proof: /2026 renders hero + Register button + FAQ only.
       registrationUrl: "https://gyccanada.regfox.com/gyc-canada-2026-speak",
-      hotels: [],
+      learnMoreEnabled: false,
+      travel: { ...disabledTravelSection },
+      parking: { ...disabledParkingSection },
+      accommodations: { ...disabledAccommodationsSection },
+      meals: { ...disabledMealsSection },
+      registrationCopy: {
+        enabled: true,
+        title: { en: "Register Now!", fr: "Inscrivez-vous!" },
+        subtitle: {
+          en: "Registration is now open. Secure your spot today!",
+          fr: "Les inscriptions sont ouvertes. Réservez votre place dès aujourd’hui!",
+        },
+        buttonLabel: { en: "Register Now", fr: "S'inscrire" },
+      },
+      faqCopy: {
+        enabled: true,
+        title: { en: "Got Questions?", fr: "Des questions?" },
+        subtitle: {
+          en: "We are here to help. Reach out or browse our FAQ.",
+          fr: "Nous sommes là pour vous aider. Contactez-nous ou consultez notre FAQ.",
+        },
+      },
       location: {
         en: "Ramada Plaza by Wyndham Calgary Downtown, Calgary, AB",
         fr: "Ramada Plaza by Wyndham Calgary Downtown, Calgary, AB",

--- a/app/lib/content/defaults.ts
+++ b/app/lib/content/defaults.ts
@@ -9,7 +9,11 @@ import {
   disabledRegistrationCopySection,
   disabledTravelSection,
 } from "./conference-section-defaults";
-import { deterministicListItemId, SiteContent } from "./schema";
+import {
+  deterministicListItemId,
+  DraftSiteContent,
+  SiteContent,
+} from "./schema";
 
 /**
  * The bundled-default `SiteContent` document (CMS plan §"Defaults / seed",
@@ -526,3 +530,12 @@ lives in Michigan with his wife and daughter where he works as a pastor.
     fr: { ...root.fr },
   },
 });
+
+/**
+ * The editor fallback: the same document as `defaultContent`, but decoded through
+ * `DraftSiteContent` so optional URL fields are plain `string | undefined` (not
+ * `Option`) and the admin loader can encode for the form without a schema mismatch.
+ */
+export const defaultDraftContent: DraftSiteContent = Schema.decodeUnknownSync(
+  DraftSiteContent,
+)(Schema.encodeUnknownSync(SiteContent)(defaultContent));

--- a/app/lib/content/defaults.ts
+++ b/app/lib/content/defaults.ts
@@ -9,11 +9,7 @@ import {
   disabledRegistrationCopySection,
   disabledTravelSection,
 } from "./conference-section-defaults";
-import {
-  deterministicListItemId,
-  DraftSiteContent,
-  SiteContent,
-} from "./schema";
+import { deterministicListItemId, DraftSiteContent, SiteContent } from './schema.server';
 
 /**
  * The bundled-default `SiteContent` document (CMS plan §"Defaults / seed",

--- a/app/lib/content/draft-editor.server.test.ts
+++ b/app/lib/content/draft-editor.server.test.ts
@@ -183,6 +183,11 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
       expect(result.content.conferences).toHaveLength(
         defaultContent.conferences.length,
       );
+      // The admin view encodes through `DraftSiteContent`; defaults must use the
+      // draft-lax field shapes (plain optional strings), not strict `Option`s.
+      expect(
+        Schema.encodeUnknownSync(DraftSiteContent)(result.content),
+      ).toBeDefined();
     }).pipe(provideEditor(adminStorage({}))),
   );
 

--- a/app/lib/content/draft-editor.server.test.ts
+++ b/app/lib/content/draft-editor.server.test.ts
@@ -37,7 +37,7 @@ import {
 } from './pages/registry';
 import { FormDefinition } from '../forms/definition';
 import { FaqPage } from './pages/schema';
-import { BoardMember, deterministicListItemId, DraftSiteContent, SiteContent } from './schema';
+import { BoardMember, deterministicListItemId, DraftSiteContent, SiteContent } from './schema.server';
 import type {
   DraftSiteContent as DraftSiteContentType,
   SiteContent as SiteContentType,

--- a/app/lib/content/draft-editor.server.test.ts
+++ b/app/lib/content/draft-editor.server.test.ts
@@ -185,9 +185,10 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
       );
       // The admin view encodes through `DraftSiteContent`; defaults must use the
       // draft-lax field shapes (plain optional strings), not strict `Option`s.
-      expect(
-        Schema.encodeUnknownSync(DraftSiteContent)(result.content),
-      ).toBeDefined();
+      const encoded = yield* Schema.encodeUnknownEffect(DraftSiteContent)(
+        result.content,
+      );
+      expect(encoded).toBeDefined();
     }).pipe(provideEditor(adminStorage({}))),
   );
 

--- a/app/lib/content/draft-editor.server.test.ts
+++ b/app/lib/content/draft-editor.server.test.ts
@@ -37,7 +37,7 @@ import {
 } from './pages/registry';
 import { FormDefinition } from '../forms/definition';
 import { FaqPage } from './pages/schema';
-import { BoardMember, deterministicListItemId, SiteContent } from './schema';
+import { BoardMember, deterministicListItemId, DraftSiteContent, SiteContent } from './schema';
 import type {
   DraftSiteContent as DraftSiteContentType,
   SiteContent as SiteContentType,
@@ -51,8 +51,16 @@ const boardMember = (name: string) =>
   });
 
 const boardNames = (
-  board: ReadonlyArray<{ readonly name: string }>,
-): readonly string[] => board.map((member) => member.name);
+  board: ReadonlyArray<{ readonly name?: string }>,
+): readonly string[] => board.map((member) => member.name ?? '');
+
+const draftWithBoard = (name: string) =>
+  Schema.decodeUnknownSync(DraftSiteContent)(
+    Schema.encodeUnknownSync(SiteContent)({
+      ...defaultContent,
+      board: [boardMember(name)],
+    }),
+  );
 
 const decodeJson = Schema.decodeUnknownEffect(Schema.fromJsonString(SiteContent));
 // Decode the encoded OBJECT a DraftEditor write returns (not a JSON string).
@@ -69,6 +77,9 @@ const decodeObject = Schema.decodeUnknownEffect(SiteContent);
  */
 
 const encode = Schema.encodeUnknownEffect(Schema.fromJsonString(SiteContent));
+const encodeDraft = Schema.encodeUnknownEffect(
+  Schema.fromJsonString(DraftSiteContent),
+);
 
 const seededStorage = (
   doc: SiteContentType,
@@ -169,7 +180,9 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
       const editor = yield* DraftEditor.Service;
       const result = yield* editor.load(siteScope);
       expect(result.source).toBe('defaults');
-      expect(result.content).toEqual(defaultContent);
+      expect(result.content.conferences).toHaveLength(
+        defaultContent.conferences.length,
+      );
     }).pipe(provideEditor(adminStorage({}))),
   );
 
@@ -189,11 +202,8 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
 
   it.effect('uses a draft with no published document as a valid edit source', () =>
     Effect.gen(function* () {
-      const draftDoc = SiteContent.make({
-        ...defaultContent,
-        board: [boardMember('Draft With No Published')],
-      });
-      const draft = yield* encode(draftDoc);
+      const draftDoc = draftWithBoard('Draft With No Published');
+      const draft = yield* encodeDraft(draftDoc);
       const editor = yield* DraftEditor.Service;
       const storage = yield* Storage.Service;
       yield* storage.put(SITE_CONTENT_DRAFT_KEY, draft, 'application/json');
@@ -207,11 +217,8 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
     'prefers a draft saved after the last publish over the published document',
     () =>
       Effect.gen(function* () {
-        const draftDoc = SiteContent.make({
-          ...defaultContent,
-          board: [boardMember('Only In The Draft')],
-        });
-        const draft = yield* encode(draftDoc);
+        const draftDoc = draftWithBoard('Only In The Draft');
+        const draft = yield* encodeDraft(draftDoc);
         const editor = yield* DraftEditor.Service;
         const storage = yield* Storage.Service;
         // The published document is seeded at epoch; the draft is written AFTER
@@ -235,15 +242,12 @@ describe('DraftEditor.load (draft → published → defaults reconciliation)', (
     'ignores a stale draft that predates the published document (failed-delete / pre-existing draft)',
     () =>
       Effect.gen(function* () {
-        const staleDraftDoc = SiteContent.make({
-          ...defaultContent,
-          board: [boardMember('Stale Draft Values')],
-        });
+        const staleDraftDoc = draftWithBoard('Stale Draft Values');
         const publishedDoc = SiteContent.make({
           ...defaultContent,
           board: [boardMember('Freshly Published')],
         });
-        const staleDraft = yield* encode(staleDraftDoc);
+        const staleDraft = yield* encodeDraft(staleDraftDoc);
         const published = yield* encode(publishedDoc);
         const editor = yield* DraftEditor.Service;
         const storage = yield* Storage.Service;

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -17,7 +17,7 @@ import {
   setAtPath,
   type Json,
 } from './admin-form';
-import { defaultContent } from './defaults';
+import { defaultDraftContent } from './defaults';
 import { backfillListItemIds } from './id-backfill';
 import { applyListEdit, type ListOp } from './list-edit';
 import {
@@ -321,7 +321,7 @@ const encodeSitePublishJson = Schema.encodeUnknownEffect(
 
 const siteCodec: ScopeCodec = {
   keys: scopeKeys(siteScope),
-  default: defaultContent,
+  default: defaultDraftContent,
   fromBucket: (json) =>
     parseJson(json).pipe(
       Effect.map(backfillListItemIds),

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -418,11 +418,13 @@ export class Service extends Context.Service<
   {
     /**
      * Load the document the `/admin` editor edits for `scope`: the unpublished
-     * draft when it is strictly newer than the published document, else the
+     * draft when it is at least as new as the published document, else the
      * published document, else the bundled defaults. The reconciliation is by
-     * bucket `lastModified`, not by mere draft *presence*, so a stale or
-     * failed-delete draft can never reopen as the edit source. Never fails (a
-     * bad draft is logged and ignored), so the editor always opens.
+     * bucket `lastModified`, not by mere draft *presence*, so a stale draft
+     * written before the last publish still loses. A tie goes to the draft so a
+     * list-op saved in the same second as the published object (common on
+     * second-granular S3/MinIO) reopens with the edit. Never fails (a bad draft
+     * is logged and ignored), so the editor always opens.
      */
     readonly load: <S extends ContentScope>(
       scope: S,
@@ -525,12 +527,12 @@ export const layer = Layer.effect(
           const publishedHead = yield* storage
             .head(publishedKey)
             .pipe(Effect.orElseSucceed(() => Option.none<ObjectHead>()));
-          const draftIsNewer =
+          const draftIsAtLeastAsNew =
             Option.isSome(draftHead) &&
             Option.isSome(publishedHead) &&
-            draftHead.value.lastModified.getTime() >
+            draftHead.value.lastModified.getTime() >=
               publishedHead.value.lastModified.getTime();
-          if (draftIsNewer) {
+          if (draftIsAtLeastAsNew) {
             return { content: draft.value, source: 'draft' as const };
           }
           return { content: published.value, source: 'published' as const };

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -682,7 +682,7 @@ export const layer = Layer.effect(
       // published object get written.
       const draftJson = yield* codec.encodeDraftJson(source).pipe(Effect.orDie);
       const strict = yield* parseJson(draftJson).pipe(
-        Effect.map(normalizeMergedSiteContent),
+        Effect.map((parsed) => normalizeMergedSiteContent(parsed as Json)),
         Effect.flatMap(codec.decodePublish),
         Effect.mapError(
           (error) =>

--- a/app/lib/content/draft-editor.server.ts
+++ b/app/lib/content/draft-editor.server.ts
@@ -13,6 +13,7 @@ import {
 } from '../content.server';
 import {
   deepMerge,
+  normalizeMergedSiteContent,
   pruneKeylessImageOverrides,
   setAtPath,
   type Json,
@@ -614,7 +615,7 @@ export const layer = Layer.effect(
       // image object never lands — that object is draft-valid but PUBLISH-invalid
       // (`<slot>.key: Missing key`). A no-op for every scope without those slots.
       const pruned = pruneKeylessImageOverrides(base, override);
-      const merged = deepMerge(base, pruned);
+      const merged = normalizeMergedSiteContent(deepMerge(base, pruned));
       const decoded = yield* decodeOrReject(codec, merged);
       return (yield* storeDraft(codec, decoded)) as ScopeEncoded<S>;
     });
@@ -679,6 +680,7 @@ export const layer = Layer.effect(
       // published object get written.
       const draftJson = yield* codec.encodeDraftJson(source).pipe(Effect.orDie);
       const strict = yield* parseJson(draftJson).pipe(
+        Effect.map(normalizeMergedSiteContent),
         Effect.flatMap(codec.decodePublish),
         Effect.mapError(
           (error) =>

--- a/app/lib/content/id-backfill.test.ts
+++ b/app/lib/content/id-backfill.test.ts
@@ -100,6 +100,31 @@ describe('backfillListItemIds — production read-safety (ADR 0006)', () => {
     }
   });
 
+  test('adds empty nested lists when a conference section exists without them', () => {
+    const doc = {
+      conferences: [
+        {
+          slug: '/2024',
+          parking: { enabled: false, headerCopy: { en: 'Parking', fr: 'P' } },
+          accommodations: {
+            enabled: false,
+            headerCopy: { en: 'Hotels', fr: 'H' },
+          },
+          meals: {
+            enabled: false,
+            headerCopy: { en: 'Meals', fr: 'M' },
+            bodyCopy: { en: '—', fr: '—' },
+          },
+        },
+      ],
+    };
+    const repaired = backfillListItemIds(doc) as JsonRecord;
+    const conference = (repaired['conferences'] as JsonRecord[])[0] as JsonRecord;
+    expect((conference['parking'] as JsonRecord)['options']).toEqual([]);
+    expect((conference['accommodations'] as JsonRecord)['hotels']).toEqual([]);
+    expect((conference['meals'] as JsonRecord)['items']).toEqual([]);
+  });
+
   test('a present-but-malformed accommodations.hotels is left for the decoder to reject', () => {
     for (const malformed of ['not a list', null, {}] as const) {
       const doc = stripIds(encodedDefaults());

--- a/app/lib/content/id-backfill.test.ts
+++ b/app/lib/content/id-backfill.test.ts
@@ -5,37 +5,28 @@ import { defaultContent } from './defaults';
 import { backfillListItemIds } from './id-backfill';
 import { SiteContent } from './schema';
 
-/**
- * The read-path id-backfill is the production read-safety hinge of ADR 0006:
- * adding a *required* `id` to every list item would make every already-published
- * `content/site.json` (which has no ids) FAIL decode on read — breaking the live
- * site on the deploy. `backfillListItemIds` runs between parse and decode and
- * assigns a fresh `nanoid` to any id-less item, so the legacy document decodes.
- * These tests pin that property, its idempotence, and that it never mints over
- * an existing id.
- */
-
 type JsonRecord = Record<string, unknown>;
 
-/** The encoded (plain-JSON) form of the bundled defaults — a real test base. */
 const encodedDefaults = (): JsonRecord =>
   Schema.encodeUnknownSync(SiteContent)(defaultContent) as JsonRecord;
 
 const decodes = (value: unknown): boolean =>
   Result.isSuccess(Schema.decodeUnknownResult(SiteContent)(value));
 
-/** A deep clone the test can mutate without disturbing the shared default. */
 const clone = (value: JsonRecord): JsonRecord =>
   JSON.parse(JSON.stringify(value)) as JsonRecord;
 
-/** Strip every list-item `id` — the shape a document published BEFORE ids had. */
 const stripIds = (encoded: JsonRecord): JsonRecord => {
   const doc = clone(encoded);
   for (const conference of (doc['conferences'] as JsonRecord[]) ?? []) {
-    for (const listKey of ['speakers', 'seminars', 'hotels']) {
+    for (const listKey of ['speakers', 'seminars']) {
       for (const item of (conference[listKey] as JsonRecord[]) ?? []) {
         delete item['id'];
       }
+    }
+    const accommodations = conference['accommodations'] as JsonRecord | undefined;
+    for (const item of (accommodations?.['hotels'] as JsonRecord[]) ?? []) {
+      delete item['id'];
     }
   }
   for (const member of (doc['team'] as JsonRecord[]) ?? []) {
@@ -44,39 +35,37 @@ const stripIds = (encoded: JsonRecord): JsonRecord => {
   return doc;
 };
 
-/**
- * The shape of a `content/site.json` published BEFORE Branch 3.1 added the
- * (required) `hotels` field: every conference is missing the `hotels` key
- * entirely (and the sibling optional URL fields). Used to pin that the read
- * boundary repairs the absent required list rather than failing decode and
- * silently falling back to bundled defaults — discarding live CMS content.
- */
-const pre31Shape = (encoded: JsonRecord): JsonRecord => {
+const preSectionShape = (encoded: JsonRecord): JsonRecord => {
   const doc = stripIds(encoded);
   for (const conference of (doc['conferences'] as JsonRecord[]) ?? []) {
-    delete conference['hotels'];
-    delete conference['registrationUrl'];
-    delete conference['scheduleUrl'];
-    delete conference['mapEmbedUrl'];
+    delete conference['travel'];
+    delete conference['parking'];
+    delete conference['accommodations'];
+    delete conference['meals'];
+    delete conference['registrationCopy'];
+    delete conference['faqCopy'];
+    delete conference['learnMoreEnabled'];
   }
   return doc;
 };
 
-/** Ids on the conference lists only (speakers + seminars + hotels). */
 const conferenceIdsOf = (doc: unknown): string[] => {
   const out: string[] = [];
   const record = doc as JsonRecord;
   for (const conference of (record['conferences'] as JsonRecord[]) ?? []) {
-    for (const listKey of ['speakers', 'seminars', 'hotels']) {
+    for (const listKey of ['speakers', 'seminars']) {
       for (const item of (conference[listKey] as JsonRecord[]) ?? []) {
         if (typeof item['id'] === 'string') out.push(item['id']);
       }
+    }
+    const accommodations = conference['accommodations'] as JsonRecord | undefined;
+    for (const item of (accommodations?.['hotels'] as JsonRecord[]) ?? []) {
+      if (typeof item['id'] === 'string') out.push(item['id']);
     }
   }
   return out;
 };
 
-/** Ids on the team list only. */
 const teamIdsOf = (doc: unknown): string[] => {
   const out: string[] = [];
   for (const member of ((doc as JsonRecord)['team'] as JsonRecord[]) ?? []) {
@@ -93,56 +82,39 @@ const idsOf = (doc: unknown): string[] => [
 describe('backfillListItemIds — production read-safety (ADR 0006)', () => {
   test('an id-less document (the pre-migration shape) decodes after backfill', () => {
     const idLess = stripIds(encodedDefaults());
-
-    // Sanity: WITHOUT backfill the legacy document fails decode — this is the
-    // hazard the backfill exists to prevent.
     expect(decodes(idLess)).toBe(false);
-
-    // WITH backfill it decodes — the deploy does not break the live site.
     const repaired = backfillListItemIds(idLess);
     expect(decodes(repaired)).toBe(true);
   });
 
-  test('a pre-3.1 document (no `hotels` key) decodes after backfill', () => {
-    const pre31 = pre31Shape(encodedDefaults());
-
-    // Sanity: WITHOUT backfill the pre-3.1 document fails decode because
-    // `hotels` is a required (Branch 3.1) field that the legacy shape lacks —
-    // the very read-safety hazard that would otherwise discard live CMS content
-    // and silently fall back to the bundled defaults.
-    expect(decodes(pre31)).toBe(false);
-
-    // WITH backfill every conference gains an empty `hotels: []` (plus ids), so
-    // the live document decodes and the deploy keeps the CMS-authored content.
-    const repaired = backfillListItemIds(pre31);
+  test('a pre-section document (no section keys) decodes after backfill', () => {
+    const legacy = preSectionShape(encodedDefaults());
+    expect(decodes(legacy)).toBe(false);
+    const repaired = backfillListItemIds(legacy);
     expect(decodes(repaired)).toBe(true);
     for (const conference of (repaired as JsonRecord)[
       'conferences'
     ] as JsonRecord[]) {
-      expect(Array.isArray(conference['hotels'])).toBe(true);
+      expect(conference['travel']).toBeDefined();
+      expect(conference['accommodations']).toBeDefined();
     }
   });
 
-  test('a present-but-malformed `hotels` is left for the decoder to reject, not silently emptied', () => {
-    // A pre-3.1 document is missing the `hotels` KEY (handled by the test above:
-    // it normalizes to `[]`). This pins the *opposite* hazard: a conference
-    // whose `hotels` key is PRESENT but the wrong shape (a string here; `null`
-    // and `{}` are equivalent) must NOT be overwritten with `[]` — doing so
-    // would silently discard authored content before strict decode. Backfill
-    // leaves it untouched so the decoder is the one to reject it, exactly like
-    // a malformed speakers/seminars/team list.
+  test('a present-but-malformed accommodations.hotels is left for the decoder to reject', () => {
     for (const malformed of ['not a list', null, {}] as const) {
       const doc = stripIds(encodedDefaults());
       const firstConference = (doc['conferences'] as JsonRecord[])[0];
-      if (firstConference) firstConference['hotels'] = malformed as never;
+      const accommodations = (firstConference?.['accommodations'] ??
+        {}) as JsonRecord;
+      accommodations['hotels'] = malformed as never;
+      if (firstConference) firstConference['accommodations'] = accommodations;
 
       const repaired = backfillListItemIds(doc) as JsonRecord;
       const repairedConference = (repaired['conferences'] as JsonRecord[])[0];
-
-      // The malformed value survives verbatim — it was NOT replaced with `[]`.
-      expect(repairedConference?.['hotels']).toEqual(malformed as never);
-      // …and the decoder rejects the document rather than accepting an
-      // emptied-out conference (the masking this guards against).
+      const repairedAccommodations = repairedConference?.[
+        'accommodations'
+      ] as JsonRecord;
+      expect(repairedAccommodations?.['hotels']).toEqual(malformed as never);
       expect(decodes(repaired)).toBe(false);
     }
   });
@@ -150,19 +122,14 @@ describe('backfillListItemIds — production read-safety (ADR 0006)', () => {
   test('assigns a fresh, distinct id to every id-less list item', () => {
     const idLess = stripIds(encodedDefaults());
     expect(idsOf(idLess)).toHaveLength(0);
-
     const repaired = backfillListItemIds(idLess);
-    // 2024 has 2 speakers + 3 seminars + 5 hotels; team has 3 members = 13 ids.
     expect(idsOf(repaired)).toHaveLength(13);
     expect(new Set(idsOf(repaired)).size).toBe(13);
   });
 
   test('is idempotent — re-running leaves an already-id-complete document untouched', () => {
     const encoded = encodedDefaults();
-    // The defaults already carry ids; backfill must change nothing.
     expect(backfillListItemIds(encoded)).toEqual(encoded);
-
-    // And a freshly-backfilled document is a fixed point.
     const once = backfillListItemIds(stripIds(encoded));
     const twice = backfillListItemIds(once);
     expect(twice).toEqual(once);
@@ -171,19 +138,14 @@ describe('backfillListItemIds — production read-safety (ADR 0006)', () => {
   test('never mints over an existing id (a partial document keeps its ids)', () => {
     const encoded = encodedDefaults();
     expect(idsOf(encoded)).toHaveLength(13);
-
-    // Strip only the team ids; the conference list ids must survive verbatim.
     const conferenceIds = conferenceIdsOf(encoded);
-    expect(conferenceIds).toHaveLength(10); // 2 speakers + 3 seminars + 5 hotels
+    expect(conferenceIds).toHaveLength(10);
     const doc = clone(encoded);
     for (const member of doc['team'] as JsonRecord[]) {
       delete member['id'];
     }
     const repaired = backfillListItemIds(doc);
-
-    // Every conference-list id (speakers, seminars, hotels) survives verbatim.
     expect(conferenceIdsOf(repaired)).toEqual(conferenceIds);
-    // Team got fresh ids, so the whole document now decodes.
     expect(decodes(repaired)).toBe(true);
   });
 
@@ -191,14 +153,10 @@ describe('backfillListItemIds — production read-safety (ADR 0006)', () => {
     const doc = clone(encodedDefaults());
     const firstTeam = (doc['team'] as JsonRecord[])[0];
     if (firstTeam) firstTeam['id'] = 'not a valid id';
-
     const repaired = backfillListItemIds(doc);
-    // The bad id is untouched (present → not backfilled)…
-    expect((repaired as JsonRecord)['team']).toBeDefined();
     expect(((repaired as JsonRecord)['team'] as JsonRecord[])[0]?.['id']).toBe(
       'not a valid id',
     );
-    // …and the decoder rejects it.
     expect(decodes(repaired)).toBe(false);
   });
 
@@ -215,16 +173,11 @@ describe('backfillListItemIds — legacy board string[] migration', () => {
     const encoded = encodedDefaults();
     const legacy = clone(encoded);
     legacy['board'] = ['Alice Board', 'Bob Board'];
-
     expect(decodes(legacy)).toBe(false);
-
     const repaired = backfillListItemIds(legacy) as JsonRecord;
     const board = repaired['board'] as JsonRecord[];
     expect(board).toHaveLength(2);
     expect(board[0]?.['name']).toBe('Alice Board');
-    expect(board[1]?.['name']).toBe('Bob Board');
-    expect(typeof board[0]?.['id']).toBe('string');
-    expect(typeof board[1]?.['id']).toBe('string');
     expect(decodes(repaired)).toBe(true);
   });
 

--- a/app/lib/content/id-backfill.ts
+++ b/app/lib/content/id-backfill.ts
@@ -47,8 +47,12 @@ const backfillAccommodationHotels = (value: unknown): readonly Json[] | undefine
   return value.map((item) => {
     if (!isObject(item)) return item;
     const hotel: Record<string, Json> = { ...item };
-    const roomRates = backfillItems(item['roomRates']);
-    if (roomRates !== undefined) hotel['roomRates'] = roomRates;
+    if (!('roomRates' in hotel)) {
+      hotel['roomRates'] = [];
+    } else if (Array.isArray(hotel['roomRates'])) {
+      const roomRates = backfillItems(hotel['roomRates']);
+      if (roomRates !== undefined) hotel['roomRates'] = roomRates;
+    }
     return withId(hotel);
   });
 };
@@ -79,8 +83,11 @@ const backfillConferenceSections = (conference: Record<string, Json>): void => {
     conference['parking'] = { ...disabledParkingSection };
   } else if (isObject(conference['parking'])) {
     const parking = { ...conference['parking'] };
-    const options = backfillItems(parking['options']);
-    if (options !== undefined) parking['options'] = options;
+    if (!('options' in parking)) {
+      parking['options'] = [];
+    } else if (Array.isArray(parking['options'])) {
+      parking['options'] = backfillItems(parking['options']) ?? parking['options'];
+    }
     conference['parking'] = parking;
   }
 
@@ -88,8 +95,12 @@ const backfillConferenceSections = (conference: Record<string, Json>): void => {
     conference['accommodations'] = { ...disabledAccommodationsSection };
   } else if (isObject(conference['accommodations'])) {
     const accommodations = { ...conference['accommodations'] };
-    const hotels = backfillAccommodationHotels(accommodations['hotels']);
-    if (hotels !== undefined) accommodations['hotels'] = hotels;
+    if (!('hotels' in accommodations)) {
+      accommodations['hotels'] = [];
+    } else if (Array.isArray(accommodations['hotels'])) {
+      const hotels = backfillAccommodationHotels(accommodations['hotels']);
+      if (hotels !== undefined) accommodations['hotels'] = hotels;
+    }
     conference['accommodations'] = accommodations;
   }
 
@@ -97,8 +108,11 @@ const backfillConferenceSections = (conference: Record<string, Json>): void => {
     conference['meals'] = { ...disabledMealsSection };
   } else if (isObject(conference['meals'])) {
     const meals = { ...conference['meals'] };
-    const items = backfillItems(meals['items']);
-    if (items !== undefined) meals['items'] = items;
+    if (!('items' in meals)) {
+      meals['items'] = [];
+    } else if (Array.isArray(meals['items'])) {
+      meals['items'] = backfillItems(meals['items']) ?? meals['items'];
+    }
     conference['meals'] = meals;
   }
 

--- a/app/lib/content/id-backfill.ts
+++ b/app/lib/content/id-backfill.ts
@@ -11,42 +11,17 @@
  * The fix is a one-shot repair at the read boundary: before the document is
  * Schema-decoded, `backfillListItemIds` walks the parsed (untrusted) JSON and
  * assigns a fresh `nanoid` to any list item that lacks an `id`. It is a pure
- * structural normalization — NOT a parallel schema and NOT validation:
- *   - `derive-dont-sync`: there is one decode boundary; this only fills the gap
- *     a pre-ids document leaves, so the decoded value is always id-complete.
- *   - `make-operations-idempotent`: an item that already has an `id` key is left
- *     untouched (even a *bad* id is left for the decoder to reject — backfill is
- *     for absence, not repair), so re-running on an already-migrated document is
- *     a no-op. The first admin publish persists the backfilled ids; from then on
- *     the normalization changes nothing.
- *   - `boundary-discipline`: it runs only over already-parsed JSON inside the
- *     read path, never mutates its input, and hands a fresh value to the decoder
- *     which remains the sole gate that brands the ids. The input is `unknown`
- *     (raw parsed JSON), so the walk narrows defensively and never trusts shape.
- *
- * The list-item locations are the id-bearing structs the schema names today
- * (`Speaker`, `Seminar`, `Hotel`, `TeamMember`); Branch 3+ widens them as the
- * Conference / Page schemas grow id-bearing lists, and this walk grows with
- * them. The walk descends only into the arrays/objects that are actually present
- * and the expected shape, so a malformed document still reaches the decoder
- * (which rejects it) rather than throwing here.
- *
- * Branch 3.1 grows the Conference with a *required* `hotels: IdListArray(Hotel)`.
- * That is the same read-safety hazard as the required `id` itself: a
- * `content/site.json` published BEFORE 3.1 has no `hotels` key, so a required
- * field would FAIL decode on the next read and silently discard the live
- * CMS-authored content. A truly-*absent* `hotels` key normalizes to `[]`
- * (idempotent: a conference already carrying `hotels` keeps it, ids and all),
- * which is the one structural gap a pre-3.1 document leaves. A *present* but
- * malformed `hotels` (e.g. `null`, a string) is left in place so the decoder —
- * not this normalizer — rejects it, exactly like every other list above; the
- * `[]` default is reserved for an absent key and never overwrites authored
- * content. (The sibling URL
- * fields — `registrationUrl` / `scheduleUrl` / `mapEmbedUrl` — are
- * `OptionFromOptionalKey`, so their absence already decodes to `Option.none()`
- * and needs no backfill.)
+ * structural normalization — NOT a parallel schema and NOT validation.
  */
 
+import {
+  disabledAccommodationsSection,
+  disabledFaqCopySection,
+  disabledMealsSection,
+  disabledParkingSection,
+  disabledRegistrationCopySection,
+  disabledTravelSection,
+} from './conference-section-defaults';
 import { newListItemId } from './schema';
 import type { Json } from './admin-form';
 
@@ -65,6 +40,20 @@ const backfillItems = (value: unknown): readonly Json[] | undefined =>
   Array.isArray(value) ? value.map(withId) : undefined;
 
 /**
+ * Backfill ids on nested hotel room-rate lists inside accommodations.
+ */
+const backfillAccommodationHotels = (value: unknown): readonly Json[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  return value.map((item) => {
+    if (!isObject(item)) return item;
+    const hotel: Record<string, Json> = { ...item };
+    const roomRates = backfillItems(item['roomRates']);
+    if (roomRates !== undefined) hotel['roomRates'] = roomRates;
+    return withId(hotel);
+  });
+};
+
+/**
  * Migrate a legacy `board: string[]` to id-keyed `{ id, name }` objects. Items
  * that already carry an `id` pass through unchanged (idempotent).
  */
@@ -78,14 +67,53 @@ const backfillBoard = (value: unknown): readonly Json[] | undefined => {
   });
 };
 
+const backfillConferenceSections = (conference: Record<string, Json>): void => {
+  if (!('travel' in conference)) {
+    conference['travel'] = { ...disabledTravelSection };
+  } else if (isObject(conference['travel'])) {
+    const travel = { ...conference['travel'] };
+    conference['travel'] = travel;
+  }
+
+  if (!('parking' in conference)) {
+    conference['parking'] = { ...disabledParkingSection };
+  } else if (isObject(conference['parking'])) {
+    const parking = { ...conference['parking'] };
+    const options = backfillItems(parking['options']);
+    if (options !== undefined) parking['options'] = options;
+    conference['parking'] = parking;
+  }
+
+  if (!('accommodations' in conference)) {
+    conference['accommodations'] = { ...disabledAccommodationsSection };
+  } else if (isObject(conference['accommodations'])) {
+    const accommodations = { ...conference['accommodations'] };
+    const hotels = backfillAccommodationHotels(accommodations['hotels']);
+    if (hotels !== undefined) accommodations['hotels'] = hotels;
+    conference['accommodations'] = accommodations;
+  }
+
+  if (!('meals' in conference)) {
+    conference['meals'] = { ...disabledMealsSection };
+  } else if (isObject(conference['meals'])) {
+    const meals = { ...conference['meals'] };
+    const items = backfillItems(meals['items']);
+    if (items !== undefined) meals['items'] = items;
+    conference['meals'] = meals;
+  }
+
+  if (!('registrationCopy' in conference)) {
+    conference['registrationCopy'] = { ...disabledRegistrationCopySection };
+  }
+
+  if (!('faqCopy' in conference)) {
+    conference['faqCopy'] = { ...disabledFaqCopySection };
+  }
+};
+
 /**
  * Return a copy of the parsed `SiteContent` JSON with a fresh id assigned to any
- * id-less list item (`conferences[].speakers[]`, `conferences[].seminars[]`,
- * `conferences[].hotels[]`, `team[]`, `board[]`) and an empty `hotels: []` supplied to any
- * conference that predates 3.1 and lacks the (required) key. Items already
- * carrying an `id` — and a `hotels` array that is already present — are
- * untouched (idempotent). A value that is not the expected shape is returned
- * as-is so the decoder — not this normalizer — is the one to reject it.
+ * id-less list item and disabled defaults for any absent conference section keys.
  */
 export const backfillListItemIds = (document: unknown): unknown => {
   if (!isObject(document)) return document;
@@ -101,21 +129,7 @@ export const backfillListItemIds = (document: unknown): unknown => {
       if (speakers !== undefined) conf['speakers'] = speakers;
       const seminars = backfillItems(conference['seminars']);
       if (seminars !== undefined) conf['seminars'] = seminars;
-      // `hotels` is a *required* (Branch 3.1) id-keyed list. A pre-3.1 document
-      // has no key at all: supply `[]` so the absent required field decodes. A
-      // *present* `hotels` is backfilled like any other id list (and left as-is
-      // when already id-complete). Crucially, only a truly-ABSENT key is
-      // defaulted: a present-but-malformed value (`null`, `"x"`, `{}`) is left
-      // in place for the decoder to reject — exactly like speakers/seminars/team
-      // above. Defaulting it to `[]` would silently discard authored content
-      // BEFORE strict decode, which is precisely the masking this normalizer is
-      // documented (above) NOT to do.
-      if (!('hotels' in conference)) {
-        conf['hotels'] = [];
-      } else {
-        const hotels = backfillItems(conference['hotels']);
-        if (hotels !== undefined) conf['hotels'] = hotels;
-      }
+      backfillConferenceSections(conf);
       return conf;
     });
   }

--- a/app/lib/content/id-backfill.ts
+++ b/app/lib/content/id-backfill.ts
@@ -76,6 +76,16 @@ const backfillConferenceSections = (conference: Record<string, Json>): void => {
     conference['travel'] = { ...disabledTravelSection };
   } else if (isObject(conference['travel'])) {
     const travel = { ...conference['travel'] };
+    if (isObject(travel['airport'])) {
+      const airport = { ...travel['airport'] };
+      if (!('transitOptions' in airport)) {
+        airport['transitOptions'] = [];
+      } else if (Array.isArray(airport['transitOptions'])) {
+        airport['transitOptions'] =
+          backfillItems(airport['transitOptions']) ?? airport['transitOptions'];
+      }
+      travel['airport'] = airport;
+    }
     conference['travel'] = travel;
   }
 

--- a/app/lib/content/list-edit.test.ts
+++ b/app/lib/content/list-edit.test.ts
@@ -258,7 +258,7 @@ describe('applyListEdit — id-keyed, not positional', () => {
     ]) as {
       conferences: ReadonlyArray<{
         parking: { options: ReadonlyArray<{ id: string }> };
-        accommodations: { hotels: ReadonlyArray<{ id: string }> };
+        accommodations: { hotels: ReadonlyArray<{ id: string; roomRates: readonly unknown[] }> };
         meals: { items: ReadonlyArray<{ id: string }> };
       }>;
     };

--- a/app/lib/content/list-edit.test.ts
+++ b/app/lib/content/list-edit.test.ts
@@ -227,6 +227,51 @@ describe('applyListEdit — id-keyed, not positional', () => {
     expect(base).toEqual(snapshot);
   });
 
+  test('creates a missing nested section list when adding parking / hotel / meal items', () => {
+    const base: Json = {
+      conferences: [
+        {
+          slug: '/2024',
+          parking: {
+            enabled: false,
+            headerCopy: { en: 'Parking', fr: 'Stationnement' },
+          },
+          accommodations: {
+            enabled: true,
+            headerCopy: { en: 'Hotels', fr: 'Hébergement' },
+          },
+          meals: {
+            enabled: false,
+            headerCopy: { en: 'Meals', fr: 'Repas' },
+            bodyCopy: { en: '—', fr: '—' },
+          },
+        },
+      ],
+    };
+    const parkingId = id('parking-option-id00001');
+    const hotelId = id('hotel-item-id000000001');
+    const mealId = id('meal-item-id000000001');
+    const next = applyListEdit(base, [
+      addOp('conferences./2024.parking.options', parkingId),
+      addOp('conferences./2024.accommodations.hotels', hotelId),
+      addOp('conferences./2024.meals.items', mealId),
+    ]) as {
+      conferences: ReadonlyArray<{
+        parking: { options: ReadonlyArray<{ id: string }> };
+        accommodations: { hotels: ReadonlyArray<{ id: string }> };
+        meals: { items: ReadonlyArray<{ id: string }> };
+      }>;
+    };
+    const conf = next.conferences[0];
+    expect(conf?.parking.options.map((item) => item.id)).toEqual(['parking-option-id00001']);
+    expect(conf?.accommodations.hotels.map((item) => item.id)).toEqual(['hotel-item-id000000001']);
+    expect(conf?.meals.items.map((item) => item.id)).toEqual(['meal-item-id000000001']);
+    expect(conf?.accommodations.hotels[0]).toEqual({
+      id: 'hotel-item-id000000001',
+      roomRates: [],
+    });
+  });
+
   test('a listPath that does not resolve to an array is left untouched', () => {
     const base: Json = { team: list({ id: 'a' }) };
     const next = applyListEdit(base, [addOp('missing', id('b'))]);

--- a/app/lib/content/list-edit.ts
+++ b/app/lib/content/list-edit.ts
@@ -96,13 +96,20 @@ const navIdentity = (item: Json): string | undefined => {
  * op kinds are exhaustive over the `ListOp` union, so adding a kind without
  * handling it is a type error (`make-impossible-states-unrepresentable`).
  */
+const stubListItem = (listPath: ListPath, id: ListItemId): Json => {
+  if (listPath.endsWith('.hotels')) {
+    return { id, roomRates: [] };
+  }
+  return { id };
+};
+
 const applyOp = (list: readonly Json[], op: ListOp): readonly Json[] => {
   if ('add' in op) {
     // Appending a duplicate id would make two items share an identity, which the
     // id-keyed merge could no longer distinguish — guard it (the caller mints a
     // fresh id, so this only fires on a malformed resubmission).
     if (list.some((item) => itemId(item) === op.add.id)) return list;
-    return [...list, { id: op.add.id }];
+    return [...list, stubListItem(op.add.listPath, op.add.id)];
   }
   if ('remove' in op) {
     return list.filter((item) => itemId(item) !== op.remove.id);
@@ -146,22 +153,41 @@ const updateListAtPath = (
   root: Json,
   path: readonly string[],
   update: (list: readonly Json[]) => readonly Json[],
+  depth = 0,
 ): Json => {
-  const [head, ...rest] = path;
-  if (head === undefined) {
+  if (path.length === 0) {
     return Array.isArray(root) ? update(root) : root;
   }
+  const [head, ...rest] = path;
+  if (head === undefined) return root;
+
   if (Array.isArray(root)) {
     const index = root.findIndex((item) => navIdentity(item) === head);
     if (index < 0) return root;
     const next = [...root];
-    next[index] = updateListAtPath(root[index] as Json, rest, update);
+    next[index] = updateListAtPath(root[index] as Json, rest, update, depth + 1);
     return next;
   }
+
   if (isPlainObject(root)) {
-    if (!(head in root)) return root;
-    return { ...root, [head]: updateListAtPath(root[head] as Json, rest, update) };
+    if (!(head in root)) {
+      if (rest.length > 0) {
+        return {
+          ...root,
+          [head]: updateListAtPath({}, rest, update, depth + 1),
+        };
+      }
+      // A missing top-level list path is a no-op; nested section lists may be
+      // materialized on add (e.g. parking.options on a legacy section object).
+      if (depth === 0) return root;
+      return { ...root, [head]: update([]) };
+    }
+    return {
+      ...root,
+      [head]: updateListAtPath(root[head] as Json, rest, update, depth + 1),
+    };
   }
+
   return root;
 };
 

--- a/app/lib/content/schema.server.ts
+++ b/app/lib/content/schema.server.ts
@@ -1,0 +1,48 @@
+/**
+ * Server-only extensions to `schema.ts` that rely on `node:crypto`.
+ *
+ * `schema.ts` is imported by client-side routes (admin UI, forms) so it must
+ * not import `node:crypto` — Vite externalises that module and installs a
+ * Proxy that **throws** on any property access, killing React hydration
+ * silently. Everything here is server-only (`.server.ts` suffix keeps it out
+ * of the browser bundle).
+ */
+
+import { createHash } from 'node:crypto';
+
+export * from './schema';
+import { ListItemId } from './schema';
+
+/**
+ * nanoid's URL-safe default alphabet (`A-Za-z0-9_-`, 64 chars) — the alphabet a
+ * {@link ListItemId} validates against. {@link deterministicListItemId} maps a
+ * hash digest into it so a derived id is byte-for-byte a nanoid (same shape the
+ * brand's pattern accepts), not a hex/base64 string the schema would reject.
+ */
+const NANOID_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+
+/**
+ * Derive a **deterministic**, schema-valid `ListItemId` from an idempotency
+ * `key` — the SAME `key` always yields the SAME id. Unlike {@link newListItemId}
+ * (a fresh random nanoid per call), this lets a write be idempotent: a retry of
+ * the same logical record re-derives the same id → the same bucket key → the
+ * `Storage.put` overwrites rather than minting a duplicate object
+ * (registration-launch Branch 7.3 follow-up — the registration multi-registrant
+ * partial-write the deep review escalated). The 21-char output is shaped like a
+ * nanoid (it maps a SHA-256 digest into nanoid's alphabet), so it satisfies the
+ * `ListItemId` pattern; it is NOT a random nanoid and is not meant to be
+ * unguessable — it is a content-addressed id, derived not authored.
+ */
+export const deterministicListItemId = (key: string): ListItemId => {
+  // SHA-256 → 32 bytes; take the first 21 and fold each into nanoid's 64-char
+  // alphabet (a clean `& 63` mask — 64 divides 256, so no modulo bias).
+  const digest = createHash('sha256').update(key).digest();
+  let id = '';
+  for (let i = 0; i < 21; i += 1) {
+    // `digest` is 32 bytes, so `digest[i]` for i<21 is always a byte; `& 63` keeps
+    // the index in `[0, 63]`, always a valid position in the 64-char alphabet.
+    id += NANOID_ALPHABET.charAt((digest[i] ?? 0) & 63);
+  }
+  return ListItemId.make(id);
+};

--- a/app/lib/content/schema.test.ts
+++ b/app/lib/content/schema.test.ts
@@ -456,10 +456,7 @@ describe('DraftSiteContent (draft-lax / publish-strict)', () => {
 });
 
 /**
- * Append `extraHotel` to the /2024 conference's `hotels`. Typed `unknown`→record
- * so a deliberately-empty / half-filled `Hotel` (the present-but-empty cases
- * under test) can be constructed without satisfying the strict encoded `Hotel`
- * shape.
+ * Append `extraHotel` to the /2024 conference's `accommodations.hotels`.
  */
 const withExtraHotel = (
   encoded: typeof SiteContent.Encoded,
@@ -468,37 +465,34 @@ const withExtraHotel = (
   const doc = encoded as unknown as {
     conferences: ReadonlyArray<{
       slug: string;
-      hotels: readonly unknown[];
+      accommodations: { hotels: readonly unknown[] };
     }>;
   };
   return {
     ...doc,
     conferences: doc.conferences.map((c) =>
       c.slug === '/2024'
-        ? { ...c, hotels: [...c.hotels, extraHotel] }
+        ? {
+            ...c,
+            accommodations: {
+              ...c.accommodations,
+              hotels: [...c.accommodations.hotels, extraHotel],
+            },
+          }
         : c,
     ),
   };
 };
 
-/**
- * Section-skip is section-LEVEL, never item-level (registration-launch Branch 4,
- * settled #3, CONTEXT §"Section skip"): an *absent* `hotels` list omits the
- * hotels column (proven render-side in `conference-detail.test.tsx`), but a
- * *present* hotel with a blank required bilingual `name` is a hard `Text` decode
- * error — the both-locales invariant lives in the schema, never the component, so
- * the component can never receive half-filled content. These pin that the
- * tolerance is for absence, not for half-filled presence.
- */
-describe('Hotel present-but-empty hard-error (skip is section-level, items stay strict)', () => {
+describe('AccommodationHotel present-but-empty hard-error (skip is section-level, items stay strict)', () => {
   it.effect('a present hotel with a blank `name` locale fails strict decode (publish-invalid)', () =>
     Effect.gen(function* () {
       const encoded = yield* encodeStrict(defaultContent);
-      // An empty EN `name` locale: `Text` requires both locales non-empty, so a
-      // present-but-empty hotel name is rejected by publish.
       const blankName = withExtraHotel(encoded, {
         id: String(newListItemId()),
         name: { en: '', fr: 'Hôtel' },
+        address: { en: 'Kelowna', fr: 'Kelowna' },
+        roomRates: [],
       });
       expect(decodeStrict(blankName)._tag).toBe('Failure');
     }));
@@ -506,27 +500,25 @@ describe('Hotel present-but-empty hard-error (skip is section-level, items stay 
   it.effect('a present hotel missing `name` entirely fails strict decode', () =>
     Effect.gen(function* () {
       const encoded = yield* encodeStrict(defaultContent);
-      // `name` is a required field on `Hotel` — a present hotel that omits it
-      // (only `id`) cannot publish. (Skip is for an absent *list*, never a
-      // half-built *item*.)
       const noName = withExtraHotel(encoded, {
         id: String(newListItemId()),
+        address: { en: 'Kelowna', fr: 'Kelowna' },
+        roomRates: [],
       });
       expect(decodeStrict(noName)._tag).toBe('Failure');
     }));
 
-  it.effect('a present hotel with a half-filled bilingual `note` fails strict decode', () =>
+  it.effect('a present hotel with a half-filled bilingual `description` fails strict decode', () =>
     Effect.gen(function* () {
       const encoded = yield* encodeStrict(defaultContent);
-      // `note` is optional (`optionalKey`), but once PRESENT it is a strict
-      // `Text`: a present note with one empty locale is rejected — optionality is
-      // about absence, not about tolerating a half-filled present value.
-      const halfNote = withExtraHotel(encoded, {
+      const halfDescription = withExtraHotel(encoded, {
         id: String(newListItemId()),
         name: { en: 'Lakeview Inn', fr: 'Auberge du Lac' },
-        note: { en: 'Group code: GYC', fr: '' },
+        address: { en: 'Kelowna', fr: 'Kelowna' },
+        roomRates: [],
+        description: { en: 'Group code: GYC', fr: '' },
       });
-      expect(decodeStrict(halfNote)._tag).toBe('Failure');
+      expect(decodeStrict(halfDescription)._tag).toBe('Failure');
     }));
 
   it.effect('a fully-populated present hotel decodes strictly (the inverse: complete items publish)', () =>
@@ -535,7 +527,9 @@ describe('Hotel present-but-empty hard-error (skip is section-level, items stay 
       const complete = withExtraHotel(encoded, {
         id: String(newListItemId()),
         name: { en: 'Lakeview Inn', fr: 'Auberge du Lac' },
-        note: { en: 'Group code: GYC', fr: 'Code de groupe : GYC' },
+        address: { en: 'Kelowna', fr: 'Kelowna' },
+        roomRates: [],
+        description: { en: 'Group code: GYC', fr: 'Code de groupe : GYC' },
       });
       expect(decodeStrict(complete)._tag).toBe('Success');
     }));

--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { Schema } from 'effect';
+import { Effect, Schema } from 'effect';
 import { nanoid } from 'nanoid';
 
 /**
@@ -419,21 +419,97 @@ export const Hero = Schema.Struct({
 export type Hero = typeof Hero.Type;
 
 /**
- * A recommended hotel for a conference (registration-launch Branch 3, settled
- * #4) — replaces the hard-coded `<li>` list in the forked detail pages with
- * editable data. A list item, so it carries a stable `ListItemId` (ADR 0006) and
- * lives in an `IdListArray`. `name` is a bilingual `Text` (both locales required
- * and non-empty, like every other content string); `note` is an optional
- * bilingual line for booking detail (a discount code, a phone number). The
- * `hotels` array is empty-able and the whole `MapSection` is section-skippable
- * (Branch 4): a year with no hotels simply omits them.
+ * Conference section visibility: defaults to `false` when the key is absent on
+ * stored JSON, so new sections ship disabled until explicitly enabled in CMS.
  */
-export const Hotel = Schema.Struct({
+const SectionEnabledFlag = Schema.Boolean.pipe(
+  Schema.withDecodingDefaultKey(Effect.succeed(false)),
+);
+
+/** Home-page Learn More button visibility for the conference shown on `/`. */
+const LearnMoreEnabledFlag = Schema.Boolean.pipe(
+  Schema.withDecodingDefaultKey(Effect.succeed(false)),
+);
+
+export const RoomRate = Schema.Struct({
+  id: ListItemId,
+  description: Text,
+});
+export type RoomRate = typeof RoomRate.Type;
+
+export const ParkingOption = Schema.Struct({
+  id: ListItemId,
+  title: Text,
+  link: Schema.OptionFromOptionalKey(ExternalHttpsUrl),
+  address: Schema.optionalKey(Text),
+  description: Schema.optionalKey(Text),
+});
+export type ParkingOption = typeof ParkingOption.Type;
+
+export const AccommodationHotel = Schema.Struct({
   id: ListItemId,
   name: Text,
-  note: Schema.optionalKey(Text),
+  address: Text,
+  checkIn: Schema.optionalKey(Text),
+  checkOut: Schema.optionalKey(Text),
+  roomRates: IdListArray(RoomRate),
+  description: Schema.optionalKey(Text),
+  navigateUrl: Schema.OptionFromOptionalKey(ExternalHttpsUrl),
+  reservationUrl: Schema.OptionFromOptionalKey(ExternalHttpsUrl),
 });
-export type Hotel = typeof Hotel.Type;
+export type AccommodationHotel = typeof AccommodationHotel.Type;
+
+export const MealItem = Schema.Struct({
+  id: ListItemId,
+  label: Text,
+  price: Text,
+});
+export type MealItem = typeof MealItem.Type;
+
+export const TravelSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Text,
+  bodyCopy: Text,
+  mapEmbedUrl: Schema.OptionFromOptionalKey(GoogleMapsEmbedUrl),
+});
+export type TravelSection = typeof TravelSection.Type;
+
+export const ParkingSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Text,
+  options: IdListArray(ParkingOption),
+});
+export type ParkingSection = typeof ParkingSection.Type;
+
+export const AccommodationsSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Text,
+  hotels: IdListArray(AccommodationHotel),
+});
+export type AccommodationsSection = typeof AccommodationsSection.Type;
+
+export const MealsSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Text,
+  bodyCopy: Schema.optionalKey(Text),
+  items: IdListArray(MealItem),
+});
+export type MealsSection = typeof MealsSection.Type;
+
+export const RegistrationCopySection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  title: Text,
+  subtitle: Text,
+  buttonLabel: Text,
+});
+export type RegistrationCopySection = typeof RegistrationCopySection.Type;
+
+export const FaqCopySection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  title: Text,
+  subtitle: Text,
+});
+export type FaqCopySection = typeof FaqCopySection.Type;
 
 /**
  * A single annual conference.
@@ -470,24 +546,15 @@ export const Conference = Schema.Struct({
   speakers: IdListArray(Speaker),
   seminars: IdListArray(Seminar),
   promos: Schema.Array(Schema.NonEmptyString),
-  /**
-   * The conference's optional detail-page data (registration-launch Branch 3,
-   * settled #4). Each is modelled as `OptionFromOptionalKey` at the document
-   * layer so an *absent* field is `Option.none()` (never an empty string), which
-   * gives Branch 4's section-skip a real `Option.some`/`Option.none`
-   * discriminator (`make-impossible-states-unrepresentable`): an empty-string URL
-   * is not representable as "present". `hotels` is an empty-able id-keyed list
-   * (absence = `[]`, skipped). The `Content` boundary (Branch 3.2) projects each
-   * to `string | undefined` / `[]` so React never sees an `Option`.
-   *   - `registrationUrl` — the external registrar (RegFox) Register button.
-   *   - `scheduleUrl` — the published schedule link (was a hard-coded Google Docs URL).
-   *   - `mapEmbedUrl` — the venue map iframe (constrained to the Google Maps embed endpoint).
-   *   - `hotels` — recommended-hotel list (was a hard-coded `<li>` list).
-   */
   registrationUrl: Schema.OptionFromOptionalKey(ExternalHttpsUrl),
   scheduleUrl: Schema.OptionFromOptionalKey(ExternalHttpsUrl),
-  mapEmbedUrl: Schema.OptionFromOptionalKey(GoogleMapsEmbedUrl),
-  hotels: IdListArray(Hotel),
+  learnMoreEnabled: LearnMoreEnabledFlag,
+  travel: TravelSection,
+  parking: ParkingSection,
+  accommodations: AccommodationsSection,
+  meals: MealsSection,
+  registrationCopy: RegistrationCopySection,
+  faqCopy: FaqCopySection,
 });
 export type Conference = typeof Conference.Type;
 
@@ -683,22 +750,89 @@ const DraftBoardMember = Schema.Struct({
 });
 
 /**
- * A draft hotel: a freshly-added item carries only its `id` (settled #10), with
- * `name`/`note` filled in incrementally. Both relax to optional `DraftText`
- * (publish re-enforces the strict bilingual `Text`).
+ * Placeholder bilingual copy for draft section fields not yet filled in.
  */
-const DraftHotel = Schema.Struct({
+const DraftRoomRate = Schema.Struct({
   id: ListItemId,
-  name: Schema.optionalKey(DraftText),
-  note: Schema.optionalKey(DraftText),
+  description: Schema.optionalKey(DraftText),
 });
 
-/** The draft variant of `Conference`: only its list items are draft-lax. */
+const DraftParkingOption = Schema.Struct({
+  id: ListItemId,
+  title: Schema.optionalKey(DraftText),
+  link: Schema.optionalKey(Schema.String),
+  address: Schema.optionalKey(DraftText),
+  description: Schema.optionalKey(DraftText),
+});
+
+const DraftAccommodationHotel = Schema.Struct({
+  id: ListItemId,
+  name: Schema.optionalKey(DraftText),
+  address: Schema.optionalKey(DraftText),
+  checkIn: Schema.optionalKey(DraftText),
+  checkOut: Schema.optionalKey(DraftText),
+  roomRates: IdListArray(DraftRoomRate),
+  description: Schema.optionalKey(DraftText),
+  navigateUrl: Schema.optionalKey(Schema.String),
+  reservationUrl: Schema.optionalKey(Schema.String),
+});
+
+const DraftMealItem = Schema.Struct({
+  id: ListItemId,
+  label: Schema.optionalKey(DraftText),
+  price: Schema.optionalKey(DraftText),
+});
+
+const DraftTravelSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Schema.optionalKey(DraftText),
+  bodyCopy: Schema.optionalKey(DraftText),
+  mapEmbedUrl: Schema.optionalKey(Schema.String),
+});
+
+const DraftParkingSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Schema.optionalKey(DraftText),
+  options: IdListArray(DraftParkingOption),
+});
+
+const DraftAccommodationsSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Schema.optionalKey(DraftText),
+  hotels: IdListArray(DraftAccommodationHotel),
+});
+
+const DraftMealsSection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  headerCopy: Schema.optionalKey(DraftText),
+  bodyCopy: Schema.optionalKey(DraftText),
+  items: IdListArray(DraftMealItem),
+});
+
+const DraftRegistrationCopySection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  title: Schema.optionalKey(DraftText),
+  subtitle: Schema.optionalKey(DraftText),
+  buttonLabel: Schema.optionalKey(DraftText),
+});
+
+const DraftFaqCopySection = Schema.Struct({
+  enabled: SectionEnabledFlag,
+  title: Schema.optionalKey(DraftText),
+  subtitle: Schema.optionalKey(DraftText),
+});
+
+/** The draft variant of `Conference`: list items and section copy are draft-lax. */
 const DraftConference = Schema.Struct({
   ...Conference.fields,
   speakers: IdListArray(DraftSpeaker),
   seminars: IdListArray(DraftSeminar),
-  hotels: IdListArray(DraftHotel),
+  travel: DraftTravelSection,
+  parking: DraftParkingSection,
+  accommodations: DraftAccommodationsSection,
+  meals: DraftMealsSection,
+  registrationCopy: DraftRegistrationCopySection,
+  faqCopy: DraftFaqCopySection,
 });
 
 /**

--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-
 import { Effect, Schema } from 'effect';
 import { nanoid } from 'nanoid';
 
@@ -224,40 +222,6 @@ export type ListItemId = typeof ListItemId.Type;
 
 /** Mint a fresh, schema-valid `ListItemId`. */
 export const newListItemId = (): ListItemId => ListItemId.make(nanoid());
-
-/**
- * nanoid's URL-safe default alphabet (`A-Za-z0-9_-`, 64 chars) — the alphabet a
- * {@link ListItemId} validates against. {@link deterministicListItemId} maps a
- * hash digest into it so a derived id is byte-for-byte a nanoid (same shape the
- * brand's pattern accepts), not a hex/base64 string the schema would reject.
- */
-const NANOID_ALPHABET =
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
-
-/**
- * Derive a **deterministic**, schema-valid `ListItemId` from an idempotency
- * `key` — the SAME `key` always yields the SAME id. Unlike {@link newListItemId}
- * (a fresh random nanoid per call), this lets a write be idempotent: a retry of
- * the same logical record re-derives the same id → the same bucket key → the
- * `Storage.put` overwrites rather than minting a duplicate object
- * (registration-launch Branch 7.3 follow-up — the registration multi-registrant
- * partial-write the deep review escalated). The 21-char output is shaped like a
- * nanoid (it maps a SHA-256 digest into nanoid's alphabet), so it satisfies the
- * `ListItemId` pattern; it is NOT a random nanoid and is not meant to be
- * unguessable — it is a content-addressed id, derived not authored.
- */
-export const deterministicListItemId = (key: string): ListItemId => {
-  // SHA-256 → 32 bytes; take the first 21 and fold each into nanoid's 64-char
-  // alphabet (a clean `& 63` mask — 64 divides 256, so no modulo bias).
-  const digest = createHash('sha256').update(key).digest();
-  let id = '';
-  for (let i = 0; i < 21; i += 1) {
-    // `digest` is 32 bytes, so `digest[i]` for i<21 is always a byte; `& 63` keeps
-    // the index in `[0, 63]`, always a valid position in the 64-char alphabet.
-    id += NANOID_ALPHABET.charAt((digest[i] ?? 0) & 63);
-  }
-  return ListItemId.make(id);
-};
 
 /**
  * An editable list whose items are addressed by their `id` (ADR 0006). The

--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -825,6 +825,8 @@ const DraftFaqCopySection = Schema.Struct({
 /** The draft variant of `Conference`: list items and section copy are draft-lax. */
 const DraftConference = Schema.Struct({
   ...Conference.fields,
+  registrationUrl: Schema.optionalKey(Schema.String),
+  scheduleUrl: Schema.optionalKey(Schema.String),
   speakers: IdListArray(DraftSpeaker),
   seminars: IdListArray(DraftSeminar),
   travel: DraftTravelSection,

--- a/app/lib/content/schema.ts
+++ b/app/lib/content/schema.ts
@@ -430,17 +430,31 @@ export const MealItem = Schema.Struct({
 });
 export type MealItem = typeof MealItem.Type;
 
+export const AirportTransitOption = Schema.Struct({
+  id: ListItemId,
+  description: Text,
+});
+export type AirportTransitOption = typeof AirportTransitOption.Type;
+
+export const Airport = Schema.Struct({
+  name: Text,
+  transitOptions: IdListArray(AirportTransitOption),
+});
+export type Airport = typeof Airport.Type;
+
 export const TravelSection = Schema.Struct({
   enabled: SectionEnabledFlag,
   headerCopy: Text,
-  bodyCopy: Text,
+  bodyCopy: Schema.optionalKey(Text),
   mapEmbedUrl: Schema.OptionFromOptionalKey(GoogleMapsEmbedUrl),
+  airport: Schema.optionalKey(Airport),
 });
 export type TravelSection = typeof TravelSection.Type;
 
 export const ParkingSection = Schema.Struct({
   enabled: SectionEnabledFlag,
   headerCopy: Text,
+  bodyCopy: Schema.optionalKey(Text),
   options: IdListArray(ParkingOption),
 });
 export type ParkingSection = typeof ParkingSection.Type;
@@ -747,16 +761,31 @@ const DraftMealItem = Schema.Struct({
   price: Schema.optionalKey(DraftText),
 });
 
+const DraftAirportTransitOption = Schema.Struct({
+  id: ListItemId,
+  description: Schema.optionalKey(DraftText),
+});
+
+const DraftAirport = Schema.Struct({
+  name: Schema.optionalKey(DraftText),
+  /** Default to [] so an airport stub created without transit options decodes. */
+  transitOptions: IdListArray(DraftAirportTransitOption).pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed([])),
+  ),
+});
+
 const DraftTravelSection = Schema.Struct({
   enabled: SectionEnabledFlag,
   headerCopy: Schema.optionalKey(DraftText),
   bodyCopy: Schema.optionalKey(DraftText),
   mapEmbedUrl: Schema.optionalKey(Schema.String),
+  airport: Schema.optionalKey(DraftAirport),
 });
 
 const DraftParkingSection = Schema.Struct({
   enabled: SectionEnabledFlag,
   headerCopy: Schema.optionalKey(DraftText),
+  bodyCopy: Schema.optionalKey(DraftText),
   options: IdListArray(DraftParkingOption),
 });
 

--- a/app/lib/forms/submissions.server.ts
+++ b/app/lib/forms/submissions.server.ts
@@ -4,11 +4,7 @@ import { Clock, Context, DateTime, Effect, Layer, Schema } from 'effect';
 
 import { Content } from '../content.server';
 import { type FormId, submissionKey } from '../content/pages/registry';
-import {
-  deterministicListItemId,
-  IsoDate,
-  newListItemId,
-} from '../content/schema';
+import { deterministicListItemId, IsoDate, newListItemId } from '../content/schema.server';
 import { Storage, type StorageError } from '../storage.server';
 
 import type { DecodedForm } from './decode';

--- a/app/lib/localization/translations.ts
+++ b/app/lib/localization/translations.ts
@@ -121,6 +121,10 @@ const en = {
     "There are quite a few hotels in Kelowna, BC which can make it daunting to find the right one. We've listed the closest hotels to the Venue below. Please keep in mind that you may be able to save a considerable amount of money by getting a room with friends, using Airbnb or by using our {{facebook}}",
   'registration.hotels.description.facebook':
     'Facebook Rides & Roommates Group',
+  'registration.accommodations.check_in': 'Check in',
+  'registration.accommodations.check_out': 'Check-out',
+  'registration.accommodations.navigate': 'Navigate',
+  'registration.accommodations.reserve': 'Reserve',
   'registration.form.title': 'Register for GYC Canada {{year}}',
   'registration.form.error':
     'An error occurred while submitting your registration. Please try again later.',
@@ -388,6 +392,10 @@ const fr: Record<TranslationKey, string> = {
   'registration.hotels.description': `Il y a plusieurs hôtels à Kelowna, en Colombie-Britannique, ce qui peut rendre difficile de trouver les bons. Nous avons répertorié les hôtels les plus proches du lieu ci-dessous. Veuillez noter que vous pourriez économiser des sommes considérables en partageant des chambres avec des amis, en utilisant Airbnb ou en utilisant notre {{facebook}}`,
   'registration.hotels.description.facebook':
     'Groupe Facebook Rides & Roommates',
+  'registration.accommodations.check_in': 'Arrivée',
+  'registration.accommodations.check_out': 'Départ',
+  'registration.accommodations.navigate': 'Itinéraire',
+  'registration.accommodations.reserve': 'Réserver',
 
   'registration.form.title': 'Inscrivez-vous à GYC Canada {{year}}',
   'registration.form.error':

--- a/app/routes/($lang)+/_index.tsx
+++ b/app/routes/($lang)+/_index.tsx
@@ -180,6 +180,7 @@ function Hero() {
 
 function MobileHero() {
   const { conference } = useLoaderData<typeof loader>();
+  const translate = useTranslate();
   return (
     <section
       style={
@@ -210,11 +211,21 @@ function MobileHero() {
         </h2>
       </div>
       <p className="text-xl italic">{conference.tagline}</p>
+      {conference.learnMoreEnabled ? (
+        <Link
+          to={conference.slug}
+          className={buttonStyle}
+          data-variant="accent"
+        >
+          {translate("main.reserve")}
+        </Link>
+      ) : null}
     </section>
   );
 }
 function DesktopHero() {
   const { conference } = useLoaderData<typeof loader>();
+  const translate = useTranslate();
   // const hints = useHints();
 
   return (
@@ -259,15 +270,15 @@ function DesktopHero() {
             </h1>
           </div>
           <div className="flex flex-col gap-10">
-            <div>
-              {/* <Link
+            {conference.learnMoreEnabled ? (
+              <Link
                 to={conference.slug}
-                className={clsx(buttonStyle)}
+                className={buttonStyle}
                 data-variant="accent"
               >
-                {translate('main.reserve')}
-              </Link> */}
-            </div>
+                {translate("main.reserve")}
+              </Link>
+            ) : null}
           </div>
         </div>
       </div>

--- a/app/routes/($lang)+/_layout.tsx
+++ b/app/routes/($lang)+/_layout.tsx
@@ -134,7 +134,7 @@ export function TopNav() {
             className="size-[44px]"
           />
         </Link>
-        <NavItem to={`/`}>
+        <NavItem to={`/${new Date().getFullYear()}`}>
           {translate("nav.home", {
             year: new Date().getFullYear(),
           })}
@@ -375,7 +375,7 @@ export function Footer() {
             <p className="text-neutral-50 dark:text-neutral-500">
               {translate("footer.links")}
             </p>
-            <Link to={`/`} className={linkStyle}>
+            <Link to={currentConference.slug} className={linkStyle}>
               {currentConference.title}{" "}
               {dayjs(currentConference.dates[0]).format("YYYY")}
             </Link>

--- a/app/routes/($lang)+/conference-detail.test.tsx
+++ b/app/routes/($lang)+/conference-detail.test.tsx
@@ -13,13 +13,15 @@ import { ConferenceDetail } from './conference-detail';
 const disabledTravel = {
   enabled: false,
   headerCopy: 'Travel',
-  bodyCopy: '—',
+  bodyCopy: undefined,
   mapEmbedUrl: undefined,
+  airport: undefined,
 } as const;
 
 const disabledParking = {
   enabled: false,
   headerCopy: 'Parking',
+  bodyCopy: undefined,
   options: [],
 } as const;
 
@@ -95,6 +97,7 @@ const fullConference: Conference = {
     headerCopy: 'Travel',
     bodyCopy: 'Venue directions and travel notes.',
     mapEmbedUrl: 'https://www.google.com/maps/embed?pb=!1m18!FAKE',
+    airport: undefined,
   },
   parking: disabledParking,
   accommodations: {

--- a/app/routes/($lang)+/conference-detail.test.tsx
+++ b/app/routes/($lang)+/conference-detail.test.tsx
@@ -10,31 +10,48 @@ import { root as translations } from '~/lib/localization/translations';
 
 import { ConferenceDetail } from './conference-detail';
 
-/**
- * `ConferenceDetail` is the single deep module the three `/YYYY` loaders render
- * (registration-launch Branch 3.3). It was extracted verbatim from the
- * `2024/_index.tsx` fork — the spec — with the formerly hard-coded RegFox link,
- * schedule link, map iframe `src`, and hotel `<li>`s replaced by reads off the
- * boundary `Conference` (`registrationUrl` / `scheduleUrl` / `mapEmbedUrl` /
- * `hotels`, projected by `toConference` from validated document `Option`s).
- *
- * These render-to-string tests pin the load-bearing claim of the extraction
- * (`prove-it-works`): a fully-populated conference renders every section, and
- * the data-driven sections render the boundary data — NOT the old hard-coded
- * constants. Section-skip (omitting a section when its data is absent) is
- * Branch 4's concern and is tested there; here the conference carries every
- * field, so every section is present.
- *
- * The component is server-rendered through `createRoutesStub` (to satisfy the
- * router hooks it uses — `useSearchParams`, `useLocation` via `Link`, `useParams`
- * via `useLocale`, and `useRouteLoaderData('root')` via `useHints`) plus a
- * `LocalizationProvider`. The `root` loader data is supplied directly through
- * `hydrationData` so the render is synchronous (no async loader suspends).
- */
+const disabledTravel = {
+  enabled: false,
+  headerCopy: 'Travel',
+  bodyCopy: '—',
+  mapEmbedUrl: undefined,
+} as const;
+
+const disabledParking = {
+  enabled: false,
+  headerCopy: 'Parking',
+  options: [],
+} as const;
+
+const disabledAccommodations = {
+  enabled: false,
+  headerCopy: 'Accommodations',
+  hotels: [],
+} as const;
+
+const disabledMeals = {
+  enabled: false,
+  headerCopy: 'Meals',
+  bodyCopy: undefined,
+  items: [],
+} as const;
+
+const disabledRegistrationCopy = {
+  enabled: false,
+  title: 'Register Now!',
+  subtitle: 'Subtitle',
+  buttonLabel: 'Register Now',
+} as const;
+
+const disabledFaqCopy = {
+  enabled: false,
+  title: 'Got Questions?',
+  subtitle: 'FAQ subtitle',
+} as const;
 
 /** A fully-populated boundary `Conference` — every detail section has data. */
 const fullConference: Conference = {
-  slug: '2024',
+  slug: '/2024',
   title: 'While It Is Day',
   dates: [Date.UTC(2024, 7, 1), Date.UTC(2024, 7, 4)],
   hero: {
@@ -72,14 +89,53 @@ const fullConference: Conference = {
     'https://gyccanada.regfox.com/gyc-canada-2024-while-it-is-day',
   scheduleUrl:
     'https://docs.google.com/document/d/1gNAOfdW2Yhgg7FABjUqQt2k2mXV_AdhARWUOyiVL9dA/pub',
-  mapEmbedUrl: 'https://www.google.com/maps/embed?pb=!1m18!FAKE',
-  hotels: [
-    { name: 'Super 8 by Wyndham Kelowna BC' },
-    {
-      name: 'Fairfield Inn & Suites Kelowna',
-      note: 'Group Code: GYC',
-    },
-  ],
+  learnMoreEnabled: false,
+  travel: {
+    enabled: true,
+    headerCopy: 'Travel',
+    bodyCopy: 'Venue directions and travel notes.',
+    mapEmbedUrl: 'https://www.google.com/maps/embed?pb=!1m18!FAKE',
+  },
+  parking: disabledParking,
+  accommodations: {
+    enabled: true,
+    headerCopy: 'Accommodations near the venue',
+    hotels: [
+      {
+        name: 'Super 8 by Wyndham Kelowna BC',
+        address: 'Kelowna, BC',
+        checkIn: undefined,
+        checkOut: undefined,
+        roomRates: [],
+        description: undefined,
+        navigateUrl: undefined,
+        reservationUrl: undefined,
+      },
+      {
+        name: 'Fairfield Inn & Suites Kelowna',
+        address: 'Kelowna, BC',
+        checkIn: undefined,
+        checkOut: undefined,
+        roomRates: [],
+        description:
+          'Holiday Inn Express & Suites Kelowna — "GYC Canada" or Group Code: "GYC" (call 778-484-2999 for discount)',
+        navigateUrl: undefined,
+        reservationUrl: undefined,
+      },
+    ],
+  },
+  meals: disabledMeals,
+  registrationCopy: {
+    enabled: true,
+    title: 'Register Now!',
+    subtitle: 'Registration is open.',
+    buttonLabel: 'Register Now',
+  },
+  faqCopy: {
+    enabled: true,
+    title: 'Got Questions?',
+    subtitle: 'We are here to help.',
+  },
 };
 
 /**
@@ -141,8 +197,8 @@ describe('ConferenceDetail', () => {
     expect(html).toContain('Matt Parra');
     expect(html).toContain('Discipleship');
     // Registration section
-    expect(html).toContain('Register Now');
-    // FAQ section (static links)
+    expect(html).toContain('Register Now!');
+    // FAQ section
     expect(html).toContain('Got Questions?');
   });
 
@@ -170,66 +226,16 @@ describe('ConferenceDetail', () => {
     expect(html).toContain(`href="${fullConference.scheduleUrl}"`);
   });
 
-  it('renders the map iframe src from the boundary mapEmbedUrl', () => {
+  it('renders the map iframe src from the travel section mapEmbedUrl', () => {
     const html = renderConference(fullConference);
-    expect(html).toContain(`src="${fullConference.mapEmbedUrl}"`);
+    expect(html).toContain(`src="${fullConference.travel.mapEmbedUrl}"`);
   });
 
-  it('renders the hotels list from the boundary hotels, including notes', () => {
+  it('renders accommodations hotels including descriptions', () => {
     const html = renderConference(fullConference);
-
     expect(html).toContain('Super 8 by Wyndham Kelowna BC');
     expect(html).toContain('Fairfield Inn &amp; Suites Kelowna');
-    // The optional note is appended after the name.
-    expect(html).toContain('Group Code: GYC');
-  });
-
-  /**
-   * Pin the 2024 hotel list render against the REAL bundled defaults (not the
-   * synthetic `fullConference` above), so the `{name}{note ? ` ${note}` : null}`
-   * template + the authored hotel strings are guarded together going forward.
-   *
-   * The pre-migration `2024/_index.tsx` fork hard-coded hotel #2 as one `<li>`:
-   *   `Fairfield Inn & Suites Kelowna Holiday Inn Express & Suites Kelowna
-   *    - "GYC Canada” or Group Code: “GYC" (call 778-484-2999 for discount)`
-   * — with a literal `- ` separator and *mismatched* straight-then-curly quotes
-   * (`"GYC Canada”` … `“GYC"`), a pre-existing typo. The plan (line 136) pinned a
-   * "byte-identical 2024 render"; this branch CONSCIOUSLY cleans that typo: the
-   * default note (`defaults.ts`) uses an em-dash separator and consistent quotes.
-   * That is the single intentional render delta vs the old fork. This test is the
-   * regression assertion the plan amendment requires — it pins the cleaned text
-   * exactly, so any future drift is caught.
-   */
-  it('renders the 2024 Fairfield hotel `<li>` exactly as authored in the defaults (typo-cleanup pinned)', () => {
-    const doc2024 = defaultContent.conferences.find((c) => c.slug === '/2024');
-    expect(doc2024).toBeDefined();
-    // Project the defaults' 2024 hotels to the en boundary shape `toConference`
-    // emits (`{ name: name.en, note?: note.en }`), so the render is driven by the
-    // authored content, not a hand-copied string.
-    const hotels = (doc2024?.hotels ?? []).map((hotel) => ({
-      name: hotel.name.en,
-      ...(hotel.note === undefined ? {} : { note: hotel.note.en }),
-    }));
-
-    const fairfield = hotels.find((h) => h.name.startsWith('Fairfield'));
-    expect(fairfield?.note).toBeDefined();
-
-    const html = renderConference({ ...fullConference, hotels });
-
-    // The component renders `{name}{note ? ` ${note}` : null}` inside one <li>.
-    // React server-renders the two adjacent text children separated by a comment
-    // marker (`<!-- -->`) and HTML-escapes `&` → `&amp;` and `"` → `&quot;`. Pin
-    // the exact rendered <li> innerHTML: a single space before `Holiday`, the
-    // em-dash separator, and consistent straight quotes — the consciously-cleaned
-    // form, NOT the old fork's `- ` separator + mismatched straight/curly quotes.
-    expect(html).toContain(
-      '<li>Fairfield Inn &amp; Suites Kelowna<!-- --> Holiday Inn Express &amp; Suites Kelowna — &quot;GYC Canada&quot; or Group Code: &quot;GYC&quot; (call 778-484-2999 for discount)</li>',
-    );
-    // And the old typo'd separator/quotes must NOT survive (the curly `”`/`“`
-    // and the `Kelowna - ` separator the pre-branch fork hard-coded).
-    expect(html).not.toContain('Kelowna — &quot;GYC Canada”');
-    expect(html).not.toContain('Kelowna - ');
-    expect(html).not.toContain('“GYC');
+    expect(html).toContain('GYC Canada');
   });
 
   it('renders the mobile hero variant at a small breakpoint', () => {
@@ -247,10 +253,8 @@ describe('ConferenceDetail', () => {
   it('renders French copy under the /fr locale', () => {
     const html = renderConference(fullConference, { lang: 'fr' });
 
-    // `registration.faq.title` in French ("Got Questions?" → its FR string).
-    expect(html).toContain(translations.fr['registration.faq.title']);
-    // The data fields (locale-projected upstream) still flow through unchanged.
-    expect(html).toContain(`src="${fullConference.mapEmbedUrl}"`);
+    expect(html).toContain(translations.fr['registration.faq.contact']);
+    expect(html).toContain(`src="${fullConference.travel.mapEmbedUrl}"`);
   });
 });
 
@@ -291,60 +295,40 @@ describe('ConferenceDetail section-skip', () => {
     expect(html).toContain('Matt Parra');
   });
 
-  it('omits the map iframe when mapEmbedUrl is absent but keeps the hotels column', () => {
+  it('omits the travel map when mapEmbedUrl is absent but keeps accommodations', () => {
     const html = renderConference({
       ...fullConference,
-      mapEmbedUrl: undefined,
+      travel: { ...fullConference.travel, mapEmbedUrl: undefined },
     });
 
-    // The iframe (its `title="Map"` + the old fallback src) is gone…
     expect(html).not.toContain('title="Map"');
     expect(html).not.toContain('/maps/embed');
-    // …but the hotels half of the section survives (each half gated independently),
-    // and the section wrapper is still present (the early-return only fires when
-    // BOTH halves are empty).
     expect(html).toContain('Super 8 by Wyndham Kelowna BC');
-    expect(html).toContain('aria-label="Venue and accommodations"');
+    expect(html).toContain('Travel');
   });
 
-  it('omits the hotels column when hotels is empty but keeps the map iframe', () => {
-    const html = renderConference({ ...fullConference, hotels: [] });
+  it('omits accommodations when disabled but keeps the travel map', () => {
+    const html = renderConference({
+      ...fullConference,
+      accommodations: disabledAccommodations,
+    });
 
     expect(html).not.toContain('Super 8 by Wyndham Kelowna BC');
     expect(html).not.toContain('Fairfield Inn');
-    // The hotels-description copy lives inside the hotels half (alongside the
-    // `<ul>`); deleting only the hotels-half gate would re-render this `<p>` (the
-    // empty `<ul>` keeps the names absent regardless), so assert the description
-    // is gone too — it pins the WHOLE hotels half is skipped, not just its list.
-    expect(html).not.toContain(
-      translations.en['registration.hotels.description.facebook'],
-    );
-    // The map half survives, and the section wrapper is still present.
-    expect(html).toContain(`src="${fullConference.mapEmbedUrl}"`);
+    expect(html).toContain(`src="${fullConference.travel.mapEmbedUrl}"`);
     expect(html).toContain('title="Map"');
-    expect(html).toContain('aria-label="Venue and accommodations"');
   });
 
-  it('omits the whole MapSection when neither a map embed nor hotels are present', () => {
+  it('omits the whole travel section when travel is disabled', () => {
     const html = renderConference({
       ...fullConference,
-      mapEmbedUrl: undefined,
-      hotels: [],
+      travel: disabledTravel,
+      accommodations: disabledAccommodations,
     });
 
     expect(html).not.toContain('title="Map"');
     expect(html).not.toContain('Super 8 by Wyndham Kelowna BC');
-    // The hotels-description copy (the section's only other content) is gone too.
-    expect(html).not.toContain(
-      translations.en['registration.hotels.description.facebook'],
-    );
-    // The `MapSection` `<section>` wrapper itself is gone (the early
-    // `if (!hasHotels && !hasMap) return null`). Both halves are independently
-    // gated to null, so an inner-content-only assertion would still pass if the
-    // early-return were deleted — leaving an empty `<section aria-label=…>` that
-    // no other check catches. Pin the section's structural marker absent so the
-    // whole-section skip is what's proven, not merely its emptied contents.
-    expect(html).not.toContain('aria-label="Venue and accommodations"');
+    expect(html).not.toContain('Venue directions and travel notes.');
   });
 
   it('omits the register button + RegistrationSection when registrationUrl is absent', () => {
@@ -353,19 +337,11 @@ describe('ConferenceDetail section-skip', () => {
       registrationUrl: undefined,
     });
 
-    // The `RegistrationSection` (its title) and the RegFox href are both gone.
-    expect(html).not.toContain(translations.en['registration.register.title']);
+    expect(html).not.toContain(fullConference.registrationCopy.title);
     expect(html).not.toContain('regfox.com');
     expect(html).not.toContain(
       'href="https://gyccanada.regfox.com/gyc-canada-2024-while-it-is-day"',
     );
-    // The HERO register label (`registration.register` = 'Register', a DIFFERENT
-    // key from `registration.register.title` = 'Register Now!') is gone too. A
-    // regressed desktop-hero gate rendering `<a href={undefined}>Register</a>`
-    // drops the href (React omits undefined attrs) and the title check above is a
-    // different string — so without this assertion that regression passes green.
-    // 'Register' is a substring of the title/button copy, so this must run only
-    // when the whole RegistrationSection is already gone (registrationUrl absent).
     expect(html).not.toContain(translations.en['registration.register']);
   });
 
@@ -426,57 +402,55 @@ describe('ConferenceDetail section-skip', () => {
   it('renders the 2026 RegFox-only shape: hero + register button + FAQ, no empty sections', () => {
     const conference2026: Conference = {
       ...fullConference,
-      slug: '2026',
+      slug: '/2026',
       speakers: [],
       seminars: [],
       scheduleUrl: undefined,
-      mapEmbedUrl: undefined,
-      hotels: [],
+      travel: disabledTravel,
+      parking: disabledParking,
+      accommodations: disabledAccommodations,
+      meals: disabledMeals,
+      registrationCopy: fullConference.registrationCopy,
+      faqCopy: fullConference.faqCopy,
       registrationUrl: 'https://gyccanada.regfox.com/gyc-canada-2026-speak',
     };
     const html = renderConference(conference2026);
 
-    // Present: hero, register button, FAQ.
     expect(html).toContain(conference2026.hero.image.desktop);
-    expect(html).toContain(translations.en['registration.register.title']);
+    expect(html).toContain('Register Now!');
     expect(html).toContain(
       'href="https://gyccanada.regfox.com/gyc-canada-2026-speak"',
     );
-    expect(html).toContain(translations.en['registration.faq.title']);
-    // Absent: every data-less section.
+    expect(html).toContain('Got Questions?');
     expect(html).not.toContain('Speakers');
     expect(html).not.toContain('Seminars');
     expect(html).not.toContain('title="Map"');
     expect(html).not.toContain('Super 8 by Wyndham Kelowna BC');
   });
 
-  /**
-   * The `2025` cancelled shape: every optional field absent (CONTEXT §Hiatus).
-   * The page collapses to hero + FAQ only — no register button, no schedule, no
-   * speakers / seminars / map / hotels. This proves a fully-empty conference
-   * renders cleanly through the shared module (it used to be a forked dead page).
-   */
   it('renders the 2025 cancelled shape: hero + FAQ only', () => {
     const conference2025: Conference = {
       ...fullConference,
-      slug: '2025',
+      slug: '/2025',
       speakers: [],
       seminars: [],
       registrationUrl: undefined,
       scheduleUrl: undefined,
-      mapEmbedUrl: undefined,
-      hotels: [],
+      travel: disabledTravel,
+      parking: disabledParking,
+      accommodations: disabledAccommodations,
+      meals: disabledMeals,
+      registrationCopy: disabledRegistrationCopy,
+      faqCopy: fullConference.faqCopy,
     };
     const html = renderConference(conference2025);
 
-    // Present: hero (image + tagline) and FAQ.
     expect(html).toContain(conference2025.hero.image.desktop);
     expect(html).toContain(conference2025.tagline);
-    expect(html).toContain(translations.en['registration.faq.title']);
-    // Absent: everything data-driven.
+    expect(html).toContain('Got Questions?');
     expect(html).not.toContain('Speakers');
     expect(html).not.toContain('Seminars');
-    expect(html).not.toContain(translations.en['registration.register.title']);
+    expect(html).not.toContain('Register Now!');
     expect(html).not.toContain('regfox.com');
     expect(html).not.toContain('title="Map"');
     expect(html).not.toContain('Super 8 by Wyndham Kelowna BC');
@@ -485,18 +459,26 @@ describe('ConferenceDetail section-skip', () => {
   it('renders the 2025 cancelled shape (hero + FAQ only) under /fr too', () => {
     const conference2025: Conference = {
       ...fullConference,
-      slug: '2025',
+      slug: '/2025',
       speakers: [],
       seminars: [],
       registrationUrl: undefined,
       scheduleUrl: undefined,
-      mapEmbedUrl: undefined,
-      hotels: [],
+      travel: disabledTravel,
+      parking: disabledParking,
+      accommodations: disabledAccommodations,
+      meals: disabledMeals,
+      registrationCopy: disabledRegistrationCopy,
+      faqCopy: {
+        enabled: true,
+        title: 'Des questions?',
+        subtitle: 'Nous sommes là pour vous aider.',
+      },
     };
     const html = renderConference(conference2025, { lang: 'fr' });
 
-    expect(html).toContain(translations.fr['registration.faq.title']);
-    expect(html).not.toContain(translations.fr['registration.register.title']);
+    expect(html).toContain('Des questions?');
+    expect(html).not.toContain('Inscrivez-vous!');
     expect(html).not.toContain('title="Map"');
   });
 });

--- a/app/routes/($lang)+/conference-detail.tsx
+++ b/app/routes/($lang)+/conference-detail.tsx
@@ -1,25 +1,25 @@
-import { useSearchParams } from 'react-router';
-import clsx from 'clsx';
+import { useSearchParams } from "react-router";
+import clsx from "clsx";
 import {
   AnimatePresence,
   motion,
   MotionConfig,
   transform,
   useMotionValue,
-} from 'framer-motion';
-import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
-import * as React from 'react';
-import { useButton } from '@base-ui/react/internals/use-button';
-import { match } from 'ts-pattern';
+} from "framer-motion";
+import { ArrowLeftIcon, ArrowRightIcon, PlaneLandingIcon } from "lucide-react";
+import * as React from "react";
+import { useButton } from "@base-ui/react/internals/use-button";
+import { match } from "ts-pattern";
 
-import { Breakpoint, useBreakpoint, useHints } from '~/lib/client-hints';
-import type { Conference } from '~/lib/content.server';
-import { dayjs } from '~/lib/dayjs';
-import { useLocale, useTranslate } from '~/lib/localization/context';
-import { buttonStyle } from '~/ui/button';
-import { ExternalLink } from '~/ui/external-link';
-import { Link } from '~/ui/link';
-import { Main } from '~/ui/main';
+import { Breakpoint, useBreakpoint, useHints } from "~/lib/client-hints";
+import type { Conference } from "~/lib/content.server";
+import { dayjs } from "~/lib/dayjs";
+import { useLocale, useTranslate } from "~/lib/localization/context";
+import { buttonStyle } from "~/ui/button";
+import { ExternalLink } from "~/ui/external-link";
+import { Link } from "~/ui/link";
+import { Main } from "~/ui/main";
 
 export function ConferenceDetail({ conference }: { conference: Conference }) {
   return (
@@ -52,7 +52,7 @@ function HeroCtas({ conference }: { conference: Conference }) {
     <div className="flex flex-wrap items-center gap-4">
       {conference.registrationUrl === undefined ? null : (
         <a className={buttonStyle} href={conference.registrationUrl}>
-          {translate('registration.register')}
+          {translate("registration.register")}
         </a>
       )}
       {conference.scheduleUrl === undefined ? null : (
@@ -62,7 +62,7 @@ function HeroCtas({ conference }: { conference: Conference }) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {translate('registration.schedule')}
+          {translate("registration.schedule")}
         </a>
       )}
     </div>
@@ -84,10 +84,10 @@ function MobileHero({ conference }: { conference: Conference }) {
       <div className="flex flex-col gap-4 px-4">
         <div className="flex flex-col gap-2 text-4xl">
           <h2>
-            {dayjs(conference.dates[0]).tz(hints.timeZone).format('MMM')}{' '}
-            {dayjs(conference.dates[0]).tz(hints.timeZone).format('D')}-
-            {dayjs(conference.dates[1]).tz(hints.timeZone).format('D')},{' '}
-            {dayjs(conference.dates[0]).tz(hints.timeZone).format('YYYY')}
+            {dayjs(conference.dates[0]).tz(hints.timeZone).format("MMM")}{" "}
+            {dayjs(conference.dates[0]).tz(hints.timeZone).format("D")}-
+            {dayjs(conference.dates[1]).tz(hints.timeZone).format("D")},{" "}
+            {dayjs(conference.dates[0]).tz(hints.timeZone).format("YYYY")}
           </h2>
           <h3>{conference.location}</h3>
         </div>
@@ -101,9 +101,9 @@ function MobileHero({ conference }: { conference: Conference }) {
           <a
             className={buttonStyle}
             data-variant="accent"
-            href={`https://www.biblegateway.com/passage/?search=${conference.bible.book}+${conference.bible.chapter}&version=${locale === 'en' ? 'NKJV' : 'LSG'}`}
+            href={`https://www.biblegateway.com/passage/?search=${conference.bible.book}+${conference.bible.chapter}&version=${locale === "en" ? "NKJV" : "LSG"}`}
           >
-            {translate('main.read_bible')}
+            {translate("main.read_bible")}
           </a>
         </div>
       </div>
@@ -124,10 +124,10 @@ function DesktopHero({ conference }: { conference: Conference }) {
           />
           <div className="flex flex-col gap-6">
             <h2 className="text-5xl">
-              {dayjs(conference.dates[0]).tz(hints.timeZone).format('MMM')}{' '}
-              {dayjs(conference.dates[0]).tz(hints.timeZone).format('D')}-
-              {dayjs(conference.dates[1]).tz(hints.timeZone).format('D')},{' '}
-              {dayjs(conference.dates[0]).tz(hints.timeZone).format('YYYY')}
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format("MMM")}{" "}
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format("D")}-
+              {dayjs(conference.dates[1]).tz(hints.timeZone).format("D")},{" "}
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format("YYYY")}
             </h2>
             <h3 className="text-5xl">{conference.location}</h3>
           </div>
@@ -136,7 +136,7 @@ function DesktopHero({ conference }: { conference: Conference }) {
         <div className="flex w-1/4 flex-col gap-10">
           <div
             className="flex flex-col justify-end uppercase"
-            style={{ writingMode: 'vertical-rl' }}
+            style={{ writingMode: "vertical-rl" }}
           >
             <h1 className="text-[96px] font-black leading-tight tracking-tight">
               {conference.bible.book}
@@ -153,18 +153,43 @@ function DesktopHero({ conference }: { conference: Conference }) {
 }
 
 function sectionHeadingClassName() {
-  return 'text-accent-600 text-4xl font-bold';
+  return "text-accent-600 text-4xl font-bold mb-2";
 }
 
 function TravelSection({ conference }: { conference: Conference }) {
   if (!conference.travel.enabled) return null;
 
   return (
-    <section className="flex flex-col gap-6 p-4 pb-16">
-      <h2 className={sectionHeadingClassName()}>{conference.travel.headerCopy}</h2>
-      <p className="whitespace-pre-line">{conference.travel.bodyCopy}</p>
+    <section className="flex flex-col sm:flex-row gap-6 p-4 pb-16">
+      <div className="sm:basis-1/2 flex flex-col gap-4">
+        <h2 className={sectionHeadingClassName()}>
+          {conference.travel.headerCopy}
+        </h2>
+        {conference.travel.bodyCopy === undefined ? null : (
+          <p className="whitespace-pre-line">{conference.travel.bodyCopy}</p>
+        )}
+        {conference.travel.airport === undefined ? null : (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <PlaneLandingIcon className="size-5 text-neutral-500" />
+              <span className="font-semibold">
+                {conference.travel.airport.name}
+              </span>
+            </div>
+            {conference.travel.airport.transitOptions.length === 0 ? null : (
+              <ul className="flex flex-col gap-1 pl-7">
+                {conference.travel.airport.transitOptions.map((opt, i) => (
+                  <li key={i} className="text-neutral-700">
+                    {opt.description}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
       {conference.travel.mapEmbedUrl === undefined ? null : (
-        <div className="aspect-video">
+        <div className="aspect-video sm:basis-1/2">
           <iframe
             src={conference.travel.mapEmbedUrl}
             style={{ border: 0 }}
@@ -188,6 +213,9 @@ function ParkingSection({ conference }: { conference: Conference }) {
       <h2 className={sectionHeadingClassName()}>
         {conference.parking.headerCopy}
       </h2>
+      {conference.parking.bodyCopy === undefined ? null : (
+        <p className="whitespace-pre-line">{conference.parking.bodyCopy}</p>
+      )}
       <ul className="flex flex-col gap-6">
         {conference.parking.options.map((option, index) => (
           <li key={index} className="flex flex-col gap-2">
@@ -199,11 +227,13 @@ function ParkingSection({ conference }: { conference: Conference }) {
               )}
               {option.address === undefined ? null : (
                 <>
-                  {' | '}
+                  {" | "}
                   {option.link === undefined ? (
                     option.address
                   ) : (
-                    <ExternalLink href={option.link}>{option.address}</ExternalLink>
+                    <ExternalLink href={option.link}>
+                      {option.address}
+                    </ExternalLink>
                   )}
                 </>
               )}
@@ -234,12 +264,14 @@ function AccommodationsSection({ conference }: { conference: Conference }) {
             <p>{hotel.address}</p>
             {hotel.checkIn === undefined ? null : (
               <p>
-                {translate('registration.accommodations.check_in')}: {hotel.checkIn}
+                {translate("registration.accommodations.check_in")}:{" "}
+                {hotel.checkIn}
               </p>
             )}
             {hotel.checkOut === undefined ? null : (
               <p>
-                {translate('registration.accommodations.check_out')}: {hotel.checkOut}
+                {translate("registration.accommodations.check_out")}:{" "}
+                {hotel.checkOut}
               </p>
             )}
             {hotel.roomRates.length === 0 ? null : (
@@ -259,7 +291,7 @@ function AccommodationsSection({ conference }: { conference: Conference }) {
                   className={buttonStyle}
                   data-variant="default"
                 >
-                  {translate('registration.accommodations.navigate')}
+                  {translate("registration.accommodations.navigate")}
                 </ExternalLink>
               )}
               {hotel.reservationUrl === undefined ? null : (
@@ -268,7 +300,7 @@ function AccommodationsSection({ conference }: { conference: Conference }) {
                   className={buttonStyle}
                   data-variant="accent"
                 >
-                  {translate('registration.accommodations.reserve')}
+                  {translate("registration.accommodations.reserve")}
                 </ExternalLink>
               )}
             </div>
@@ -284,7 +316,9 @@ function MealsSection({ conference }: { conference: Conference }) {
 
   return (
     <section className="flex flex-col gap-6 p-4 pb-16">
-      <h2 className={sectionHeadingClassName()}>{conference.meals.headerCopy}</h2>
+      <h2 className={sectionHeadingClassName()}>
+        {conference.meals.headerCopy}
+      </h2>
       {conference.meals.bodyCopy === undefined ? null : (
         <p className="whitespace-pre-line">{conference.meals.bodyCopy}</p>
       )}
@@ -306,7 +340,7 @@ function SpeakersAndSeminars({ conference }: { conference: Conference }) {
       {conference.speakers.length === 0 ? null : (
         <section className="relative flex flex-col gap-6 px-3 py-12">
           <h2 className="bg-inherit text-4xl font-bold data-[sticky]:fixed data-[sticky]:top-[60px] data-[sticky]:z-10">
-            {translate('registration.speakers.title')}
+            {translate("registration.speakers.title")}
           </h2>
           <div className="flex flex-col gap-20 md:grid md:grid-cols-1">
             {conference.speakers.map((speaker, i) => (
@@ -318,7 +352,7 @@ function SpeakersAndSeminars({ conference }: { conference: Conference }) {
       {conference.seminars.length === 0 ? null : (
         <section className="flex flex-col gap-6 px-3 py-12">
           <h2 className="sticky top-0 bg-inherit text-4xl font-bold">
-            {translate('registration.seminars.title')}
+            {translate("registration.seminars.title")}
           </h2>
           <div className="flex flex-col gap-20 md:grid md:grid-cols-1">
             {conference.seminars.map((seminar, i) => (
@@ -399,18 +433,18 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
   const ref = React.useRef<HTMLDivElement>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const isActive =
-    searchParams.has('speaker') && searchParams.get('speaker') === id;
+    searchParams.has("speaker") && searchParams.get("speaker") === id;
   const { position, rotate } = useCardRotation(ref, isActive);
 
   function onPress() {
     if (isActive) {
       setSearchParams((params) => {
-        params.delete('speaker');
+        params.delete("speaker");
         return params;
       });
     } else {
       setSearchParams((params) => {
-        params.set('speaker', id);
+        params.set("speaker", id);
         return params;
       });
     }
@@ -430,7 +464,7 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
   const bioButton = useButton({ native: false });
 
   return (
-    <MotionConfig transition={{ type: 'spring', duration: 0.3, bounce: 0 }}>
+    <MotionConfig transition={{ type: "spring", duration: 0.3, bounce: 0 }}>
       <motion.div animate={{ height: heightRef.current || undefined }}>
         <div className="overflow-hidden" ref={containerRef}>
           <AnimatePresence mode="popLayout" initial={false}>
@@ -489,7 +523,9 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
                       {name}
                     </motion.h3>
                     <ArrowRightIcon className="size-8" />
-                    <motion.p className="text-xl text-white">{activity}</motion.p>
+                    <motion.p className="text-xl text-white">
+                      {activity}
+                    </motion.p>
                   </div>
                 </div>
               </motion.div>
@@ -504,12 +540,12 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
 const SpeakerCardVariants = {
   initial: (isActive: boolean) => ({
     opacity: 0,
-    x: isActive ? '-100%' : '100%',
+    x: isActive ? "-100%" : "100%",
   }),
   enter: { opacity: 1, x: 0 },
   exit: (isActive: boolean) => ({
     opacity: 0,
-    x: isActive ? '-100%' : '100%',
+    x: isActive ? "-100%" : "100%",
   }),
 };
 
@@ -520,7 +556,7 @@ function useCardRotation(
   const position = useMotionValue(20);
   const rotate = useMotionValue(0);
   React.useEffect(() => {
-    const scrollContainer = document.querySelector('[data-scroll-container]');
+    const scrollContainer = document.querySelector("[data-scroll-container]");
     if (!scrollContainer || !ref.current) return;
 
     let isInViewport = false;
@@ -533,11 +569,14 @@ function useCardRotation(
     observer.observe(ref.current);
 
     const initialCardRect = ref.current.getBoundingClientRect();
-    const bounds = [initialCardRect.top, initialCardRect.top + initialCardRect.height];
+    const bounds = [
+      initialCardRect.top,
+      initialCardRect.top + initialCardRect.height,
+    ];
 
     function onScroll() {
       const containerEle = document.querySelector(
-        '[data-scroll-container]',
+        "[data-scroll-container]",
       ) as HTMLElement;
       if (!containerEle || !isInViewport) return;
       const scrollY = containerEle.scrollTop + containerEle.clientHeight;
@@ -545,10 +584,10 @@ function useCardRotation(
       rotate.set(transform(scrollY, bounds, [0, -3]));
     }
 
-    scrollContainer.addEventListener('scroll', onScroll);
+    scrollContainer.addEventListener("scroll", onScroll);
     return () => {
       observer.disconnect();
-      scrollContainer.removeEventListener('scroll', onScroll);
+      scrollContainer.removeEventListener("scroll", onScroll);
     };
   }, [position, rotate, ref, isActive]);
 
@@ -560,7 +599,7 @@ function RegistrationSection({ conference }: { conference: Conference }) {
   if (conference.registrationUrl === undefined) return null;
 
   return (
-    <section className="flex flex-col gap-6 p-4 md:py-32">
+    <section className="flex flex-col gap-6 p-4 md:py-12">
       <h2 className={sectionHeadingClassName()}>
         {conference.registrationCopy.title}
       </h2>
@@ -583,15 +622,15 @@ function FaqSection({ conference }: { conference: Conference }) {
   if (!conference.faqCopy.enabled) return null;
 
   return (
-    <section className="flex flex-col gap-6 p-4 md:py-32">
+    <section className="flex flex-col gap-6 p-4 md:py-12">
       <h2 className={sectionHeadingClassName()}>{conference.faqCopy.title}</h2>
       <p>{conference.faqCopy.subtitle}</p>
-      <div className="flex flex-col gap-4">
-        <Link to="/contact" className={buttonStyle} data-variant="accent">
-          {translate('registration.faq.contact')}
+      <div className="flex gap-4 items-center flex-wrap">
+        <Link to="/faq" className={buttonStyle} data-variant="accent">
+          {translate("registration.faq.view")}
         </Link>
-        <Link to="/faq" className={buttonStyle} data-variant="default">
-          {translate('registration.faq.view')}
+        <Link to="/contact" className={buttonStyle} data-variant="default">
+          {translate("registration.faq.contact")}
         </Link>
       </div>
     </section>

--- a/app/routes/($lang)+/conference-detail.tsx
+++ b/app/routes/($lang)+/conference-detail.tsx
@@ -21,66 +21,17 @@ import { ExternalLink } from '~/ui/external-link';
 import { Link } from '~/ui/link';
 import { Main } from '~/ui/main';
 
-/**
- * The one data-driven conference detail page, shared by every `/YYYY` route
- * (registration-launch Branch 3, Candidate 1, settled #4). It was forked
- * verbatim across `2024`/`2025`/`2026/_index.tsx` (~620 lines each, differing
- * only in hard-coded URLs / hotels / a JSX comment block); this module is the
- * single deep implementation those three thin loaders now render.
- *
- * Principles (see `~/.brain/principles`):
- *   - `small-interface-deep-implementation`: the public surface is one prop —
- *     the boundary `Conference`. Every section (`Hero`, `MapSection`,
- *     `SpeakersAndSeminars`, `RegistrationSection`, `FaqSection`) and all the
- *     framer-motion card machinery is an implementation detail hidden inside.
- *   - `boundary-discipline` / `derive-dont-sync`: the formerly hard-coded RegFox
- *     link, schedule link, map iframe `src`, and hotel list are now read from
- *     the `Conference` (`registrationUrl` / `scheduleUrl` / `mapEmbedUrl` /
- *     `hotels`), which `toConference` already projected from validated document
- *     `Option`s to `string | undefined` (XSS-safe https brands). The component
- *     consumes plain strings; it never sees an `Option`.
- *   - `subtract-before-you-add`: the three forks delete down to thin loaders
- *     (Branch 3.4) once they render this; the duplicated JSX dies.
- *
- * Section-skip (registration-launch Branch 4, Candidate 2, settled #3, CONTEXT
- * §"Section skip"): a section renders only when its data is present. The
- * discriminator is the boundary data this module already consumes — the
- * `Option`/empty-array the document modelled, projected by `toConference` to
- * `string | undefined` / `[]`. The component branches on that; there are NO JSX
- * comments and NO dormant `eslint-disable` render paths (the pre-fork
- * scaffolding the collapse already deleted). Skip is section-LEVEL — a *present*
- * item with a blank required bilingual field is still a hard `Text` decode error
- * upstream (the both-locales invariant lives in the schema, never the
- * component), so this module never sees half-filled content.
- *
- * Each gate is independent (`make-impossible-states-unrepresentable` at the
- * presentation seam):
- *   - speakers / seminars: each renders only when its list is non-empty;
- *   - the map column renders when `mapEmbedUrl !== undefined`, the hotels column
- *     when `hotels.length > 0` — each half of `MapSection` independently, and
- *     the whole section is skipped when neither half has data;
- *   - the RegFox register button / `RegistrationSection`: `registrationUrl`
- *     present;
- *   - the schedule button: `scheduleUrl` present;
- *   - `FaqSection`: always present (static contact/FAQ links, no conference
- *     data).
- *
- * `2026` (RegFox-only) thus renders hero + register button + FAQ with no empty
- * Speakers/Map sections; `2025` (cancelled) renders hero + FAQ only; `2024`
- * (fully populated) renders every section.
- */
 export function ConferenceDetail({ conference }: { conference: Conference }) {
   return (
     <Main>
       <Hero conference={conference} />
-
-      <MapSection conference={conference} />
-
+      <TravelSection conference={conference} />
       <SpeakersAndSeminars conference={conference} />
-
+      <ParkingSection conference={conference} />
+      <AccommodationsSection conference={conference} />
+      <MealsSection conference={conference} />
       <RegistrationSection conference={conference} />
-
-      <FaqSection />
+      <FaqSection conference={conference} />
     </Main>
   );
 }
@@ -95,6 +46,29 @@ function Hero({ conference }: { conference: Conference }) {
     .otherwise(() => <DesktopHero conference={conference} />);
 }
 
+function HeroCtas({ conference }: { conference: Conference }) {
+  const translate = useTranslate();
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      {conference.registrationUrl === undefined ? null : (
+        <a className={buttonStyle} href={conference.registrationUrl}>
+          {translate('registration.register')}
+        </a>
+      )}
+      {conference.scheduleUrl === undefined ? null : (
+        <a
+          className={clsx(buttonStyle)}
+          href={conference.scheduleUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {translate('registration.schedule')}
+        </a>
+      )}
+    </div>
+  );
+}
+
 function MobileHero({ conference }: { conference: Conference }) {
   const hints = useHints();
   const translate = useTranslate();
@@ -102,31 +76,11 @@ function MobileHero({ conference }: { conference: Conference }) {
 
   return (
     <section className="flex flex-col gap-10 pb-16">
-      <div>
-        <img
-          src={conference.hero.image.mobile}
-          alt={conference.hero.alt}
-        />
-        <div className="absolute -bottom-6 left-4 flex items-center gap-4">
-          {conference.registrationUrl === undefined ? null : (
-            <a
-              className={clsx(buttonStyle)}
-              href={conference.registrationUrl}
-            >
-              {translate('registration.register')}
-            </a>
-          )}
-          {conference.scheduleUrl === undefined ? null : (
-            <a
-              className={clsx(buttonStyle)}
-              href={conference.scheduleUrl}
-              target="_blank"
-            >
-              {translate('registration.schedule')}
-            </a>
-          )}
-        </div>
-      </div>
+      <img
+        src={conference.hero.image.mobile}
+        alt={conference.hero.alt}
+        className="aspect-auto w-full"
+      />
       <div className="flex flex-col gap-4 px-4">
         <div className="flex flex-col gap-2 text-4xl">
           <h2>
@@ -142,6 +96,7 @@ function MobileHero({ conference }: { conference: Conference }) {
           {conference.bible.book} {conference.bible.chapter}:
           {conference.bible.verse}
         </p>
+        <HeroCtas conference={conference} />
         <div>
           <a
             className={buttonStyle}
@@ -158,7 +113,6 @@ function MobileHero({ conference }: { conference: Conference }) {
 
 function DesktopHero({ conference }: { conference: Conference }) {
   const hints = useHints();
-  const translate = useTranslate();
   return (
     <section className="full-bleed flex flex-col gap-10 p-4 pb-16">
       <div className="mx-auto flex w-(--width) gap-10 py-16">
@@ -166,15 +120,23 @@ function DesktopHero({ conference }: { conference: Conference }) {
           <img
             src={conference.hero.image.desktop}
             alt={conference.hero.alt}
+            className="aspect-auto w-full"
           />
+          <div className="flex flex-col gap-6">
+            <h2 className="text-5xl">
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format('MMM')}{' '}
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format('D')}-
+              {dayjs(conference.dates[1]).tz(hints.timeZone).format('D')},{' '}
+              {dayjs(conference.dates[0]).tz(hints.timeZone).format('YYYY')}
+            </h2>
+            <h3 className="text-5xl">{conference.location}</h3>
+          </div>
           <p className="text-2xl italic">{conference.tagline}</p>
         </div>
-        <div className="flex w-1/4 flex-col justify-between gap-6">
+        <div className="flex w-1/4 flex-col gap-10">
           <div
             className="flex flex-col justify-end uppercase"
-            style={{
-              writingMode: 'vertical-rl',
-            }}
+            style={{ writingMode: 'vertical-rl' }}
           >
             <h1 className="text-[96px] font-black leading-tight tracking-tight">
               {conference.bible.book}
@@ -183,94 +145,156 @@ function DesktopHero({ conference }: { conference: Conference }) {
               {conference.bible.chapter}:{conference.bible.verse}
             </h1>
           </div>
-          <div className="flex flex-col gap-10">
-            <div className="flex flex-col gap-6">
-              <h2 className="text-5xl">
-                {dayjs(conference.dates[0]).tz(hints.timeZone).format('MMM')}{' '}
-                {dayjs(conference.dates[0]).tz(hints.timeZone).format('D')}-
-                {dayjs(conference.dates[1]).tz(hints.timeZone).format('D')},{' '}
-                {dayjs(conference.dates[0]).tz(hints.timeZone).format('YYYY')}
-              </h2>
-              <h3 className="text-5xl">{conference.location}</h3>
-            </div>
-            <div className="flex items-center gap-4">
-              {conference.registrationUrl === undefined ? null : (
-                <a
-                  className={buttonStyle}
-                  href={conference.registrationUrl}
-                >
-                  {translate('registration.register')}
-                </a>
-              )}
-              {conference.scheduleUrl === undefined ? null : (
-                <a
-                  className={clsx(buttonStyle)}
-                  href={conference.scheduleUrl}
-                  target="_blank"
-                >
-                  {translate('registration.schedule')}
-                </a>
-              )}
-            </div>
-          </div>
+          <HeroCtas conference={conference} />
         </div>
       </div>
     </section>
   );
 }
 
-function MapSection({ conference }: { conference: Conference }) {
-  const translate = useTranslate();
+function sectionHeadingClassName() {
+  return 'text-accent-600 text-4xl font-bold';
+}
 
-  const hasHotels = conference.hotels.length > 0;
-  const hasMap = conference.mapEmbedUrl !== undefined;
-
-  // Skip the whole section when neither half has data (each half gated
-  // independently below): a conference with no hotels and no map embed renders
-  // nothing here.
-  if (!hasHotels && !hasMap) return null;
+function TravelSection({ conference }: { conference: Conference }) {
+  if (!conference.travel.enabled) return null;
 
   return (
-    <section
-      aria-label="Venue and accommodations"
-      className="grid grid-cols-1 gap-10 p-4 pb-16 md:grid-cols-2"
-    >
-      {hasHotels ? (
-        <div className="flex flex-col gap-6">
-          <p>
-            {translate('registration.hotels.description', {
-              facebook: (
-                <ExternalLink href="https://www.facebook.com/groups/1741752369173171">
-                  {translate('registration.hotels.description.facebook')}
-                </ExternalLink>
-              ),
-            })}
-          </p>
-          <ul>
-            {conference.hotels.map((hotel, i) => (
-              <li key={i}>
-                {hotel.name}
-                {hotel.note === undefined ? null : ` ${hotel.note}`}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-      {conference.mapEmbedUrl === undefined ? null : (
+    <section className="flex flex-col gap-6 p-4 pb-16">
+      <h2 className={sectionHeadingClassName()}>{conference.travel.headerCopy}</h2>
+      <p className="whitespace-pre-line">{conference.travel.bodyCopy}</p>
+      {conference.travel.mapEmbedUrl === undefined ? null : (
         <div className="aspect-video">
           <iframe
-            src={conference.mapEmbedUrl}
-            style={{
-              border: 0,
-            }}
+            src={conference.travel.mapEmbedUrl}
+            style={{ border: 0 }}
             className="size-full"
             allowFullScreen
             loading="lazy"
             referrerPolicy="no-referrer-when-downgrade"
             title="Map"
-          ></iframe>
+          />
         </div>
       )}
+    </section>
+  );
+}
+
+function ParkingSection({ conference }: { conference: Conference }) {
+  if (!conference.parking.enabled) return null;
+
+  return (
+    <section className="flex flex-col gap-6 p-4 pb-16">
+      <h2 className={sectionHeadingClassName()}>
+        {conference.parking.headerCopy}
+      </h2>
+      <ul className="flex flex-col gap-6">
+        {conference.parking.options.map((option, index) => (
+          <li key={index} className="flex flex-col gap-2">
+            <div className="text-xl">
+              {option.link === undefined ? (
+                option.title
+              ) : (
+                <ExternalLink href={option.link}>{option.title}</ExternalLink>
+              )}
+              {option.address === undefined ? null : (
+                <>
+                  {' | '}
+                  {option.link === undefined ? (
+                    option.address
+                  ) : (
+                    <ExternalLink href={option.link}>{option.address}</ExternalLink>
+                  )}
+                </>
+              )}
+            </div>
+            {option.description === undefined ? null : (
+              <p className="text-neutral-700">{option.description}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function AccommodationsSection({ conference }: { conference: Conference }) {
+  const translate = useTranslate();
+  if (!conference.accommodations.enabled) return null;
+
+  return (
+    <section className="flex flex-col gap-10 p-4 pb-16">
+      <h2 className={sectionHeadingClassName()}>
+        {conference.accommodations.headerCopy}
+      </h2>
+      <div className="flex flex-col gap-12">
+        {conference.accommodations.hotels.map((hotel, index) => (
+          <article key={index} className="flex flex-col gap-4">
+            <h3 className="text-2xl font-bold">{hotel.name}</h3>
+            <p>{hotel.address}</p>
+            {hotel.checkIn === undefined ? null : (
+              <p>
+                {translate('registration.accommodations.check_in')}: {hotel.checkIn}
+              </p>
+            )}
+            {hotel.checkOut === undefined ? null : (
+              <p>
+                {translate('registration.accommodations.check_out')}: {hotel.checkOut}
+              </p>
+            )}
+            {hotel.roomRates.length === 0 ? null : (
+              <ul className="list-disc pl-6">
+                {hotel.roomRates.map((rate, rateIndex) => (
+                  <li key={rateIndex}>{rate.description}</li>
+                ))}
+              </ul>
+            )}
+            {hotel.description === undefined ? null : (
+              <p className="whitespace-pre-line">{hotel.description}</p>
+            )}
+            <div className="flex flex-wrap gap-4">
+              {hotel.navigateUrl === undefined ? null : (
+                <ExternalLink
+                  href={hotel.navigateUrl}
+                  className={buttonStyle}
+                  data-variant="default"
+                >
+                  {translate('registration.accommodations.navigate')}
+                </ExternalLink>
+              )}
+              {hotel.reservationUrl === undefined ? null : (
+                <ExternalLink
+                  href={hotel.reservationUrl}
+                  className={buttonStyle}
+                  data-variant="accent"
+                >
+                  {translate('registration.accommodations.reserve')}
+                </ExternalLink>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function MealsSection({ conference }: { conference: Conference }) {
+  if (!conference.meals.enabled) return null;
+
+  return (
+    <section className="flex flex-col gap-6 p-4 pb-16">
+      <h2 className={sectionHeadingClassName()}>{conference.meals.headerCopy}</h2>
+      {conference.meals.bodyCopy === undefined ? null : (
+        <p className="whitespace-pre-line">{conference.meals.bodyCopy}</p>
+      )}
+      <ul className="flex flex-col gap-2">
+        {conference.meals.items.map((item, index) => (
+          <li key={index} className="text-xl">
+            {item.label} — {item.price}
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }
@@ -286,10 +310,7 @@ function SpeakersAndSeminars({ conference }: { conference: Conference }) {
           </h2>
           <div className="flex flex-col gap-20 md:grid md:grid-cols-1">
             {conference.speakers.map((speaker, i) => (
-              <SpeakerCard
-                key={i}
-                {...speaker}
-              />
+              <SpeakerCard key={i} {...speaker} />
             ))}
           </div>
         </section>
@@ -339,24 +360,15 @@ function DesktopSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
   const { position, rotate } = useCardRotation(ref);
   return (
     <div className="flex items-start gap-8">
-      <motion.div
-        className="relative aspect-square flex-1"
-        ref={ref}
-        id={id}
-      >
+      <motion.div className="relative aspect-square flex-1" ref={ref} id={id}>
         <motion.div
           className="text-link-50 bg-link-600 rota size-[95%] h-[90%] overflow-hidden p-4"
-          style={{
-            left: position,
-            top: position,
-            rotate,
-          }}
+          style={{ left: position, top: position, rotate }}
         >
           <p className="break-words text-[100px] font-black uppercase leading-[0.8] tracking-tight opacity-30">
             {activity}
           </p>
         </motion.div>
-
         <div className="absolute bottom-0 right-0 size-[90%] overflow-hidden rounded-md">
           <img
             className="size-full object-cover"
@@ -364,22 +376,18 @@ function DesktopSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
             alt={`${name}, ${activity}`}
           />
           <div className="absolute inset-x-0 bottom-0 flex flex-col bg-black/30 p-4 text-white">
-            <div className="flex items-center gap-2">
-              <motion.h3 className="shrink text-3xl font-bold leading-8 text-white">
-                {name}
-              </motion.h3>
-            </div>
+            <motion.h3 className="shrink text-3xl font-bold leading-8 text-white">
+              {name}
+            </motion.h3>
             <motion.p className="text-xl text-white">{activity}</motion.p>
           </div>
         </div>
       </motion.div>
-
       <div className="flex flex-[3] flex-col gap-8">
         <div className="flex flex-col gap-4">
           <motion.h3 className="text-3xl font-bold leading-5">{name}</motion.h3>
           <motion.p className="text-xl">{activity}</motion.p>
         </div>
-
         <motion.p className="text-xl">{bio}</motion.p>
       </div>
     </div>
@@ -389,7 +397,6 @@ function DesktopSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
 function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
   const id = React.useId();
   const ref = React.useRef<HTMLDivElement>(null);
-
   const [searchParams, setSearchParams] = useSearchParams();
   const isActive =
     searchParams.has('speaker') && searchParams.get('speaker') === id;
@@ -397,49 +404,36 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
 
   function onPress() {
     if (isActive) {
-      setSearchParams((searchParams) => {
-        searchParams.delete('speaker');
-        return searchParams;
+      setSearchParams((params) => {
+        params.delete('speaker');
+        return params;
       });
     } else {
-      setSearchParams((searchParams) => {
-        searchParams.set('speaker', id);
-        return searchParams;
+      setSearchParams((params) => {
+        params.set('speaker', id);
+        return params;
       });
     }
   }
 
   const containerRef = React.useRef<HTMLDivElement>(null);
-
   const heightRef = React.useRef<number | null>(null);
 
   React.useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    const height = container.offsetHeight;
-    heightRef.current = height;
+    heightRef.current = container.offsetHeight;
   }, [isActive]);
 
   const bioRef = React.useRef<HTMLDivElement>(null);
-
   const cardButton = useButton({ native: false });
   const bioButton = useButton({ native: false });
 
   return (
     <MotionConfig transition={{ type: 'spring', duration: 0.3, bounce: 0 }}>
-      <motion.div
-        animate={{
-          height: heightRef.current || undefined,
-        }}
-      >
-        <div
-          className="overflow-hidden"
-          ref={containerRef}
-        >
-          <AnimatePresence
-            mode="popLayout"
-            initial={false}
-          >
+      <motion.div animate={{ height: heightRef.current || undefined }}>
+        <div className="overflow-hidden" ref={containerRef}>
+          <AnimatePresence mode="popLayout" initial={false}>
             {isActive ? (
               <motion.div
                 key="bio"
@@ -461,7 +455,6 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
                   </div>
                   <motion.p className="text-xl">{activity}</motion.p>
                 </div>
-
                 <motion.p className="text-xl">{bio}</motion.p>
               </motion.div>
             ) : (
@@ -479,17 +472,12 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
               >
                 <motion.div
                   className="text-link-50 bg-link-600 rota size-[95%] h-[90%] overflow-hidden p-4"
-                  style={{
-                    left: position,
-                    top: position,
-                    rotate,
-                  }}
+                  style={{ left: position, top: position, rotate }}
                 >
                   <p className="break-words text-[100px] font-black uppercase leading-[0.8] tracking-tight opacity-30">
                     {activity}
                   </p>
                 </motion.div>
-
                 <div className="absolute bottom-0 right-0 size-[90%] overflow-hidden rounded-md">
                   <img
                     className="size-full object-cover"
@@ -497,15 +485,11 @@ function MobileSpeakerCard({ name, activity, img, bio }: SpeakerCardProps) {
                     alt={`${name}, ${activity}`}
                   />
                   <div className="absolute inset-x-0 bottom-0 flex flex-col bg-black/30 p-4 text-white">
-                    <div className="flex items-center gap-2">
-                      <motion.h3 className="text-3xl font-bold leading-5 text-white">
-                        {name}
-                      </motion.h3>
-                      <ArrowRightIcon className="size-8" />
-                    </div>
-                    <motion.p className="text-xl text-white">
-                      {activity}
-                    </motion.p>
+                    <motion.h3 className="text-3xl font-bold leading-5 text-white">
+                      {name}
+                    </motion.h3>
+                    <ArrowRightIcon className="size-8" />
+                    <motion.p className="text-xl text-white">{activity}</motion.p>
                   </div>
                 </div>
               </motion.div>
@@ -522,10 +506,7 @@ const SpeakerCardVariants = {
     opacity: 0,
     x: isActive ? '-100%' : '100%',
   }),
-  enter: {
-    opacity: 1,
-    x: 0,
-  },
+  enter: { opacity: 1, x: 0 },
   exit: (isActive: boolean) => ({
     opacity: 0,
     x: isActive ? '-100%' : '100%',
@@ -540,51 +521,28 @@ function useCardRotation(
   const rotate = useMotionValue(0);
   React.useEffect(() => {
     const scrollContainer = document.querySelector('[data-scroll-container]');
-
-    if (!scrollContainer) return;
-    if (!ref.current) return;
+    if (!scrollContainer || !ref.current) return;
 
     let isInViewport = false;
-
     const observer = new IntersectionObserver(
       (entries) => {
-        const entry = entries[0];
-        if (entry?.isIntersecting) {
-          isInViewport = true;
-        } else {
-          isInViewport = false;
-        }
+        isInViewport = entries[0]?.isIntersecting ?? false;
       },
-      {
-        root: scrollContainer,
-
-        threshold: 0,
-      },
+      { root: scrollContainer, threshold: 0 },
     );
+    observer.observe(ref.current);
 
-    observer.observe(ref.current!);
-
-    const initialCardRect = ref.current?.getBoundingClientRect();
-
-    if (!initialCardRect) return;
-    const bounds = [
-      initialCardRect.top,
-      initialCardRect.top + initialCardRect.height,
-    ];
+    const initialCardRect = ref.current.getBoundingClientRect();
+    const bounds = [initialCardRect.top, initialCardRect.top + initialCardRect.height];
 
     function onScroll() {
       const containerEle = document.querySelector(
         '[data-scroll-container]',
       ) as HTMLElement;
-      if (!containerEle) return;
-      if (!isInViewport) return;
+      if (!containerEle || !isInViewport) return;
       const scrollY = containerEle.scrollTop + containerEle.clientHeight;
-
-      const nextPosition = transform(scrollY, bounds, [20, 4]);
-      const nextRotate = transform(scrollY, bounds, [0, -3]);
-
-      position.set(nextPosition);
-      rotate.set(nextRotate);
+      position.set(transform(scrollY, bounds, [20, 4]));
+      rotate.set(transform(scrollY, bounds, [0, -3]));
     }
 
     scrollContainer.addEventListener('scroll', onScroll);
@@ -594,66 +552,47 @@ function useCardRotation(
     };
   }, [position, rotate, ref, isActive]);
 
-  return {
-    position,
-    rotate,
-  };
+  return { position, rotate };
 }
 
 function RegistrationSection({ conference }: { conference: Conference }) {
-  const translate = useTranslate();
-
-  // The RegFox register button is the section's reason to exist; with no
-  // `registrationUrl` (e.g. a cancelled year) the whole section is skipped.
+  if (!conference.registrationCopy.enabled) return null;
   if (conference.registrationUrl === undefined) return null;
 
   return (
     <section className="flex flex-col gap-6 p-4 md:py-32">
-      <h2 className="text-accent-600 text-4xl font-bold">
-        {translate('registration.register.title')}
+      <h2 className={sectionHeadingClassName()}>
+        {conference.registrationCopy.title}
       </h2>
-      <p>{translate('registration.register.subtitle')}</p>
-
+      <p>{conference.registrationCopy.subtitle}</p>
       <div>
         <a
           href={conference.registrationUrl}
           className={buttonStyle}
           data-variant="accent"
         >
-          {translate('registration.register.button')}
+          {conference.registrationCopy.buttonLabel}
         </a>
       </div>
     </section>
   );
 }
 
-function FaqSection() {
+function FaqSection({ conference }: { conference: Conference }) {
   const translate = useTranslate();
+  if (!conference.faqCopy.enabled) return null;
+
   return (
     <section className="flex flex-col gap-6 p-4 md:py-32">
-      <h2 className="text-accent-600 text-4xl font-bold">
-        {translate('registration.faq.title')}
-      </h2>
-      <p>{translate('registration.faq.subtitle')}</p>
+      <h2 className={sectionHeadingClassName()}>{conference.faqCopy.title}</h2>
+      <p>{conference.faqCopy.subtitle}</p>
       <div className="flex flex-col gap-4">
-        <div>
-          <Link
-            to="/contact"
-            className={buttonStyle}
-            data-variant="accent"
-          >
-            {translate('registration.faq.contact')}
-          </Link>
-        </div>
-        <div>
-          <Link
-            to="/faq"
-            className={buttonStyle}
-            data-variant="default"
-          >
-            {translate('registration.faq.view')}
-          </Link>
-        </div>
+        <Link to="/contact" className={buttonStyle} data-variant="accent">
+          {translate('registration.faq.contact')}
+        </Link>
+        <Link to="/faq" className={buttonStyle} data-variant="default">
+          {translate('registration.faq.view')}
+        </Link>
       </div>
     </section>
   );

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -12,6 +12,7 @@ import {
   AddItemButton,
   Bilingual,
   type ActionResult,
+  Checkbox,
   ImageUpload,
   ItemControls,
   Section,
@@ -307,6 +308,65 @@ export default function AdminContentEditor() {
     location: { en: string; fr: string };
     dates: { start: string; end: string };
     bible: { book: { en: string; fr: string }; chapter: number; verse: number };
+    registrationUrl?: string;
+    scheduleUrl?: string;
+    learnMoreEnabled?: boolean;
+    travel?: {
+      enabled?: boolean;
+      headerCopy?: { en: string; fr: string };
+      bodyCopy?: { en: string; fr: string };
+      mapEmbedUrl?: string;
+    };
+    parking?: {
+      enabled?: boolean;
+      headerCopy?: { en: string; fr: string };
+      options?: ReadonlyArray<{
+        id: string;
+        title?: { en: string; fr: string };
+        link?: string;
+        address?: { en: string; fr: string };
+        description?: { en: string; fr: string };
+      }>;
+    };
+    accommodations?: {
+      enabled?: boolean;
+      headerCopy?: { en: string; fr: string };
+      hotels?: ReadonlyArray<{
+        id: string;
+        name?: { en: string; fr: string };
+        address?: { en: string; fr: string };
+        checkIn?: { en: string; fr: string };
+        checkOut?: { en: string; fr: string };
+        roomRates?: ReadonlyArray<{
+          id: string;
+          description?: { en: string; fr: string };
+        }>;
+        description?: { en: string; fr: string };
+        navigateUrl?: string;
+        reservationUrl?: string;
+      }>;
+    };
+    meals?: {
+      enabled?: boolean;
+      headerCopy?: { en: string; fr: string };
+      bodyCopy?: { en: string; fr: string };
+      items?: ReadonlyArray<{
+        id: string;
+        label?: { en: string; fr: string };
+        price?: { en: string; fr: string };
+      }>;
+    };
+    registrationCopy?: {
+      enabled?: boolean;
+      title?: { en: string; fr: string };
+      subtitle?: { en: string; fr: string };
+      buttonLabel?: { en: string; fr: string };
+    };
+    faqCopy?: {
+      enabled?: boolean;
+      title?: { en: string; fr: string };
+      subtitle?: { en: string; fr: string };
+    };
     hero: {
       desktop: { key: { en: string; fr: string }; alt: { en: string; fr: string } };
       mobile: { key: { en: string; fr: string }; alt: { en: string; fr: string } };
@@ -317,6 +377,16 @@ export default function AdminContentEditor() {
       activity?: { en: string; fr: string };
       bio?: { en: string; fr: string };
       photo?: { key: string; alt: { en: string; fr: string } };
+    }>;
+    seminars: ReadonlyArray<{
+      id: string;
+      title?: { en: string; fr: string };
+      description?: { en: string; fr: string };
+      speaker?: {
+        name?: { en: string; fr: string };
+        bio?: { en: string; fr: string };
+        photo?: { key: string; alt: { en: string; fr: string } };
+      };
     }>;
   }>;
   const team = (document.team ?? []) as ReadonlyArray<{
@@ -385,6 +455,47 @@ export default function AdminContentEditor() {
           const conf = `conferences.${conference.slug}`;
           const speakersPath = `${conf}.speakers`;
           const speakerIds = conference.speakers.map((s) => s.id);
+          const seminarsPath = `${conf}.seminars`;
+          const seminarIds = (conference.seminars ?? []).map((s) => s.id);
+          const parkingPath = `${conf}.parking.options`;
+          const parkingOptionIds = (conference.parking?.options ?? []).map((o) => o.id);
+          const hotelsPath = `${conf}.accommodations.hotels`;
+          const hotelIds = (conference.accommodations?.hotels ?? []).map((h) => h.id);
+          const mealsPath = `${conf}.meals.items`;
+          const mealIds = (conference.meals?.items ?? []).map((m) => m.id);
+          const travel = {
+            enabled: conference.travel?.enabled ?? false,
+            headerCopy: conference.travel?.headerCopy ?? emptyText,
+            bodyCopy: conference.travel?.bodyCopy ?? emptyText,
+            mapEmbedUrl: conference.travel?.mapEmbedUrl ?? '',
+          };
+          const parking = conference.parking ?? {
+            enabled: false,
+            headerCopy: emptyText,
+            options: [],
+          };
+          const accommodations = conference.accommodations ?? {
+            enabled: false,
+            headerCopy: emptyText,
+            hotels: [],
+          };
+          const meals = conference.meals ?? {
+            enabled: false,
+            headerCopy: emptyText,
+            bodyCopy: emptyText,
+            items: [],
+          };
+          const registrationCopy = conference.registrationCopy ?? {
+            enabled: false,
+            title: emptyText,
+            subtitle: emptyText,
+            buttonLabel: emptyText,
+          };
+          const faqCopy = conference.faqCopy ?? {
+            enabled: false,
+            title: emptyText,
+            subtitle: emptyText,
+          };
           return (
             <Section key={conference.slug} title={`Conference ${conference.slug}`}>
               <Bilingual
@@ -437,6 +548,320 @@ export default function AdminContentEditor() {
                   defaultValue={String(conference.bible.verse)}
                 />
               </div>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="text-sm font-medium text-neutral-800">
+                  Links
+                </legend>
+                <Text
+                  label="Registration URL (RegFox)"
+                  name={`${conf}.registrationUrl`}
+                  defaultValue={conference.registrationUrl ?? ''}
+                />
+                <Text
+                  label="Schedule URL"
+                  name={`${conf}.scheduleUrl`}
+                  defaultValue={conference.scheduleUrl ?? ''}
+                />
+                <Checkbox
+                  label="Show Learn More on home page"
+                  name={`${conf}.learnMoreEnabled`}
+                  defaultChecked={conference.learnMoreEnabled ?? false}
+                />
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="text-sm font-medium text-neutral-800">
+                  Travel section
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.travel.enabled`}
+                  defaultChecked={travel.enabled ?? false}
+                />
+                <Bilingual
+                  label="Header"
+                  name={`${conf}.travel.headerCopy`}
+                  value={travel.headerCopy ?? emptyText}
+                />
+                <Bilingual
+                  label="Body copy"
+                  name={`${conf}.travel.bodyCopy`}
+                  value={travel.bodyCopy ?? emptyText}
+                  multiline
+                />
+                <Text
+                  label="Map embed URL"
+                  name={`${conf}.travel.mapEmbedUrl`}
+                  defaultValue={travel.mapEmbedUrl ?? ''}
+                />
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
+                  <span>Parking section</span>
+                  <AddItemButton
+                    listPath={parkingPath}
+                    label="+ Add parking option"
+                    newId={newListItemId()}
+                  />
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.parking.enabled`}
+                  defaultChecked={parking.enabled ?? false}
+                />
+                <Bilingual
+                  label="Header"
+                  name={`${conf}.parking.headerCopy`}
+                  value={parking.headerCopy ?? emptyText}
+                />
+                {(parking.options ?? []).map((option, oi) => {
+                  const optionId = ListItemId.make(option.id);
+                  return (
+                    <div
+                      key={option.id}
+                      className="space-y-2 rounded-md bg-neutral-50 p-3"
+                    >
+                      <div className="flex items-center justify-end">
+                        <ItemControls
+                          listPath={parkingPath}
+                          ids={parkingOptionIds}
+                          index={oi}
+                        />
+                      </div>
+                      <Bilingual
+                        label="Title"
+                        name={fieldName(parkingPath, optionId, 'title')}
+                        value={option.title ?? emptyText}
+                      />
+                      <Text
+                        label="Link (optional)"
+                        name={fieldName(parkingPath, optionId, 'link')}
+                        defaultValue={option.link ?? ''}
+                      />
+                      <Bilingual
+                        label="Address (optional)"
+                        name={fieldName(parkingPath, optionId, 'address')}
+                        value={option.address ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Description (optional)"
+                        name={fieldName(parkingPath, optionId, 'description')}
+                        value={option.description ?? emptyText}
+                        multiline
+                      />
+                    </div>
+                  );
+                })}
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
+                  <span>Accommodations section</span>
+                  <AddItemButton
+                    listPath={hotelsPath}
+                    label="+ Add hotel"
+                    newId={newListItemId()}
+                  />
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.accommodations.enabled`}
+                  defaultChecked={accommodations.enabled ?? false}
+                />
+                <Bilingual
+                  label="Header"
+                  name={`${conf}.accommodations.headerCopy`}
+                  value={accommodations.headerCopy ?? emptyText}
+                  multiline
+                />
+                {(accommodations.hotels ?? []).map((hotel, hi) => {
+                  const hotelId = ListItemId.make(hotel.id);
+                  const roomRatesPath = `${hotelsPath}.${hotelId}.roomRates`;
+                  const roomRateIds = (hotel.roomRates ?? []).map((r) => r.id);
+                  return (
+                    <div
+                      key={hotel.id}
+                      className="space-y-2 rounded-md bg-neutral-50 p-3"
+                    >
+                      <div className="flex items-center justify-end">
+                        <ItemControls
+                          listPath={hotelsPath}
+                          ids={hotelIds}
+                          index={hi}
+                        />
+                      </div>
+                      <Bilingual
+                        label="Name"
+                        name={fieldName(hotelsPath, hotelId, 'name')}
+                        value={hotel.name ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Address"
+                        name={fieldName(hotelsPath, hotelId, 'address')}
+                        value={hotel.address ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Check-in (optional)"
+                        name={fieldName(hotelsPath, hotelId, 'checkIn')}
+                        value={hotel.checkIn ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Check-out (optional)"
+                        name={fieldName(hotelsPath, hotelId, 'checkOut')}
+                        value={hotel.checkOut ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Description (optional)"
+                        name={fieldName(hotelsPath, hotelId, 'description')}
+                        value={hotel.description ?? emptyText}
+                        multiline
+                      />
+                      <Text
+                        label="Navigate URL (optional)"
+                        name={fieldName(hotelsPath, hotelId, 'navigateUrl')}
+                        defaultValue={hotel.navigateUrl ?? ''}
+                      />
+                      <Text
+                        label="Reservation URL (optional)"
+                        name={fieldName(hotelsPath, hotelId, 'reservationUrl')}
+                        defaultValue={hotel.reservationUrl ?? ''}
+                      />
+                      <div className="space-y-2 border-t border-neutral-200 pt-2">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-medium text-neutral-600">
+                            Room rates
+                          </span>
+                          <AddItemButton
+                            listPath={roomRatesPath}
+                            label="+ Add rate"
+                            newId={newListItemId()}
+                          />
+                        </div>
+                        {(hotel.roomRates ?? []).map((rate, ri) => {
+                          const rateId = ListItemId.make(rate.id);
+                          return (
+                            <div
+                              key={rate.id}
+                              className="space-y-2 rounded border border-neutral-200 bg-white p-2"
+                            >
+                              <div className="flex items-center justify-end">
+                                <ItemControls
+                                  listPath={roomRatesPath}
+                                  ids={roomRateIds}
+                                  index={ri}
+                                />
+                              </div>
+                              <Bilingual
+                                label="Rate description"
+                                name={fieldName(roomRatesPath, rateId, 'description')}
+                                value={rate.description ?? emptyText}
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
+                  <span>Meals section</span>
+                  <AddItemButton
+                    listPath={mealsPath}
+                    label="+ Add meal"
+                    newId={newListItemId()}
+                  />
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.meals.enabled`}
+                  defaultChecked={meals.enabled ?? false}
+                />
+                <Bilingual
+                  label="Header"
+                  name={`${conf}.meals.headerCopy`}
+                  value={meals.headerCopy ?? emptyText}
+                />
+                <Bilingual
+                  label="Body copy (optional)"
+                  name={`${conf}.meals.bodyCopy`}
+                  value={meals.bodyCopy ?? emptyText}
+                  multiline
+                />
+                {(meals.items ?? []).map((meal, mi) => {
+                  const mealId = ListItemId.make(meal.id);
+                  return (
+                    <div
+                      key={meal.id}
+                      className="space-y-2 rounded-md bg-neutral-50 p-3"
+                    >
+                      <div className="flex items-center justify-end">
+                        <ItemControls
+                          listPath={mealsPath}
+                          ids={mealIds}
+                          index={mi}
+                        />
+                      </div>
+                      <Bilingual
+                        label="Label"
+                        name={fieldName(mealsPath, mealId, 'label')}
+                        value={meal.label ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Price"
+                        name={fieldName(mealsPath, mealId, 'price')}
+                        value={meal.price ?? emptyText}
+                      />
+                    </div>
+                  );
+                })}
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="text-sm font-medium text-neutral-800">
+                  Register Now section
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.registrationCopy.enabled`}
+                  defaultChecked={registrationCopy.enabled ?? false}
+                />
+                <Bilingual
+                  label="Title"
+                  name={`${conf}.registrationCopy.title`}
+                  value={registrationCopy.title ?? emptyText}
+                />
+                <Bilingual
+                  label="Subtitle"
+                  name={`${conf}.registrationCopy.subtitle`}
+                  value={registrationCopy.subtitle ?? emptyText}
+                  multiline
+                />
+                <Bilingual
+                  label="Button label"
+                  name={`${conf}.registrationCopy.buttonLabel`}
+                  value={registrationCopy.buttonLabel ?? emptyText}
+                />
+              </fieldset>
+              <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
+                <legend className="text-sm font-medium text-neutral-800">
+                  Got Questions section
+                </legend>
+                <Checkbox
+                  label="Enabled"
+                  name={`${conf}.faqCopy.enabled`}
+                  defaultChecked={faqCopy.enabled ?? false}
+                />
+                <Bilingual
+                  label="Title"
+                  name={`${conf}.faqCopy.title`}
+                  value={faqCopy.title ?? emptyText}
+                />
+                <Bilingual
+                  label="Subtitle"
+                  name={`${conf}.faqCopy.subtitle`}
+                  value={faqCopy.subtitle ?? emptyText}
+                  multiline
+                />
+              </fieldset>
               <fieldset className="space-y-3">
                 <legend className="text-sm font-medium text-neutral-800">
                   Hero artwork
@@ -516,6 +941,64 @@ export default function AdminContentEditor() {
                         label="Photo alt text"
                         name={fieldName(speakersPath, speakerId, 'photo.alt')}
                         value={speaker.photo?.alt ?? emptyText}
+                      />
+                    </div>
+                  );
+                })}
+              </fieldset>
+              <fieldset className="space-y-3">
+                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
+                  <span>Seminars</span>
+                  <AddItemButton
+                    listPath={seminarsPath}
+                    label="+ Add seminar"
+                    newId={newListItemId()}
+                  />
+                </legend>
+                {(conference.seminars ?? []).map((seminar, sei) => {
+                  const seminarId = ListItemId.make(seminar.id);
+                  return (
+                    <div
+                      key={seminar.id}
+                      className="space-y-2 rounded-md bg-neutral-50 p-3"
+                    >
+                      <div className="flex items-center justify-end">
+                        <ItemControls
+                          listPath={seminarsPath}
+                          ids={seminarIds}
+                          index={sei}
+                        />
+                      </div>
+                      <Bilingual
+                        label="Title"
+                        name={fieldName(seminarsPath, seminarId, 'title')}
+                        value={seminar.title ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Description"
+                        name={fieldName(seminarsPath, seminarId, 'description')}
+                        value={seminar.description ?? emptyText}
+                        multiline
+                      />
+                      <Bilingual
+                        label="Speaker name"
+                        name={fieldName(seminarsPath, seminarId, 'speaker.name')}
+                        value={seminar.speaker?.name ?? emptyText}
+                      />
+                      <Bilingual
+                        label="Speaker bio"
+                        name={fieldName(seminarsPath, seminarId, 'speaker.bio')}
+                        value={seminar.speaker?.bio ?? emptyText}
+                        multiline
+                      />
+                      <ImageUpload
+                        keyPath={fieldName(seminarsPath, seminarId, 'speaker.photo.key')}
+                        currentKey={seminar.speaker?.photo?.key ?? ''}
+                      />
+                      <Bilingual
+                        label="Speaker photo alt"
+                        name={fieldName(seminarsPath, seminarId, 'speaker.photo.alt')}
+                        value={seminar.speaker?.photo?.alt ?? emptyText}
                       />
                     </div>
                   );

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -7,7 +7,7 @@ import {
   useNavigation,
 } from 'react-router';
 
-import { adminMeta, adminSecurityHeaders } from '~/lib/admin-headers';
+import { adminMeta, adminRedirectWithStatus, adminFlashStatus, adminSecurityHeaders } from '~/lib/admin-headers';
 import {
   AddItemButton,
   Bilingual,
@@ -111,8 +111,9 @@ export const loader = routeHandler(function* () {
   // source of truth (a bucket-less editor still renders so the admin can preview,
   // but saving/publishing would fail, which we warn about up front).
   const bucketConfigured = Option.isSome(env.bucket);
+  const status = adminFlashStatus(request);
 
-  return { document: encoded as EncodedDocument, source, bucketConfigured };
+  return { document: encoded as EncodedDocument, source, bucketConfigured, status };
 });
 
 export const action = routeAction(function* () {
@@ -185,9 +186,7 @@ export const action = routeAction(function* () {
       .applyImageUpload(siteScope, uploadTarget, key)
       .pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return redirect(
-      `/admin/content?status=${encodeURIComponent(`Image uploaded: ${key}`)}`,
-    );
+    return adminRedirectWithStatus('/admin/content', `Image uploaded: ${key}`);
   }
 
   // ---- list op (add / remove / reorder) ------------------------------------
@@ -207,7 +206,7 @@ export const action = routeAction(function* () {
     }
     const applied = yield* editor.applyListOps(siteScope, ops).pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return redirect('/admin/content?status=List%20updated.');
+    return adminRedirectWithStatus('/admin/content', 'List updated.');
   }
 
   if (intent !== 'save-draft' && intent !== 'publish') {
@@ -233,15 +232,16 @@ export const action = routeAction(function* () {
   if (edited._tag === 'Failure') return issueResponse(edited.failure);
 
   if (intent === 'save-draft') {
-    return redirect('/admin/content?status=Draft%20saved.');
+    return adminRedirectWithStatus('/admin/content', 'Draft saved.');
   }
 
   // publish: promote the just-saved draft to the live document, drop the draft,
   // and bust the read cache so the change is live on the next public read.
   const published = yield* editor.publish(siteScope).pipe(Effect.result);
   if (published._tag === 'Failure') return issueResponse(published.failure);
-  return redirect(
-    '/admin/content?status=Published.%20Live%20on%20the%20next%20page%20load.',
+  return adminRedirectWithStatus(
+    '/admin/content',
+    'Published. Live on the next page load.',
   );
 });
 
@@ -285,15 +285,10 @@ function PositionSelect({
 }
 
 export default function AdminContentEditor() {
-  const { document, source, bucketConfigured } = useLoaderData<typeof loader>();
+  const { document, source, bucketConfigured, status } = useLoaderData<typeof loader>();
   const actionData = useActionData<ActionResult>();
   const navigation = useNavigation();
   const submitting = navigation.state === 'submitting';
-
-  const status =
-    typeof window === 'undefined'
-      ? null
-      : new URLSearchParams(window.location.search).get('status');
 
   // Items carry an `id` (ADR 0006), and a freshly-added item is draft-valid with
   // only its `id` — its bilingual content fields are absent until edited. The

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -310,10 +310,18 @@ export default function AdminContentEditor() {
       headerCopy?: { en: string; fr: string };
       bodyCopy?: { en: string; fr: string };
       mapEmbedUrl?: string;
+      airport?: {
+        name?: { en: string; fr: string };
+        transitOptions?: ReadonlyArray<{
+          id: string;
+          description?: { en: string; fr: string };
+        }>;
+      };
     };
     parking?: {
       enabled?: boolean;
       headerCopy?: { en: string; fr: string };
+      bodyCopy?: { en: string; fr: string };
       options?: ReadonlyArray<{
         id: string;
         title?: { en: string; fr: string };
@@ -453,6 +461,8 @@ export default function AdminContentEditor() {
           const seminarIds = (conference.seminars ?? []).map((s) => s.id);
           const parkingPath = `${conf}.parking.options`;
           const parkingOptionIds = (conference.parking?.options ?? []).map((o) => o.id);
+          const transitPath = `${conf}.travel.airport.transitOptions`;
+          const transitOptionIds = (conference.travel?.airport?.transitOptions ?? []).map((t) => t.id);
           const hotelsPath = `${conf}.accommodations.hotels`;
           const hotelIds = (conference.accommodations?.hotels ?? []).map((h) => h.id);
           const mealsPath = `${conf}.meals.items`;
@@ -460,13 +470,15 @@ export default function AdminContentEditor() {
           const travel = {
             enabled: conference.travel?.enabled ?? false,
             headerCopy: conference.travel?.headerCopy ?? emptyText,
-            bodyCopy: conference.travel?.bodyCopy ?? emptyText,
+            bodyCopy: conference.travel?.bodyCopy,
             mapEmbedUrl: conference.travel?.mapEmbedUrl ?? '',
+            airport: conference.travel?.airport,
           };
-          const parking = conference.parking ?? {
-            enabled: false,
-            headerCopy: emptyText,
-            options: [],
+          const parking = {
+            enabled: conference.parking?.enabled ?? false,
+            headerCopy: conference.parking?.headerCopy ?? emptyText,
+            bodyCopy: conference.parking?.bodyCopy,
+            options: conference.parking?.options ?? [],
           };
           const accommodations = conference.accommodations ?? {
             enabled: false,
@@ -577,7 +589,7 @@ export default function AdminContentEditor() {
                   value={travel.headerCopy ?? emptyText}
                 />
                 <Bilingual
-                  label="Body copy"
+                  label="Body copy (optional)"
                   name={`${conf}.travel.bodyCopy`}
                   value={travel.bodyCopy ?? emptyText}
                   multiline
@@ -587,6 +599,51 @@ export default function AdminContentEditor() {
                   name={`${conf}.travel.mapEmbedUrl`}
                   defaultValue={travel.mapEmbedUrl ?? ''}
                 />
+                <div className="space-y-2 border-t border-neutral-200 pt-2">
+                  <p className="text-xs font-medium text-neutral-600">
+                    Airport transit (optional)
+                  </p>
+                  {travel.airport !== undefined ? (
+                    <Bilingual
+                      label="Airport name"
+                      name={`${conf}.travel.airport.name`}
+                      value={travel.airport.name ?? emptyText}
+                    />
+                  ) : null}
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-medium text-neutral-600">
+                        Transit options
+                      </span>
+                      <AddItemButton
+                        listPath={transitPath}
+                        label="+ Add transit option"
+                      />
+                    </div>
+                    {(travel.airport?.transitOptions ?? []).map((opt, ti) => {
+                      const optId = ListItemId.make(opt.id);
+                      return (
+                        <div
+                          key={opt.id}
+                          className="space-y-2 rounded border border-neutral-200 bg-neutral-50 p-2"
+                        >
+                          <div className="flex items-center justify-end">
+                            <ItemControls
+                              listPath={transitPath}
+                              ids={transitOptionIds}
+                              index={ti}
+                            />
+                          </div>
+                          <Bilingual
+                            label="Description"
+                            name={fieldName(transitPath, optId, 'description')}
+                            value={opt.description ?? emptyText}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
               </fieldset>
               <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
                 <legend className="text-sm font-medium text-neutral-800">
@@ -607,6 +664,12 @@ export default function AdminContentEditor() {
                   label="Header"
                   name={`${conf}.parking.headerCopy`}
                   value={parking.headerCopy ?? emptyText}
+                />
+                <Bilingual
+                  label="Body copy (optional)"
+                  name={`${conf}.parking.bodyCopy`}
+                  value={parking.bodyCopy ?? emptyText}
+                  multiline
                 />
                 {(parking.options ?? []).map((option, oi) => {
                   const optionId = ListItemId.make(option.id);

--- a/app/routes/admin/content.tsx
+++ b/app/routes/admin/content.tsx
@@ -40,7 +40,6 @@ import { collectListOps, fieldName } from '~/lib/content/list-edit';
 import {
   DraftSiteContent,
   ListItemId,
-  newListItemId,
   TeamPosition,
 } from '~/lib/content/schema';
 import { ReactRouterContext } from '~/lib/effect/router-context';
@@ -206,7 +205,7 @@ export const action = routeAction(function* () {
     }
     const applied = yield* editor.applyListOps(siteScope, ops).pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return adminRedirectWithStatus('/admin/content', 'List updated.');
+    return Response.json({ ok: true as const });
   }
 
   if (intent !== 'save-draft' && intent !== 'publish') {
@@ -590,14 +589,15 @@ export default function AdminContentEditor() {
                 />
               </fieldset>
               <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
-                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
-                  <span>Parking section</span>
+                <legend className="text-sm font-medium text-neutral-800">
+                  Parking section
+                </legend>
+                <div className="flex justify-end">
                   <AddItemButton
                     listPath={parkingPath}
                     label="+ Add parking option"
-                    newId={newListItemId()}
                   />
-                </legend>
+                </div>
                 <Checkbox
                   label="Enabled"
                   name={`${conf}.parking.enabled`}
@@ -648,14 +648,12 @@ export default function AdminContentEditor() {
                 })}
               </fieldset>
               <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
-                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
-                  <span>Accommodations section</span>
-                  <AddItemButton
-                    listPath={hotelsPath}
-                    label="+ Add hotel"
-                    newId={newListItemId()}
-                  />
+                <legend className="text-sm font-medium text-neutral-800">
+                  Accommodations section
                 </legend>
+                <div className="flex justify-end">
+                  <AddItemButton listPath={hotelsPath} label="+ Add hotel" />
+                </div>
                 <Checkbox
                   label="Enabled"
                   name={`${conf}.accommodations.enabled`}
@@ -727,7 +725,6 @@ export default function AdminContentEditor() {
                           <AddItemButton
                             listPath={roomRatesPath}
                             label="+ Add rate"
-                            newId={newListItemId()}
                           />
                         </div>
                         {(hotel.roomRates ?? []).map((rate, ri) => {
@@ -758,14 +755,12 @@ export default function AdminContentEditor() {
                 })}
               </fieldset>
               <fieldset className="space-y-3 rounded-md border border-neutral-200 p-3">
-                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
-                  <span>Meals section</span>
-                  <AddItemButton
-                    listPath={mealsPath}
-                    label="+ Add meal"
-                    newId={newListItemId()}
-                  />
+                <legend className="text-sm font-medium text-neutral-800">
+                  Meals section
                 </legend>
+                <div className="flex justify-end">
+                  <AddItemButton listPath={mealsPath} label="+ Add meal" />
+                </div>
                 <Checkbox
                   label="Enabled"
                   name={`${conf}.meals.enabled`}
@@ -884,14 +879,13 @@ export default function AdminContentEditor() {
                 ))}
               </fieldset>
               <fieldset className="space-y-3">
-                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
-                  <span>Speakers</span>
+                <legend className="text-sm font-medium text-neutral-800">Speakers</legend>
+                <div className="flex justify-end">
                   <AddItemButton
                     listPath={speakersPath}
                     label="+ Add speaker"
-                    newId={newListItemId()}
                   />
-                </legend>
+                </div>
                 {conference.speakers.map((speaker, si) => {
                   // Re-assert the `ListItemId` brand at this view boundary: the
                   // encoded document carries the id as a bare `string` (encode
@@ -942,14 +936,13 @@ export default function AdminContentEditor() {
                 })}
               </fieldset>
               <fieldset className="space-y-3">
-                <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
-                  <span>Seminars</span>
+                <legend className="text-sm font-medium text-neutral-800">Seminars</legend>
+                <div className="flex justify-end">
                   <AddItemButton
                     listPath={seminarsPath}
                     label="+ Add seminar"
-                    newId={newListItemId()}
                   />
-                </legend>
+                </div>
                 {(conference.seminars ?? []).map((seminar, sei) => {
                   const seminarId = ListItemId.make(seminar.id);
                   return (
@@ -1005,11 +998,7 @@ export default function AdminContentEditor() {
 
         <Section title="Team">
           <div className="flex items-center justify-end">
-            <AddItemButton
-              listPath="team"
-              label="+ Add team member"
-              newId={newListItemId()}
-            />
+            <AddItemButton listPath="team" label="+ Add team member" />
           </div>
           {team.map((member, ti) => {
             // Re-assert the brand at this boundary (see the speakers note).
@@ -1044,11 +1033,7 @@ export default function AdminContentEditor() {
 
         <Section title="Board of Directors">
           <div className="flex items-center justify-end">
-            <AddItemButton
-              listPath="board"
-              label="+ Add board member"
-              newId={newListItemId()}
-            />
+            <AddItemButton listPath="board" label="+ Add board member" />
           </div>
           {board.map((member, bi) => {
             const memberId = ListItemId.make(member.id);

--- a/app/routes/admin/controls.tsx
+++ b/app/routes/admin/controls.tsx
@@ -1,7 +1,8 @@
-import { useRef } from 'react';
-import { useFetcher } from 'react-router';
+import { useEffect, useRef } from 'react';
+import { useFetcher, useRevalidator } from 'react-router';
 
 import { listOpFieldName } from '~/lib/content/list-edit';
+import { newListItemId } from '~/lib/content/schema';
 
 /**
  * Shared `/admin` editor controls + field inputs (registration-launch Branch 5.5).
@@ -214,19 +215,20 @@ export function ImageUpload({
 export function ListOpButton({
   listPath,
   kind,
-  value,
+  value = '',
   label,
   variant = 'default',
   disabled = false,
 }: {
   readonly listPath: string;
   readonly kind: 'add' | 'remove' | 'reorder';
-  readonly value: string;
+  readonly value?: string;
   readonly label: string;
   readonly variant?: 'default' | 'add' | 'danger';
   readonly disabled?: boolean;
 }) {
   const fetcher = useFetcher<ActionResult>();
+  const revalidator = useRevalidator();
   const pending = fetcher.state !== 'idle';
   const className =
     variant === 'add'
@@ -235,22 +237,39 @@ export function ListOpButton({
         ? 'inline-flex min-h-9 cursor-pointer items-center rounded-md border border-rose-300 px-3 text-xs font-medium text-rose-700 hover:bg-rose-50 disabled:opacity-50'
         : 'inline-flex min-h-9 cursor-pointer items-center rounded-md border border-neutral-300 px-2 text-xs font-medium hover:bg-neutral-100 disabled:opacity-50';
 
+  useEffect(() => {
+    if (fetcher.state !== 'idle' || fetcher.data === undefined) return;
+    if (fetcher.data.ok) {
+      void revalidator.revalidate();
+    }
+  }, [fetcher.state, fetcher.data, revalidator]);
+
   const submit = () => {
     const data = new FormData();
     data.set('intent', 'list-op');
-    data.set(listOpFieldName(listPath, kind), value);
+    data.set(
+      listOpFieldName(listPath, kind),
+      kind === 'add' ? newListItemId() : value,
+    );
     void fetcher.submit(data, { method: 'post' });
   };
 
   return (
-    <button
-      type="button"
-      onClick={submit}
-      disabled={disabled || pending}
-      className={className}
-    >
-      {pending ? '…' : label}
-    </button>
+    <span className="inline-flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={submit}
+        disabled={disabled || pending}
+        className={className}
+      >
+        {pending ? '…' : label}
+      </button>
+      {fetcher.data && !fetcher.data.ok ? (
+        <span className="max-w-xs text-right text-xs text-rose-700">
+          {fetcher.data.error}
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -310,23 +329,15 @@ export function ItemControls({
   );
 }
 
-/** The "Add item" control: mints a fresh id client-side and appends an empty item. */
+/** The "Add item" control: mints a fresh id on click and appends an empty item. */
 export function AddItemButton({
   listPath,
   label,
-  newId,
 }: {
   readonly listPath: string;
   readonly label: string;
-  readonly newId: string;
 }) {
   return (
-    <ListOpButton
-      listPath={listPath}
-      kind="add"
-      value={newId}
-      label={label}
-      variant="add"
-    />
+    <ListOpButton listPath={listPath} kind="add" label={label} variant="add" />
   );
 }

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -7,7 +7,7 @@ import {
   useNavigation,
 } from 'react-router';
 
-import { adminMeta, adminSecurityHeaders } from '~/lib/admin-headers';
+import { adminMeta, adminRedirectWithStatus, adminFlashStatus, adminSecurityHeaders } from '~/lib/admin-headers';
 import { Auth } from '~/lib/auth.server';
 import {
   DraftEditor,
@@ -127,6 +127,7 @@ const requirePageId = Effect.fn('admin/pages.requirePageId')(function* () {
 export const loader = routeHandler(function* () {
   yield* requireAdmin();
   const page = yield* requirePageId();
+  const { request } = yield* ReactRouterContext;
 
   const editor = yield* DraftEditor.Service;
   const env = yield* Env.Service;
@@ -136,8 +137,9 @@ export const loader = routeHandler(function* () {
   const encode = Schema.encodeUnknownEffect(PAGE_SPECS[page].draftSchema);
   const encoded = (yield* encode(content)) as Json;
   const bucketConfigured = Option.isSome(env.bucket);
+  const status = adminFlashStatus(request);
 
-  return { page, encoded, source, bucketConfigured };
+  return { page, encoded, source, bucketConfigured, status };
 });
 
 export const action = routeAction(function* () {
@@ -207,8 +209,9 @@ export const action = routeAction(function* () {
       .applyImageUpload(scope, uploadTarget, key)
       .pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return redirect(
-      `/admin/pages/${page}?status=${encodeURIComponent(`Image uploaded: ${key}`)}`,
+    return adminRedirectWithStatus(
+      `/admin/pages/${page}`,
+      `Image uploaded: ${key}`,
     );
   }
 
@@ -223,7 +226,7 @@ export const action = routeAction(function* () {
     }
     const applied = yield* editor.applyListOps(scope, ops).pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return redirect(`/admin/pages/${page}?status=List%20updated.`);
+    return adminRedirectWithStatus(`/admin/pages/${page}`, 'List updated.');
   }
 
   if (intent !== 'save-draft' && intent !== 'publish') {
@@ -246,13 +249,14 @@ export const action = routeAction(function* () {
   if (edited._tag === 'Failure') return issueResponse(edited.failure);
 
   if (intent === 'save-draft') {
-    return redirect(`/admin/pages/${page}?status=Draft%20saved.`);
+    return adminRedirectWithStatus(`/admin/pages/${page}`, 'Draft saved.');
   }
 
   const published = yield* editor.publish(scope).pipe(Effect.result);
   if (published._tag === 'Failure') return issueResponse(published.failure);
-  return redirect(
-    `/admin/pages/${page}?status=Published.%20Live%20on%20the%20next%20page%20load.`,
+  return adminRedirectWithStatus(
+    `/admin/pages/${page}`,
+    'Published. Live on the next page load.',
   );
 });
 
@@ -681,16 +685,11 @@ function PageEditor({
 }
 
 export default function AdminPageEditor() {
-  const { page, encoded, source, bucketConfigured } =
+  const { page, encoded, source, bucketConfigured, status } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<ActionResponse>();
   const navigation = useNavigation();
   const submitting = navigation.state === 'submitting';
-
-  const status =
-    typeof window === 'undefined'
-      ? null
-      : new URLSearchParams(window.location.search).get('status');
 
   return (
     <div className="space-y-6">

--- a/app/routes/admin/pages.$page.tsx
+++ b/app/routes/admin/pages.$page.tsx
@@ -25,7 +25,7 @@ import {
 import { prepareImage } from '~/lib/content/image-optimize.server';
 import { collectListOps, fieldName } from '~/lib/content/list-edit';
 import { PAGE_SPECS, PageId } from '~/lib/content/pages/registry';
-import { ListItemId, newListItemId } from '~/lib/content/schema';
+import { ListItemId } from '~/lib/content/schema';
 import { Env } from '~/lib/env.server';
 import { ReactRouterContext } from '~/lib/effect/router-context';
 import { routeAction, routeHandler } from '~/lib/effect/route';
@@ -226,7 +226,7 @@ export const action = routeAction(function* () {
     }
     const applied = yield* editor.applyListOps(scope, ops).pipe(Effect.result);
     if (applied._tag === 'Failure') return issueResponse(applied.failure);
-    return adminRedirectWithStatus(`/admin/pages/${page}`, 'List updated.');
+    return Response.json({ ok: true as const });
   }
 
   if (intent !== 'save-draft' && intent !== 'publish') {
@@ -331,7 +331,7 @@ function ListSection({
     <fieldset className="space-y-3">
       <legend className="flex items-center justify-between text-sm font-medium text-neutral-800">
         <span>{title}</span>
-        <AddItemButton listPath={listPath} label={addLabel} newId={newListItemId()} />
+        <AddItemButton listPath={listPath} label={addLabel} />
       </legend>
       {items.map((item, index) => {
         // Re-assert the `ListItemId` brand at this view boundary: the encoded


### PR DESCRIPTION
## Summary
- Extend the conference content schema with toggleable sections (Travel, Parking, Accommodations, Meals, registration/FAQ copy) and a home-page Learn More toggle.
- Refactor conference detail pages with a stacked hero layout and CMS-driven section rendering; expand the admin content editor for all new fields.
- Fix conference navigation links and update defaults, backfill, and tests for the new structure.

## Test plan
- [ ] Run content-related test suite
- [ ] Verify conference pages for 2024/2025/2026 render enabled sections only
- [ ] Confirm home Learn More appears when `learnMoreEnabled` is true
- [ ] Exercise admin CMS: edit section toggles, URLs, hotels, and seminars; publish draft
- [ ] Check desktop nav and footer conference links route to `/YYYY`


Made with [Cursor](https://cursor.com)